### PR TITLE
Make dependency versions compatible with installing ^1.0@beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
         "sensio/generator-bundle": "^3.1",
-        "sylius/grid-bundle": "^1.0",
-        "sylius/locale": "^1.0",
+        "sylius/grid-bundle": "^1.0@beta",
+        "sylius/locale": "^1.0@beta",
         "twig/twig": "^1.28"
     },
     "suggest": {


### PR DESCRIPTION
Hey folks,

When trying to install the beta version of this bundle (`composer require sylius/resource-bundle:^1.0@beta`), I get the following Composer error:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for sylius/resource-bundle ^1.0@beta -> satisfiable by sylius/resource-bundle[v1.0.0-beta.1].
    - sylius/resource-bundle v1.0.0-beta.1 requires sylius/resource ^1.0 -> satisfiable by sylius/resource[1.0.x-dev, v1.0.0-alpha.1, v1.0.0-alpha.2, v1.0.0-beta.1] but these conflict with your requirements or minimum-stability.
```

Lowering the stability of the problematic dependencies would solve that, as they have not published a stable release yet.

I guess that this could otherwise be solved by lowering the global `minimum-stability` to `beta` in the root `composer.json`, or inline-aliasing the 2 concerned dependencies, but I’m not sure if that would be really recommendable.