### PR TITLE
Autowire factories and repositories by class and name

### DIFF
--- a/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
@@ -110,7 +110,13 @@ abstract class AbstractDriver implements DriverInterface
         $container->setDefinition($metadata->getServiceId('factory'), $definition);
 
         if (method_exists($container, 'registerAliasForArgument')) {
-            foreach (class_implements($factoryClass) as $typehintClass) {
+            $typehintClasses = array_merge(
+                class_implements($factoryClass),
+                [$factoryClass],
+                class_parents($factoryClass)
+            );
+
+            foreach ($typehintClasses as $typehintClass) {
                 $container->registerAliasForArgument(
                     $metadata->getServiceId('factory'),
                     $typehintClass,

--- a/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -58,7 +58,13 @@ final class DoctrineORMDriver extends AbstractDoctrineDriver
         $container->setDefinition($metadata->getServiceId('repository'), $definition);
 
         if (method_exists($container, 'registerAliasForArgument')) {
-            foreach (class_implements($repositoryClass) as $typehintClass) {
+            $typehintClasses = array_merge(
+                class_implements($repositoryClass),
+                [$repositoryClass],
+                class_parents($repositoryClass)
+            );
+
+            foreach ($typehintClasses as $typehintClass) {
                 $container->registerAliasForArgument(
                     $metadata->getServiceId('repository'),
                     $typehintClass,

--- a/src/Bundle/test/src/AppBundle/Resources/config/services.php
+++ b/src/Bundle/test/src/AppBundle/Resources/config/services.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use AppBundle\Service\FirstAutowiredService;
+use AppBundle\Service\NoInterfaceAutowiredService;
 use AppBundle\Service\SecondAutowiredService;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,6 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 if (method_exists($container, 'registerAliasForArgument')) {
     $container->autowire(FirstAutowiredService::class)->setPublic(true);
     $container->autowire(SecondAutowiredService::class)->setPublic(true);
+    $container->autowire(NoInterfaceAutowiredService::class)->setPublic(true);
 } else {
     $container->setDefinition(FirstAutowiredService::class, (new Definition(FirstAutowiredService::class, [
         new Reference('app.factory.book'),
@@ -30,5 +32,12 @@ if (method_exists($container, 'registerAliasForArgument')) {
         new Reference('app.factory.book'),
         new Reference('app.repository.book'),
         new Reference('app.manager.book'),
+    ]))->setPublic(true));
+
+    $container->setDefinition(NoInterfaceAutowiredService::class, (new Definition(NoInterfaceAutowiredService::class, [
+        new Reference('app.factory.book'),
+        new Reference('app.repository.book'),
+        new Reference('app.factory.comic_book'),
+        new Reference('app.repository.comic_book'),
     ]))->setPublic(true));
 }

--- a/src/Bundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
+++ b/src/Bundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
-* This file is part of the Sylius package.
-*
-* (c) Paweł Jędrzejewski
-*
-* For the full copyright and license information, please view the LICENSE
-* file that was distributed with this source code.
-*/
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace AppBundle\Service;

--- a/src/Bundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
+++ b/src/Bundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
@@ -1,0 +1,44 @@
+<?php
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+declare(strict_types=1);
+
+namespace AppBundle\Service;
+
+use AppBundle\Factory\BookFactory;
+use AppBundle\Repository\BookRepository;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Component\Resource\Factory\Factory;
+
+final class NoInterfaceAutowiredService
+{
+    /** @var BookFactory */
+    private $bookFactory;
+
+    /** @var BookRepository */
+    private $bookRepository;
+
+    /** @var Factory */
+    private $comicBookFactory;
+
+    /** @var EntityRepository */
+    private $comicBookRepository;
+
+    public function __construct(
+        BookFactory $bookFactory,
+        BookRepository $bookRepository,
+        Factory $comicBookFactory,
+        EntityRepository $comicBookRepository
+    ) {
+        $this->bookFactory = $bookFactory;
+        $this->bookRepository = $bookRepository;
+        $this->comicBookFactory = $comicBookFactory;
+        $this->comicBookRepository = $comicBookRepository;
+    }
+}

--- a/src/Bundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/src/Bundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
@@ -15,6 +15,8 @@ namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection;
 
 use AppBundle\Entity\Book;
 use AppBundle\Entity\BookTranslation;
+use AppBundle\Entity\ComicBook;
+use AppBundle\Factory\BookFactory;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 
@@ -80,6 +82,34 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
          ]);
 
         $this->assertContainerBuilderHasAlias('sylius.translation_locale_provider', 'test.custom_locale_provider');
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_break_when_aliasing_two_resources_use_same_factory_class(): void
+    {
+        // TODO: Move Resource-Grid integration to a dedicated compiler pass
+        $this->setParameter('kernel.bundles', []);
+        $this->load([
+            'resources' => [
+                'app.book' => [
+                    'classes' => [
+                        'model' => Book::class,
+                        'factory' => BookFactory::class,
+                    ],
+                ],
+                'app.comic_book' => [
+                    'classes' => [
+                        'model' => ComicBook::class,
+                        'factory' => BookFactory::class,
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertContainerBuilderHasService('app.factory.book');
+        $this->assertContainerBuilderHasService('app.factory.comic_book');
+        $this->assertContainerBuilderHasAlias(BookFactory::class, 'app.factory.comic_book');
     }
 
     /**

--- a/src/Bundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/src/Bundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
@@ -109,7 +109,9 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
         ]);
         $this->assertContainerBuilderHasService('app.factory.book');
         $this->assertContainerBuilderHasService('app.factory.comic_book');
-        $this->assertContainerBuilderHasAlias(BookFactory::class, 'app.factory.comic_book');
+
+        $this->assertContainerBuilderHasAlias(sprintf('%s $bookFactory', BookFactory::class), 'app.factory.book');
+        $this->assertContainerBuilderHasAlias(sprintf('%s $comicBookFactory', BookFactory::class), 'app.factory.comic_book');
     }
 
     /**


### PR DESCRIPTION
Replaces and bases on https://github.com/Sylius/Sylius/pull/10217 by @loic425.

Allows for autowiring `FactoryClass $resourceFactory` and `RepositoryClass $resourceRepository`.