### PR TITLE
[RFC] Add success flashes before post event

### DIFF
--- a/src/Bundle/Controller/ResourceController.php
+++ b/src/Bundle/Controller/ResourceController.php
@@ -208,13 +208,16 @@ class ResourceController extends Controller
             }
 
             $this->repository->add($newResource);
+
+            if ($configuration->isHtmlRequest()) {
+                $this->flashHelper->addSuccessFlash($configuration, ResourceActions::CREATE, $newResource);
+            }
+
             $postEvent = $this->eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource);
 
             if (!$configuration->isHtmlRequest()) {
                 return $this->viewHandler->handle($configuration, View::create($newResource, Response::HTTP_CREATED));
             }
-
-            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::CREATE, $newResource);
 
             if ($postEvent->hasResponse()) {
                 return $postEvent->getResponse();
@@ -289,6 +292,10 @@ class ResourceController extends Controller
                 return $this->redirectHandler->redirectToReferer($configuration);
             }
 
+            if ($configuration->isHtmlRequest()) {
+                $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
+            }
+
             $postEvent = $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
             if (!$configuration->isHtmlRequest()) {
@@ -296,8 +303,6 @@ class ResourceController extends Controller
 
                 return $this->viewHandler->handle($configuration, $view);
             }
-
-            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
 
             if ($postEvent->hasResponse()) {
                 return $postEvent->getResponse();
@@ -370,13 +375,15 @@ class ResourceController extends Controller
             return $this->redirectHandler->redirectToReferer($configuration);
         }
 
+        if ($configuration->isHtmlRequest()) {
+            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::DELETE, $resource);
+        }
+
         $postEvent = $this->eventDispatcher->dispatchPostEvent(ResourceActions::DELETE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
             return $this->viewHandler->handle($configuration, View::create(null, Response::HTTP_NO_CONTENT));
         }
-
-        $this->flashHelper->addSuccessFlash($configuration, ResourceActions::DELETE, $resource);
 
         if ($postEvent->hasResponse()) {
             return $postEvent->getResponse();
@@ -493,6 +500,10 @@ class ResourceController extends Controller
             return $this->redirectHandler->redirectToReferer($configuration);
         }
 
+        if ($configuration->isHtmlRequest()) {
+            $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
+        }
+
         $postEvent = $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
@@ -500,8 +511,6 @@ class ResourceController extends Controller
 
             return $this->viewHandler->handle($configuration, $view);
         }
-
-        $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
 
         if ($postEvent->hasResponse()) {
             return $postEvent->getResponse();


### PR DESCRIPTION
I don't know is it intended behavior or not 🤔 For me, a natural place to throw a post event is **just before redirect**. With this change, we can, for example, operate on flashed basing on create/updated/deleted resource data (I had such a case 💃)