### PR TITLE
New Twig date filter

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -47,7 +47,7 @@
             {% endblock %}
             <hr>
             <footer>
-                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|format_date('Y') }}.</p>
+                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|date('Y') }}.</p>
             </footer>
         </div>
         {% block sylius_javascripts %}


### PR DESCRIPTION
Because while running `assetic:dump` command I always have:

```
The template "SyliusResourceBundle::layout.html.twig" contains an error: Unknown "format_date" filter. Did you mean "format_file" in "SyliusResourceBundle::layout.html.twig" at line 50
```