### PR TITLE
Fallback on metadata default form class 

### DIFF
--- a/Controller/RequestConfiguration.php
+++ b/Controller/RequestConfiguration.php
@@ -120,7 +120,15 @@ class RequestConfiguration
      */
     public function getFormType()
     {
-        return $this->parameters->get('form', sprintf('%s_%s', $this->metadata->getApplicationName(), $this->metadata->getName()));
+        if($type = $this->parameters->get('form')) {
+            return $type;
+        } else {
+            if($this->metadata->hasClass('form')) {
+                return $this->metadata->getClass('form')['default'];
+            }
+
+            return sprintf('%s_%s', $this->metadata->getApplicationName(), $this->metadata->getName());
+        }
     }
 
     /**

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -228,7 +228,7 @@ class ResourceController extends Controller
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
             
-            if($form->isSubmitted() && $form->isValid()) {
+            if($form->isValid()) {
                 $newResource = $form->getData();
 
                 $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -225,30 +225,34 @@ class ResourceController extends Controller
 
         $form = $this->resourceFormFactory->create($configuration, $newResource);
 
-        if ($request->isMethod('POST') && $form->submit($request)->isValid()) {
-            $newResource = $form->getData();
+        if ($request->isMethod('POST')) {
+            $form->submit($request->request->get($form->getName()));
+            
+            if($form->isValid()) {
+                $newResource = $form->getData();
 
-            $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);
+                $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);
 
-            if ($event->isStopped() && !$configuration->isHtmlRequest()) {
-                throw new HttpException($event->getErrorCode(), $event->getMessage());
+                if ($event->isStopped() && !$configuration->isHtmlRequest()) {
+                    throw new HttpException($event->getErrorCode(), $event->getMessage());
+                }
+                if ($event->isStopped()) {
+                    $this->flashHelper->addFlashFromEvent($configuration, $event);
+
+                    return $this->redirectHandler->redirectToIndex($configuration, $newResource);
+                }
+
+                $this->repository->add($newResource);
+                $this->eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource);
+
+                if (!$configuration->isHtmlRequest()) {
+                    return $this->viewHandler->handle($configuration, View::create($newResource, 201));
+                }
+    
+                $this->flashHelper->addSuccessFlash($configuration, ResourceActions::CREATE, $newResource);
+    
+                return $this->redirectHandler->redirectToResource($configuration, $newResource);
             }
-            if ($event->isStopped()) {
-                $this->flashHelper->addFlashFromEvent($configuration, $event);
-
-                return $this->redirectHandler->redirectToIndex($configuration, $newResource);
-            }
-
-            $this->repository->add($newResource);
-            $this->eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource);
-
-            if (!$configuration->isHtmlRequest()) {
-                return $this->viewHandler->handle($configuration, View::create($newResource, 201));
-            }
-
-            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::CREATE, $newResource);
-
-            return $this->redirectHandler->redirectToResource($configuration, $newResource);
         }
 
         if (!$configuration->isHtmlRequest()) {
@@ -282,30 +286,33 @@ class ResourceController extends Controller
 
         $form = $this->resourceFormFactory->create($configuration, $resource);
 
-        if (in_array($request->getMethod(), array('POST', 'PUT', 'PATCH')) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
-            $resource = $form->getData();
-
-            $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
-
-            if ($event->isStopped() && !$configuration->isHtmlRequest()) {
-                throw new HttpException($event->getErrorCode(), $event->getMessage());
-            }
-            if ($event->isStopped()) {
-                $this->flashHelper->addFlashFromEvent($configuration, $event);
-
+        if (in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
+            $form->submit($request->request->get($form->getName(), !$request->isMethod('PATCH')));
+            
+            if($form->isValid()) {
+                $resource = $form->getData();
+    
+                $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
+    
+                if ($event->isStopped() && !$configuration->isHtmlRequest()) {
+                    throw new HttpException($event->getErrorCode(), $event->getMessage());
+                }
+                if ($event->isStopped()) {
+                    $this->flashHelper->addFlashFromEvent($configuration, $event);
+    
+                    return $this->redirectHandler->redirectToResource($configuration, $resource);
+                }
+    
+                $this->manager->flush();
+                $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
+    
+                if (!$configuration->isHtmlRequest()) {
+                    return $this->viewHandler->handle($configuration, View::create($resource, 204));
+                }
+    
+                $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
+    
                 return $this->redirectHandler->redirectToResource($configuration, $resource);
-            }
-
-            $this->manager->flush();
-            $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
-
-            if (!$configuration->isHtmlRequest()) {
-                return $this->viewHandler->handle($configuration, View::create($resource, 204));
-            }
-
-            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
-
-            return $this->redirectHandler->redirectToResource($configuration, $resource);
         }
 
         if (!$configuration->isHtmlRequest()) {

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -287,7 +287,7 @@ class ResourceController extends Controller
         $form = $this->resourceFormFactory->create($configuration, $resource);
 
         if (in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
-            $form->submit($request->request->get($form->getName(), !$request->isMethod('PATCH')));
+            $form->handleRequest($request);
             
             if($form->isValid()) {
                 $resource = $form->getData();

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -226,9 +226,9 @@ class ResourceController extends Controller
         $form = $this->resourceFormFactory->create($configuration, $newResource);
 
         if ($request->isMethod('POST')) {
-            $form->submit($request->request->get($form->getName()));
+            $form->handleRequest($request);
             
-            if($form->isValid()) {
+            if($form->isSubmitted() && $form->isValid()) {
                 $newResource = $form->getData();
 
                 $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -313,6 +313,7 @@ class ResourceController extends Controller
                 $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
     
                 return $this->redirectHandler->redirectToResource($configuration, $resource);
+            }
         }
 
         if (!$configuration->isHtmlRequest()) {

--- a/Controller/ResourceFormFactory.php
+++ b/Controller/ResourceFormFactory.php
@@ -39,10 +39,6 @@ class ResourceFormFactory implements ResourceFormFactoryInterface
     {
         $formType = $requestConfiguration->getFormType();
 
-        if (false !== strpos($formType, '\\')) {
-            $formType = new $formType();
-        }
-
         if ($requestConfiguration->isHtmlRequest()) {
             return $this->formFactory->create($formType, $resource);
         }


### PR DESCRIPTION
In route, if don't exist the parameter "form", getFormType returns a string name for the form. A deprecated warning occurs (Accessing type "*****" by its string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name "************").