### PR TITLE
Introduced create, update and delete events

### DIFF
--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -288,7 +288,7 @@ class ResourceController extends FOSRestController
         $manager = $this->getManager();
 
         $this->dispatchEvent('pre_delete', $resource);
-        $manager->persist($resource);
+        $manager->remove($resource);
         $this->dispatchEvent('delete', $resource);
         $manager->flush();
         $this->dispatchEvent('post_delete', $resource);


### PR DESCRIPTION
There are some situations where you need to do some actions after a persist/delete and before the flush. This PR tries solve this issue introducing three new events that are fired after persist/delete.
