### PR TITLE
Critiera Applier

### DIFF
--- a/src/Bundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Bundle/Doctrine/ORM/EntityRepository.php
@@ -80,32 +80,33 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
 
             $name = $this->getPropertyName($property);
 
-            if('' === $value) {
+            if ('' === $value) {
                 continue;
             }
 
             if (null === $value) {
                 $queryBuilder->andWhere($queryBuilder->expr()->isNull($name));
+
                 continue;
             }
 
             if (is_array($value)) {
                 $queryBuilder->andWhere($queryBuilder->expr()->in($name, $value));
+
                 continue;
             }
 
             $parameter = str_replace('.', '_', $property);
-            if(is_string($value)) {
-                $expression = $queryBuilder->expr()->like($name, ':'. $parameter);
+            if (is_string($value)) {
+                $expression = $queryBuilder->expr()->like($name, ':' . $parameter);
             } else {
-                $expression = $queryBuilder->expr()->eq($name, ':'.$parameter);
+                $expression = $queryBuilder->expr()->eq($name, ':' . $parameter);
             }
 
             $queryBuilder
                 ->andWhere($expression)
                 ->setParameter($parameter, $value)
             ;
-
         }
     }
 

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceRepositoryPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceRepositoryPassTest.php
@@ -58,6 +58,8 @@ final class RegisterResourceRepositoryPassTest extends AbstractCompilerPassTestC
         );
 
         $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.registry.resource_repository');
     }
 
     /**

--- a/src/Bundle/test/src/Tests/Controller/BookApiTest.php
+++ b/src/Bundle/test/src/Tests/Controller/BookApiTest.php
@@ -115,6 +115,7 @@ EOT;
 
         $this->client->request('GET', '/books/' . $objects['book1']->getId());
         $response = $this->client->getResponse();
+
         $this->assertResponse($response, 'books/show_response');
     }
 
@@ -198,9 +199,22 @@ EOT;
      */
     public function it_applies_filtering_for_existing_field()
     {
-        $this->loadFixturesFromFile('more_books.yml');
+        $this->loadFixturesFromFile('books.yml');
 
         $this->client->request('GET', '/filterable-books/', ['criteria' => ['author' => 'J.R.R. Tolkien']]);
+        $response = $this->client->getResponse();
+
+        $this->assertResponseCode($response, Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_applies_partial_filtering_for_an_existing_field()
+    {
+        $this->loadFixturesFromFile('more_books.yml');
+
+        $this->client->request('GET', '/filterable-books/', ['criteria' => ['author' => 'Tolkien']]);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_OK);


### PR DESCRIPTION
In the current version of the plugin if you are using it to generate CRUD routes for an api the filter mechanism doesn't support filtering with only a part of the search term.

In this commit I am trying to fix this.