### PR TITLE
load metadata event subscriber for mongodb-odm

### DIFF
--- a/DependencyInjection/Compiler/ResolveDoctrineTargetDocumentsPass.php
+++ b/DependencyInjection/Compiler/ResolveDoctrineTargetDocumentsPass.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\ResourceBundle\DependencyInjection\DoctrineTargetDocumentsResolver;
+use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Resolves given target documents with container parameters.
+ * Usable only with *doctrine/orm* driver.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+class ResolveDoctrineTargetDocumentsPass implements CompilerPassInterface
+{
+    /**
+     * @var array $interfaces
+     */
+    private $interfaces;
+
+    /**
+     * @var string $bundlePrefix
+     */
+    private $bundlePrefix;
+
+    public function __construct($bundlePrefix, array $interfaces)
+    {
+        $this->bundlePrefix = $bundlePrefix;
+        $this->interfaces = $interfaces;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM === $this->getDriver($container)) {
+            $resolver = new DoctrineTargetDocumentsResolver();
+            $resolver->resolve($container, $this->interfaces);
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return string
+     */
+    private function getDriver(ContainerBuilder $container)
+    {
+        return $container->getParameter(sprintf('%s.driver', $this->bundlePrefix));
+    }
+}

--- a/DependencyInjection/DoctrineTargetDocumentsResolver.php
+++ b/DependencyInjection/DoctrineTargetDocumentsResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Resolves given target entities with container parameters.
+ * Usable only with *doctrine/mongodb-odm* driver.
+ *
+ * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
+ */
+class DoctrineTargetDocumentsResolver extends DoctrineTargetEntitiesResolver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(ContainerBuilder $container, array $interfaces)
+    {
+        if (!$container->hasDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')) {
+            throw new \RuntimeException('Cannot find Doctrine RTDL');
+        }
+
+        $resolveTargetDocumentListener = $container->findDefinition('doctrine_mongodb.odm.listeners.resolve_target_document');
+
+        foreach ($interfaces as $interface => $model) {
+            $resolveTargetDocumentListener
+                ->addMethodCall('addResolveTargetDocument', array(
+                    $this->getInterface($container, $interface),
+                    $this->getClass($container, $model),
+                    array()
+                ))
+            ;
+        }
+
+        if (!$resolveTargetDocumentListener->hasTag('doctrine_mongodb.odm.event_listener')) {
+            $resolveTargetDocumentListener->addTag('doctrine_mongodb.odm.event_listener', array('event' => 'loadClassMetadata'));
+        }
+    }
+}

--- a/DependencyInjection/DoctrineTargetEntitiesResolver.php
+++ b/DependencyInjection/DoctrineTargetEntitiesResolver.php
@@ -54,7 +54,7 @@ class DoctrineTargetEntitiesResolver
      * @return string
      * @throws \InvalidArgumentException
      */
-    private function getInterface(ContainerBuilder $container, $key)
+    protected function getInterface(ContainerBuilder $container, $key)
     {
         if ($container->hasParameter($key)) {
             return $container->getParameter($key);
@@ -76,7 +76,7 @@ class DoctrineTargetEntitiesResolver
      * @return string
      * @throws \InvalidArgumentException
      */
-    private function getClass(ContainerBuilder $container, $key)
+    protected function getClass(ContainerBuilder $container, $key)
     {
         if ($container->hasParameter($key)) {
             return $container->getParameter($key);

--- a/EventListener/LoadODMMetadataSubscriber.php
+++ b/EventListener/LoadODMMetadataSubscriber.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+
+/**
+ * Doctrine listener used to manipulate mappings.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+class LoadODMMetadataSubscriber implements EventSubscriber
+{
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * Constructor
+     *
+     * @param array $classes
+     */
+    public function __construct($classes)
+    {
+        $this->classes = $classes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            'loadClassMetadata'
+        );
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        /** @var ClassMetadata $metadata */
+        $metadata = $eventArgs->getClassMetadata();
+
+        $this->setCustomRepositoryClasses($metadata);
+
+        if (!$metadata->isMappedSuperclass) {
+            $this->setAssociationMappings($metadata, $eventArgs->getDocumentManager()->getConfiguration());
+        } else {
+            $this->unsetAssociationMappings($metadata);
+        }
+    }
+
+    private function setCustomRepositoryClasses(ClassMetadataInfo $metadata)
+    {
+        foreach ($this->classes as $class) {
+            if (array_key_exists('model', $class) && $class['model'] === $metadata->getName()) {
+                $metadata->isMappedSuperclass = false;
+                if (array_key_exists('repository', $class)) {
+                    $metadata->setCustomRepositoryClass($class['repository']);
+                }
+            }
+        }
+    }
+
+    private function setAssociationMappings(ClassMetadataInfo $metadata, $configuration)
+    {
+        foreach (class_parents($metadata->getName()) as $parent) {
+            $parentMetadata = new ClassMetadata($parent);
+            if (in_array($parent, $configuration->getMetadataDriverImpl()->getAllClassNames())) {
+                $configuration->getMetadataDriverImpl()->loadMetadataForClass($parent, $parentMetadata);
+                if ($parentMetadata->isMappedSuperclass) {
+                    foreach ($parentMetadata->associationMappings as $key => $value) {
+                        if ($this->hasRelation($value['association'])) {
+                            $metadata->associationMappings[$key] = $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private function unsetAssociationMappings(ClassMetadataInfo $metadata)
+    {
+        foreach ($metadata->associationMappings as $key => $value) {
+            if ($this->hasRelation($value['association'])) {
+                unset($metadata->associationMappings[$key]);
+            }
+        }
+    }
+
+    private function hasRelation($type)
+    {
+        return in_array(
+            $type,
+            array(
+                ClassMetadataInfo::REFERENCE_ONE,
+                ClassMetadataInfo::REFERENCE_MANY,
+                ClassMetadataInfo::EMBED_ONE,
+                ClassMetadataInfo::EMBED_MANY,
+            ),
+            true
+        );
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,6 +24,7 @@
         <parameter key="sylius.form.type.object_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\ObjectToIdentifierType</parameter>
 
         <parameter key="sylius.event_subscriber.load_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadMetadataSubscriber</parameter>
+        <parameter key="sylius.event_subscriber.load_odm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadODMMetadataSubscriber</parameter>
         <parameter key="sylius.event_subscriber.kernel_controller.class">Sylius\Bundle\ResourceBundle\EventListener\KernelControllerSubscriber</parameter>
 
         <!-- Sylius State Machine -->
@@ -47,6 +48,10 @@
         <service id="sylius.event_subscriber.load_metadata" class="%sylius.event_subscriber.load_metadata.class%">
             <argument>%sylius.config.classes%</argument>
             <tag name="doctrine.event_subscriber" />
+        </service>
+        <service id="sylius.event_subscriber.load_odm_metadata" class="%sylius.event_subscriber.load_odm_metadata.class%">
+            <argument>%sylius.config.classes%</argument>
+            <tag name="doctrine_mongodb.odm.event_subscriber" />
         </service>
         <service id="sylius.event_subscriber.kernel_controller" class="%sylius.event_subscriber.kernel_controller.class%">
             <tag name="kernel.event_subscriber" />

--- a/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ResolveDoctrineTargetDocumentsPassSpec.php
+++ b/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ResolveDoctrineTargetDocumentsPassSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Compiler pass which resolves interfaces into target document names during
+ * compile time of container.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+class ResolveDoctrineTargetDocumentsPassSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('sylius_resource', array());
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(
+            'Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\ResolveDoctrineTargetDocumentsPass'
+        );
+    }
+
+    function it_is_a_compiler_pass()
+    {
+        $this->shouldImplement('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface');
+    }
+
+    function it_should_resolve_documents(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $container->getParameter('sylius_resource.driver')
+            ->shouldBeCalled()
+            ->willReturn('doctrine/mongodb-odm');
+
+        $container->hasDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $this->process($container);
+    }
+}

--- a/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetDocumentsResolverSpec.php
+++ b/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetDocumentsResolverSpec.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Doctrine target documents resolver spec.
+ * It adds proper method calls to doctrine listener.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+class DoctrineTargetDocumentsResolverSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\DependencyInjection\DoctrineTargetDocumentsResolver');
+    }
+
+    function it_should_get_interfaces_from_the_container(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $resolverDefinition->hasTag('doctrine_mongodb.odm.event_listener')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addTag('doctrine_mongodb.odm.event_listener', array('event' => 'loadClassMetadata'))
+            ->shouldBeCalled();
+
+        $container->hasDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $container->hasParameter('sylius.resource.interface')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->getParameter('sylius.resource.interface')
+            ->shouldBeCalled()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Document\FooInterface');
+
+        $container->hasParameter('sylius.resource.model')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->getParameter('sylius.resource.model')
+            ->shouldBeCalled()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo');
+
+        $resolverDefinition->addMethodCall(
+            'addResolveTargetDocument',
+            array(
+                'spec\Sylius\Bundle\ResourceBundle\Fixture\Document\FooInterface', 'spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo', array()
+            ))->shouldBeCalled();
+
+        $this->resolve($container, array(
+            'sylius.resource.interface' => 'sylius.resource.model'
+        ));
+    }
+
+    function it_should_get_interfaces(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $resolverDefinition->hasTag('doctrine_mongodb.odm.event_listener')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addTag('doctrine_mongodb.odm.event_listener', array('event' => 'loadClassMetadata'))
+            ->shouldBeCalled();
+
+        $container->hasDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine_mongodb.odm.listeners.resolve_target_document')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $container->hasParameter('Sylius\Component\Resource\Repository\RepositoryInterface')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $container->hasParameter('spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addMethodCall(
+            'addResolveTargetDocument',
+            array(
+                'Sylius\Component\Resource\Repository\RepositoryInterface', 'spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo', array()
+            ))->shouldBeCalled();
+
+        $this->resolve($container, array(
+            'Sylius\Component\Resource\Repository\RepositoryInterface' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo'
+        ));
+    }
+}

--- a/spec/Sylius/Bundle/ResourceBundle/Fixture/Document/Foo.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Fixture/Document/Foo.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Document;
+
+/**
+ * Foo document.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+class Foo
+{
+}

--- a/spec/Sylius/Bundle/ResourceBundle/Fixture/Document/FooInterface.php
+++ b/spec/Sylius/Bundle/ResourceBundle/Fixture/Document/FooInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Document;
+
+/**
+ * Foo Interface.
+ *
+ * @author Ivannis Suárez Jérez <ivannis.suarez@gmail.com>
+ */
+interface FooInterface
+{
+}


### PR DESCRIPTION
Added the #221 issue behavior for mongodb-odm Documents. There is only one detail, the ResolveTargetDocumentListener should be exposed as a service, I did a pull request in the doctrine/DoctrineMongoDBBundle#246 to add this.
