### PR TITLE
Fixed multiple sorting for Doctrine ORM EntityRepository

### DIFF
--- a/Doctrine/ORM/EntityRepository.php
+++ b/Doctrine/ORM/EntityRepository.php
@@ -182,9 +182,15 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
             return;
         }
 
+        $i = 0;
         foreach ($sorting as $property => $order) {
             if (!empty($order)) {
-                $queryBuilder->orderBy($this->getPropertyName($property), $order);
+                if ($i == 0) {
+                    $queryBuilder->orderBy($this->getPropertyName($property), $order);
+                } else {
+                    $queryBuilder->addOrderBy($this->getPropertyName($property), $order);
+                }
+                $i ++;
             }
         }
     }


### PR DESCRIPTION
QueryBuilder's orderBy method replaces any previously specified orderings, addOrderBy must be used to append some more.
