### PR TITLE
load metadata event listener

### DIFF
--- a/DependencyInjection/SyliusResourceExtension.php
+++ b/DependencyInjection/SyliusResourceExtension.php
@@ -41,6 +41,7 @@ class SyliusResourceExtension extends Extension
         if (isset($config['resources'])) {
             $this->createResourceServices($config['resources'], $container);
         }
+        $container->setParameter('sylius.config.classes', array());
     }
 
     private function createResourceServices(array $configs, ContainerBuilder $container)

--- a/EventListener/LoadMetadataSubscriber.php
+++ b/EventListener/LoadMetadataSubscriber.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * Sylius\Bundle\ResourceBundle\EventListener\LoadMetadataListener
+ *
+ * @author Ivan Molchanov <ivan.molchanov@opensoftdev.ru>
+ */
+class LoadMetadataSubscriber implements EventSubscriber
+{
+
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * Constructor
+     *
+     * @param array $classes
+     */
+    public function __construct($classes)
+    {
+        $this->classes = $classes;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            'loadClassMetadata'
+        );
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $metadata = $eventArgs->getClassMetadata();
+        foreach ($this->classes as $class) {
+            if ($class['model'] === $metadata->getName()) {
+                $metadata->isMappedSuperclass = false;
+            }
+        }
+        if (!$metadata->isMappedSuperclass) {
+            foreach (class_parents($metadata->getName()) as $parent) {
+                $parentMetadata = new ClassMetadata(
+                    $parent,
+                    $eventArgs->getEntityManager()->getConfiguration()->getNamingStrategy()
+                );
+                $eventArgs
+                    ->getEntityManager()
+                    ->getConfiguration()
+                    ->getMetadataDriverImpl()
+                    ->loadMetadataForClass(
+                        $parent,
+                        $parentMetadata
+                    );
+                if ($parentMetadata->isMappedSuperclass) {
+                    foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
+                        if ($value['type'] === ClassMetadataInfo::ONE_TO_MANY || $value['type'] === ClassMetadataInfo::ONE_TO_ONE) {
+                            $metadata->associationMappings[$key] = $value;
+                        }
+                    }
+                }
+            }
+        } else {
+            foreach ($metadata->getAssociationMappings() as $key => $value) {
+                if ($value['type'] === ClassMetadataInfo::ONE_TO_MANY || $value['type'] === ClassMetadataInfo::ONE_TO_ONE) {
+                    unset($metadata->associationMappings[$key]);
+                }
+            }
+        }
+    }
+}

--- a/Resources/config/container/services.xml
+++ b/Resources/config/container/services.xml
@@ -18,6 +18,7 @@
 
     <parameters>
         <parameter key="sylius_resource.twig.class">Sylius\Bundle\ResourceBundle\Twig\SyliusResourceExtension</parameter>
+        <parameter key="sylius.event_subscribers.load_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadMetadataSubscriber</parameter>
     </parameters>
 
     <services>
@@ -25,6 +26,10 @@
             <argument type="service" id="router" />
             <tag name="twig.extension" />
             <tag name="kernel.event_listener" event="kernel.request" method="fetchRequest" />
+        </service>
+        <service id="sylius.event_subscribers.load_metadata" class="%sylius.event_subscribers.load_metadata.class%">
+            <tag name="doctrine.event_subscriber" />
+            <argument>%sylius.config.classes%</argument>
         </service>
     </services>
 


### PR DESCRIPTION
This PR solves https://github.com/Sylius/Sylius/issues/221 and https://github.com/Sylius/Sylius/issues/207

Every bundle which will use this listener should have the following code

``` php
    if ($container->hasParameter('sylius.config.classes')) {
        $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
    }
    $container->setParameter('sylius.config.classes', $classes);
```

in BundleExtension::mapClassParameters()
