### PR TITLE
Fix tests relating to GeoJson / MongoDB driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "phpspec/phpspec":      "2.0.*@dev",
         "twig/twig":            "~1.11",
         "doctrine/orm":         "~2.3",
-        "doctrine/mongodb-odm": "1.0.*@dev"
+        "doctrine/mongodb-odm": "1.0.*@dev",
+        "jmikola/geojson":      "1.0.*@dev"
     },
     "suggest": {
         "fsc/hateoas-bundle":   "0.3.x-dev",


### PR DESCRIPTION
This commit fixes the following errors that were showing up when running the ResourceBundle tests without any other Sylius repositories.

Fixed tests:
        Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
  41  ! is initializable
        exception [exc:ReflectionException("Class GeoJson\Geometry\Geometry does not exist")] has been thrown.

```
    Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
```

  46  ! implements Sylius repository interface
        exception [exc:ReflectionException("Class GeoJson\Geometry\Geometry does not exist")] has been thrown.

```
    Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
```

  51  ! creates Pagerfanta paginator
        exception [exc:ReflectionException("Class GeoJson\Geometry\Geometry does not exist")] has been thrown.
