### PR TITLE
Update ORMTranslatableListener.php (Solves issue #103)

### DIFF
--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -61,7 +61,7 @@ final class ORMTranslatableListener implements EventSubscriber
         $classMetadata = $eventArgs->getClassMetadata();
         $reflection = $classMetadata->getReflectionClass();
 
-        if ($reflection == NULL || $reflection->isAbstract()) {
+        if ($reflection === NULL || $reflection->isAbstract()) {
             return;
         }
 

--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -61,7 +61,7 @@ final class ORMTranslatableListener implements EventSubscriber
         $classMetadata = $eventArgs->getClassMetadata();
         $reflection = $classMetadata->getReflectionClass();
 
-        if ($reflection->isAbstract()) {
+        if (!$reflection || $reflection->isAbstract()) {
             return;
         }
 

--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -61,7 +61,7 @@ final class ORMTranslatableListener implements EventSubscriber
         $classMetadata = $eventArgs->getClassMetadata();
         $reflection = $classMetadata->getReflectionClass();
 
-        if (!$reflection || $reflection->isAbstract()) {
+        if ($reflection == NULL || $reflection->isAbstract()) {
             return;
         }
 

--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -61,7 +61,7 @@ final class ORMTranslatableListener implements EventSubscriber
         $classMetadata = $eventArgs->getClassMetadata();
         $reflection = $classMetadata->getReflectionClass();
 
-        if ($reflection === NULL || $reflection->isAbstract()) {
+        if ($reflection === null || $reflection->isAbstract()) {
             return;
         }
 


### PR DESCRIPTION
Running make:entity will cause PHP Fatal error if $reflection is null when evaluating $reflection->isAbstract(). Checking if $reflection is null and avoiding the subsequent evaluation will prevent the error.