### PR TITLE
Ensure forward compatibility with ResolveTargetEntityListener

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/DoctrineTargetEntitiesResolverPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/DoctrineTargetEntitiesResolverPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
+use Doctrine\Common\EventSubscriber;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -44,7 +45,12 @@ final class DoctrineTargetEntitiesResolverPass implements CompilerPassInterface
             ]);
         }
 
-        if (!$resolveTargetEntityListener->hasTag('doctrine.event_listener')) {
+        $resolveTargetEntityListenerClass = $container->getParameterBag()->resolveValue($resolveTargetEntityListener->getClass());
+        if (is_a($resolveTargetEntityListenerClass, EventSubscriber::class, true)) {
+            if (!$resolveTargetEntityListener->hasTag('doctrine.event_subscriber')) {
+                $resolveTargetEntityListener->addTag('doctrine.event_subscriber');
+            }
+        } elseif (!$resolveTargetEntityListener->hasTag('doctrine.event_listener')) {
             $resolveTargetEntityListener->addTag('doctrine.event_listener', ['event' => 'loadClassMetadata']);
         }
     }


### PR DESCRIPTION
This should be harmless and will ensure forward compatibility (e.g. when `ResolveTargetEntityListener` decides to subscribe to another event, however unlikely).