### PR TITLE
Allow for DoctrineBundle ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.2",
 
-        "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/doctrine-bundle": "^1.12|^2.0",
         "doctrine/persistence": "^1.3",
         "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^3.5",

--- a/src/Bundle/AbstractResourceBundle.php
+++ b/src/Bundle/AbstractResourceBundle.php
@@ -43,7 +43,7 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
                 if (class_exists($compilerPassClassName)) {
                     if (!method_exists($compilerPassClassName, $compilerPassMethod)) {
                         throw new InvalidConfigurationException(
-                            "The 'mappingFormat' value is invalid, must be 'xml', 'yml' or 'annotation'."
+                            "The 'mappingFormat' value is invalid, must be 'xml', 'yaml' or 'annotation'."
                         );
                     }
 


### PR DESCRIPTION
Related to #121.
The only class we use in ResourceBundle has not been changed in 2.0, so we can support both at the same time.