### PR TITLE
Fix event dispatcher deprecation

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -75,6 +75,7 @@
             <errorLevel type="suppress">
                 <referencedFunction name="Symfony\Component\HttpFoundation\HeaderBag::all" />
                 <referencedFunction name="Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch" />
+                <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch" />
             </errorLevel>
         </TooManyArguments>
 

--- a/src/Bundle/Controller/EventDispatcher.php
+++ b/src/Bundle/Controller/EventDispatcher.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Model\ResourceInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
 
 final class EventDispatcher implements EventDispatcherInterface
 {
@@ -39,7 +39,7 @@ final class EventDispatcher implements EventDispatcherInterface
         $metadata = $requestConfiguration->getMetadata();
         $event = new ResourceControllerEvent($resource);
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s.%s', $metadata->getApplicationName(), $metadata->getName(), $eventName));
 
         return $event;
     }
@@ -56,7 +56,7 @@ final class EventDispatcher implements EventDispatcherInterface
         $metadata = $requestConfiguration->getMetadata();
         $event = new ResourceControllerEvent($resources);
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s.%s', $metadata->getApplicationName(), $metadata->getName(), $eventName));
 
         return $event;
     }
@@ -73,7 +73,7 @@ final class EventDispatcher implements EventDispatcherInterface
         $metadata = $requestConfiguration->getMetadata();
         $event = new ResourceControllerEvent($resource);
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.pre_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s.pre_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName));
 
         return $event;
     }
@@ -90,7 +90,7 @@ final class EventDispatcher implements EventDispatcherInterface
         $metadata = $requestConfiguration->getMetadata();
         $event = new ResourceControllerEvent($resource);
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.post_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s.post_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName));
 
         return $event;
     }
@@ -108,8 +108,8 @@ final class EventDispatcher implements EventDispatcherInterface
         $event = new ResourceControllerEvent($resource);
 
         $this->eventDispatcher->dispatch(
-            sprintf('%s.%s.initialize_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName),
-            $event
+            $event,
+            sprintf('%s.%s.initialize_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName)
         );
 
         return $event;

--- a/src/Bundle/spec/Controller/EventDispatcherSpec.php
+++ b/src/Bundle/spec/Controller/EventDispatcherSpec.php
@@ -22,7 +22,7 @@ use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\ResourceActions;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class EventDispatcherSpec extends ObjectBehavior
 {
@@ -47,7 +47,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.show', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.show')->shouldBeCalled();
 
         $this->dispatch(ResourceActions::SHOW, $requestConfiguration, $resource)->shouldHaveType(ResourceControllerEvent::class);
     }
@@ -63,7 +63,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.register', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.register')->shouldBeCalled();
 
         $this->dispatch(ResourceActions::CREATE, $requestConfiguration, $resource)->shouldHaveType(ResourceControllerEvent::class);
     }
@@ -79,7 +79,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.register', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.register')->shouldBeCalled();
 
         $this->dispatchMultiple(ResourceActions::CREATE, $requestConfiguration, $resources)->shouldHaveType(ResourceControllerEvent::class);
     }
@@ -95,7 +95,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.pre_create', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.pre_create')->shouldBeCalled();
 
         $this->dispatchPreEvent(ResourceActions::CREATE, $requestConfiguration, $resource);
     }
@@ -111,7 +111,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.pre_register', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.pre_register')->shouldBeCalled();
 
         $this->dispatchPreEvent(ResourceActions::CREATE, $requestConfiguration, $resource);
     }
@@ -127,7 +127,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.post_create', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.post_create')->shouldBeCalled();
 
         $this->dispatchPostEvent(ResourceActions::CREATE, $requestConfiguration, $resource);
     }
@@ -143,7 +143,7 @@ final class EventDispatcherSpec extends ObjectBehavior
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getName()->willReturn('product');
 
-        $eventDispatcher->dispatch('sylius.product.post_register', Argument::type(ResourceControllerEvent::class))->shouldBeCalled();
+        $eventDispatcher->dispatch(Argument::type(ResourceControllerEvent::class), 'sylius.product.post_register')->shouldBeCalled();
 
         $this->dispatchPostEvent(ResourceActions::CREATE, $requestConfiguration, $resource)->shouldHaveType(ResourceControllerEvent::class);
     }


### PR DESCRIPTION
User Deprecated: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.