### PR TITLE
Fix DoctrineORMAdapter with $fetchJoinCollection false making result …

### DIFF
--- a/src/Bundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Bundle/Doctrine/ORM/EntityRepository.php
@@ -57,10 +57,10 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
         return $this->getPaginator($queryBuilder);
     }
 
-    protected function getPaginator(QueryBuilder $queryBuilder): Pagerfanta
+    // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly (see #3775)
+    protected function getPaginator(QueryBuilder $queryBuilder, $fetchJoinCollection = true, $useOutputWalker = false): Pagerfanta
     {
-        // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly (see #3775)
-        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, false, false));
+        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, $fetchJoinCollection, $useOutputWalker));
     }
 
     /**


### PR DESCRIPTION
…returned less

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #148 
| License         | MIT

**Description**  
<!-- A clear and concise description of the bug you are experiencing. -->
The setting shipped in 1.6 can return much less result than expected.

**Steps to reproduce**  
Consider I was trying to get a Pagerfanta for product with specific variant code pattern, with `$fetchJoinCollection` set as false. In `doctrine/orm/lib/Doctrine/ORM/Tools/Pagination/Paginator.php` `getIterator` it will execute something like

```sql
SELECT 
...
FROM product p
JOIN variant pv ON ...
WHERE
...
LIMIT 100
```

Since 1 product can have multiple variants, number of distinct products returned is likely less than 100.

**Possible Solution**  
With `$fetchJoinCollection` set to true, doctrine will first select all distinct IDs first and then select all tuples afterwards to ensure number of products returned matches what `setMaxResults` set.

Long long time ago $fetchJoinCollection was set to true and everything works fine.
