### PR TITLE
Added some specs for doctrine repos, generate human readable alias.

### DIFF
--- a/Doctrine/ORM/EntityRepository.php
+++ b/Doctrine/ORM/EntityRepository.php
@@ -17,7 +17,7 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 
 /**
- * Doctrine ORM driver entity manager.
+ * Doctrine ORM driver entity repository.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
@@ -45,7 +45,7 @@ class EntityRepository extends BaseEntityRepository
         return $this
             ->getCollectionQueryBuilder()
             ->getQuery()
-            ->execute()
+            ->getResult()
         ;
     }
 
@@ -78,7 +78,7 @@ class EntityRepository extends BaseEntityRepository
 
         return $queryBuilder
             ->getQuery()
-            ->execute()
+            ->getResult()
         ;
     }
 
@@ -133,6 +133,6 @@ class EntityRepository extends BaseEntityRepository
 
     protected function getAlias()
     {
-        return 'o';
+        return lcfirst(substr(strrchr($this->getClassName(), '\\'), 1));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,13 @@
         "white-october/pagerfanta-bundle": "*"
     },
     "require-dev": {
-        "phpspec/phpspec2": "dev-develop"
+        "doctrine/orm":         "~2.3",
+        "doctrine/mongodb-odm": "*",
+        "phpspec/phpspec2":     "dev-develop"
+    },
+    "suggest": {
+        "doctrine/orm":         "~2.3",
+        "doctrine/mongodb-odm": "*"
     },
     "config": {
         "bin-dir": "bin"

--- a/spec/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -12,7 +12,7 @@ use PHPSpec2\ObjectBehavior;
 class Configuration extends ObjectBehavior
 {
     /**
-     * @param Symfony\Component\HttpFoundation\Request $request
+     * @param Symfony\Component\HttpFoundation\Request      $request
      * @param Symfony\Component\HttpFoundation\ParameterBag $attributes
      */
     function let($request, $attributes)

--- a/spec/Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Doctrine\ODM\MongoDB;
+
+use PHPSpec2\ObjectBehavior;
+
+/**
+ * Doctrine ODM driver document repository spec.
+ *
+ * @author Саша Стаменковић <umpirsky@gmail.com>
+ */
+class DocumentRepository extends ObjectBehavior
+{
+    /**
+     * @param Doctrine\ODM\MongoDB\DocumentManager       $documentManager
+     * @param Doctrine\ODM\MongoDB\UnitOfWork            $unitOfWork
+     * @param Doctrine\ODM\MongoDB\Mapping\ClassMetadata $class
+     * @param Doctrine\ODM\MongoDB\Query\Builder         $queryBuilder
+     */
+    function let($documentManager, $unitOfWork, $class, $queryBuilder)
+    {
+        $class->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo';
+
+        $documentManager
+            ->createQueryBuilder($class->name)
+            ->willReturn($queryBuilder)
+        ;
+
+        $this->beConstructedWith($documentManager, $unitOfWork, $class);
+    }
+
+    function it_should_be_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Doctrine\ODM\MongoDB\DocumentRepository');
+        $this->shouldHaveType('Doctrine\ODM\MongoDB\DocumentRepository');
+    }
+
+    function it_should_create_paginator()
+    {
+        $this
+            ->createPaginator()
+            ->shouldHaveType('Pagerfanta\Pagerfanta')
+        ;
+    }
+}

--- a/spec/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Doctrine\ORM;
+
+use PHPSpec2\ObjectBehavior;
+
+/**
+ * Doctrine ORM driver entity repository spec.
+ *
+ * @author Саша Стаменковић <umpirsky@gmail.com>
+ */
+class EntityRepository extends ObjectBehavior
+{
+    /**
+     * @param Doctrine\ORM\EntityManager         $entityManager
+     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param Doctrine\ORM\QueryBuilder          $queryBuilder
+     */
+    function let($entityManager, $class, $queryBuilder)
+    {
+        $class->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo';
+
+        $entityManager
+            ->createQueryBuilder()
+            ->willReturn($queryBuilder)
+        ;
+
+        $queryBuilder
+            ->select(ANY_ARGUMENT)
+            ->willReturn($queryBuilder)
+        ;
+        $queryBuilder
+            ->from(ANY_ARGUMENTS)
+            ->willReturn($queryBuilder)
+        ;
+
+        $this->beConstructedWith($entityManager, $class);
+    }
+
+    function it_should_be_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository');
+        $this->shouldHaveType('Doctrine\ORM\EntityRepository');
+    }
+
+    function it_should_create_new()
+    {
+        $this->createNew()->shouldHaveType('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo');
+    }
+
+    function it_should_return_null_if_not_found()
+    {
+        $this->find(1)->shouldReturn(null);
+    }
+
+    /**
+     * @param Doctrine\ORM\QueryBuilder $queryBuilder
+     */
+    function it_should_apply_criteria_when_finding_one_by_criteria($queryBuilder)
+    {
+        $criteria = array(
+            'foo' => 'bar',
+            'bar' => 'baz',
+        );
+
+        $this->it_should_apply_criteria($criteria, $queryBuilder);
+
+        $this->findOneBy($criteria)->shouldReturn(null);
+    }
+
+    /**
+     * @param Doctrine\ORM\QueryBuilder $queryBuilder
+     */
+    function it_should_apply_criteria_when_finding_by_criteria($queryBuilder)
+    {
+        $criteria = array(
+            'foo' => 'bar',
+            'bar' => 'baz',
+        );
+
+        $this->it_should_apply_criteria($criteria, $queryBuilder);
+
+        $this->findBy($criteria)->shouldReturn(null);
+    }
+
+    function it_should_return_null_if_all_not_found()
+    {
+        $this->findAll()->shouldReturn(null);
+    }
+
+    function it_should_create_paginator()
+    {
+        $this
+            ->createPaginator()
+            ->shouldHaveType('Pagerfanta\Pagerfanta')
+        ;
+    }
+
+    private function it_should_apply_criteria(array $criteria, $queryBuilder)
+    {
+        foreach ($criteria as $property => $value) {
+            $queryBuilder
+                ->andWhere('foo.'.$property.' = :'.$property)
+                ->shouldBeCalled()
+                ->willReturn($queryBuilder)
+            ;
+
+            $queryBuilder
+                ->setParameter($property, $value)
+                ->shouldBeCalled()
+                ->willReturn($queryBuilder)
+            ;
+        }
+    }
+}

--- a/spec/Sylius/Bundle/ResourceBundle/Fixture/Entity/Foo.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Fixture/Entity/Foo.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Entity;
+
+/**
+ * Foo entity.
+ *
+ * @author Саша Стаменковић <umpirsky@gmail.com>
+ */
+class Foo
+{
+}


### PR DESCRIPTION
Specs are added for `DocumentRepository` and `EntityRepository`. Only strange thing is that `EntityRepository::findAll()` and `EntityRepository::findBy()` return null. I expected to return empty collection. Didn't figure out why.

`EntityRepository::getAlias()` now returns more readable alias, example, for entity `spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooBar` it will return alias `fooBar`, which is more readable then `o`.
