### PR TITLE
Symfony 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ env:
 
 jobs:
     fast_finish: true
-    allow_failures:
-        -
-            env: SYMFONY_VERSION=5.0.*
 
 cache:
     directories:


### PR DESCRIPTION
Fixes https://github.com/Sylius/SyliusResourceBundle/issues/121

Pull request to track where we are on Symfony 5 support.
https://github.com/Sylius/SyliusResourceBundle/pull/124 Replace deprecated object manager
https://github.com/Sylius/SyliusResourceBundle/pull/125 Replace deprecated object repository
https://github.com/Sylius/SyliusResourceBundle/pull/126 Replace dbal types
https://github.com/Sylius/SyliusResourceBundle/pull/135 Allow for DoctrineBundle ^2.0