### PR TITLE
added getRedirectRoute in ResourceController and resource name in 404 message

### DIFF
--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -205,20 +205,33 @@ class ResourceController extends Controller
 
     protected function redirectTo(ResourceInterface $resource)
     {
-        $redirect = $this->getConfiguration()->getRedirect();
-        $route = $redirect ? $redirect : $this->getResourceRoute();
-
+        $route = $this->getRedirectRoute('show');
+        
         return $this->handleView(RouteRedirectView::create($route, array('id' => $resource->getId())));
     }
 
     protected function redirectToCollection()
-    {
-        $redirect = $this->getConfiguration()->getRedirect();
-        $route = $redirect ? $redirect : $this->getResourceCollectionRoute();
+    {        
+        $route = $this->getRedirectRoute('list');
 
         return $this->handleView(RouteRedirectView::create($route));
     }
 
+    protected function getRedirectRoute($name)
+    {
+        $config = $this->getConfiguration();
+    
+        if (null !== $route = $config->getRedirect()) {
+            return $route;
+        }
+    
+        return sprintf('%s_%s_%s',
+                $config->getBundlePrefix(),
+                $config->getResourceName(),
+                $name
+        );        
+    }
+    
     protected function getManager()
     {
         return $this->getService('manager');
@@ -237,7 +250,7 @@ class ResourceController extends Controller
     protected function findOr404(array $criteria)
     {
         if (!$resource = $this->getRepository()->findOneBy($criteria)) {
-            throw new NotFoundHttpException('Requested resource does not exist');
+            throw new NotFoundHttpException(sprintf('Requested %s does not exist', $this->getConfiguration()->getResourceName()));
         }
 
         return $resource;


### PR DESCRIPTION
The methods getResourceRoute and getResourceCollectionRoute don't exist and ResourceController fails when the user don't set the redirect value in _sylius.recource attribute. I added the getRedirectRoute method to solve this problem.
