### PR TITLE
Fix extended types deprecation

### DIFF
--- a/src/Bundle/Form/Extension/CollectionTypeExtension.php
+++ b/src/Bundle/Form/Extension/CollectionTypeExtension.php
@@ -50,4 +50,9 @@ final class CollectionTypeExtension extends AbstractTypeExtension
     {
         return CollectionType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [CollectionType::class];
+    }
 }


### PR DESCRIPTION
Class "Sylius\Bundle\ResourceBundle\Form\Extension\CollectionTypeExtension" should implement method "static Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()": Gets the extended types - not implementing it is deprecated since Symfony 4.2.

Not implementing the "Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()" method in "Sylius\Bundle\ResourceBundle\Form\Extension\CollectionTypeExtension" is deprecated since Symfony 4.2.