### PR TITLE
Autodiscover resource's model interfaces and deprecate explicit configuration

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolver.php
+++ b/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+final class TargetEntitiesResolver implements TargetEntitiesResolverInterface
+{
+    public function resolve(array $resources): array
+    {
+        $interfaces = [];
+
+        foreach ($resources as $alias => $configuration) {
+            $model = $this->getModel($alias, $configuration);
+
+            foreach (class_implements($model) as $interface) {
+                if ($interface === ResourceInterface::class) {
+                    continue;
+                }
+
+                $interfaces[$interface][] = $model;
+            }
+        }
+
+        $interfaces = array_filter($interfaces, function (array $classes): bool {
+            return count($classes) === 1;
+        });
+
+        $interfaces = array_map(function (array $classes): string {
+            return (string) current($classes);
+        }, $interfaces);
+
+        foreach ($resources as $alias => $configuration) {
+            if (isset($configuration['classes']['interface'])) {
+                $model = $this->getModel($alias, $configuration);
+                $interface = $configuration['classes']['interface'];
+
+                @trigger_error(
+                    sprintf(
+                        'Specifying interface for resources is deprecated since ResourceBundle v1.6 and will be removed in v2.0. ' .
+                        'Please rely on autodiscovering entity interfaces instead. ' .
+                        'Triggered by resource "%s" with model "%s" and interface "%s".',
+                        $alias,
+                        $model,
+                        $interface
+                    ),
+                    \E_USER_DEPRECATED
+                );
+
+                $interfaces[$interface] = $model;
+            }
+        }
+
+        return $interfaces;
+    }
+
+    private function getModel(string $alias, array $configuration): string
+    {
+        if (!isset($configuration['classes']['model'])) {
+            throw new \InvalidArgumentException(sprintf('Could not get model class from resource "%s".', $alias));
+        }
+
+        return $configuration['classes']['model'];
+    }
+}

--- a/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolverInterface.php
+++ b/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper;
+
+interface TargetEntitiesResolverInterface
+{
+    /**
+     * @return array Interface to class map.
+     */
+    public function resolve(array $resourcesConfiguration): array;
+}

--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\DoctrineTargetEntitiesResolverPass;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper\TargetEntitiesResolver;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterFormBuilderPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourceRepositoryPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourcesPass;
@@ -36,7 +37,7 @@ final class SyliusResourceBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterResourcesPass());
-        $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(new TargetEntitiesResolver()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RegisterResourceRepositoryPass());
         $container->addCompilerPass(new RegisterFormBuilderPass());
         $container->addCompilerPass(new WinzouStateMachinePass());

--- a/src/Bundle/Tests/Fixtures/AnimalInterface.php
+++ b/src/Bundle/Tests/Fixtures/AnimalInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+interface AnimalInterface extends ResourceInterface
+{
+}

--- a/src/Bundle/Tests/Fixtures/Bear.php
+++ b/src/Bundle/Tests/Fixtures/Bear.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+final class Bear implements BearInterface
+{
+    public function getId(): int
+    {
+        return 42;
+    }
+}

--- a/src/Bundle/Tests/Fixtures/BearInterface.php
+++ b/src/Bundle/Tests/Fixtures/BearInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+interface BearInterface extends MammalInterface
+{
+}

--- a/src/Bundle/Tests/Fixtures/Fly.php
+++ b/src/Bundle/Tests/Fixtures/Fly.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+final class Fly implements FlyInterface
+{
+    public function getId(): int
+    {
+        return 42;
+    }
+}

--- a/src/Bundle/Tests/Fixtures/FlyInterface.php
+++ b/src/Bundle/Tests/Fixtures/FlyInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+interface FlyInterface extends AnimalInterface
+{
+}

--- a/src/Bundle/Tests/Fixtures/MammalInterface.php
+++ b/src/Bundle/Tests/Fixtures/MammalInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+interface MammalInterface extends AnimalInterface
+{
+}

--- a/src/Bundle/Tests/Fixtures/Resource.php
+++ b/src/Bundle/Tests/Fixtures/Resource.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+final class Resource implements ResourceInterface
+{
+    public function getId()
+    {
+        return 42;
+    }
+}

--- a/src/Bundle/spec/DependencyInjection/Compiler/Helper/TargetEntitiesResolverSpec.php
+++ b/src/Bundle/spec/DependencyInjection/Compiler/Helper/TargetEntitiesResolverSpec.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper\TargetEntitiesResolverInterface;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\AnimalInterface;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\Bear;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\BearInterface;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\Fly;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\FlyInterface;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\MammalInterface;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\Resource;
+
+class TargetEntitiesResolverSpec extends ObjectBehavior
+{
+    function it_is_a_target_entities_resolver(): void
+    {
+        $this->shouldImplement(TargetEntitiesResolverInterface::class);
+    }
+
+    function it_skips_resource_interface(): void
+    {
+        $emptyConfig = ['app.resource' => ['classes' => ['model' => Resource::class]]];
+
+        $this->resolve($emptyConfig)->shouldReturn([]);
+    }
+
+    function it_autodiscovers_interfaces_based_on_the_model_class(): void
+    {
+        $flyConfig = ['app.fly' => ['classes' => ['model' => Fly::class]]];
+
+        $this->resolve($flyConfig)->shouldHaveCount(2);
+        $this->resolve($flyConfig)->shouldHaveKeyWithValue(FlyInterface::class, Fly::class);
+        $this->resolve($flyConfig)->shouldHaveKeyWithValue(AnimalInterface::class, Fly::class);
+
+        $bearConfig = ['app.bear' => ['classes' => ['model' => Bear::class]]];
+
+        $this->resolve($bearConfig)->shouldHaveCount(3);
+        $this->resolve($bearConfig)->shouldHaveKeyWithValue(BearInterface::class, Bear::class);
+        $this->resolve($bearConfig)->shouldHaveKeyWithValue(MammalInterface::class, Bear::class);
+        $this->resolve($bearConfig)->shouldHaveKeyWithValue(AnimalInterface::class, Bear::class);
+    }
+
+    function it_autodiscovers_only_unique_interfaces_based_on_model_classes(): void
+    {
+        $config = [
+            'app.fly' => ['classes' => ['model' => Fly::class]],
+            'app.bear' => ['classes' => ['model' => Bear::class]],
+        ];
+
+        $this->resolve($config)->shouldHaveCount(3);
+        $this->resolve($config)->shouldHaveKeyWithValue(BearInterface::class, Bear::class);
+        $this->resolve($config)->shouldHaveKeyWithValue(MammalInterface::class, Bear::class);
+        $this->resolve($config)->shouldHaveKeyWithValue(FlyInterface::class, Fly::class);
+
+        $this->resolve($config)->shouldNotHaveKeyWithValue(AnimalInterface::class, Fly::class);
+        $this->resolve($config)->shouldNotHaveKeyWithValue(AnimalInterface::class, Bear::class);
+    }
+
+    function it_uses_the_interface_defined_in_the_config(): void
+    {
+        $config = [
+            'app.deprecated' => ['classes' => ['model' => Resource::class, 'interface' => \Countable::class]],
+        ];
+
+        $this->resolve($config)->shouldHaveCount(1);
+        $this->resolve($config)->shouldHaveKeyWithValue(\Countable::class, Resource::class);
+        $this->shouldTrigger(\E_USER_DEPRECATED)->during('resolve', [$config]);
+    }
+
+    function it_uses_the_interface_defined_explicitly_over_the_autodiscovered_one(): void
+    {
+        $config = [
+            'app.deprecated' => ['classes' => ['model' => Resource::class, 'interface' => MammalInterface::class]],
+            'app.bear' => ['classes' => ['model' => Bear::class]],
+        ];
+
+        $this->resolve($config)->shouldHaveCount(3);
+        $this->resolve($config)->shouldHaveKeyWithValue(MammalInterface::class, Resource::class);
+        $this->resolve($config)->shouldHaveKeyWithValue(AnimalInterface::class, Bear::class);
+        $this->resolve($config)->shouldHaveKeyWithValue(BearInterface::class, Bear::class);
+        $this->shouldTrigger(\E_USER_DEPRECATED)->during('resolve', [$config]);
+    }
+
+    function it_throws_an_exception_if_model_class_can_not_be_resolved(): void
+    {
+        $config = ['app.error' => ['classes' => ['interface' => \Countable::class]]];
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('resolve', [$config]);
+    }
+}


### PR DESCRIPTION
Fixes #94, solution described in https://github.com/Sylius/SyliusResourceBundle/issues/94#issuecomment-501568904.