### PR TITLE
Making the view handler generic

### DIFF
--- a/src/Bundle/Controller/ViewHandler.php
+++ b/src/Bundle/Controller/ViewHandler.php
@@ -14,15 +14,15 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Controller;
 
 use FOS\RestBundle\View\View;
-use FOS\RestBundle\View\ViewHandler as RestViewHandler;
+use FOS\RestBundle\View\ViewHandlerInterface as RestViewHandlerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ViewHandler implements ViewHandlerInterface
 {
-    /** @var RestViewHandler */
+    /** @var RestViewHandlerInterface */
     private $restViewHandler;
 
-    public function __construct(RestViewHandler $restViewHandler)
+    public function __construct(RestViewHandlerInterface $restViewHandler)
     {
         $this->restViewHandler = $restViewHandler;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | --none--
| License         | MIT

Making the base Viewhandler generic to make it easier to replace the view handler.