### PR TITLE
Pagerfanta updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     ],
     "require": {
         "php": "^7.3",
-        "babdev/pagerfanta-bundle": "^2.0",
-        "doctrine/doctrine-bundle": "^1.12 || ^2.0",
+        "babdev/pagerfanta-bundle": "^2.5",
+        "doctrine/doctrine-bundle": "^1.12|^2.0",
         "doctrine/persistence": "^1.3",
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/registry": "^1.2",

--- a/docs/index_resources.md
+++ b/docs/index_resources.md
@@ -16,7 +16,7 @@ When you go to ``/books``, the ResourceController will use the repository (``app
 The default template will be rendered - ``App:Book:index.html.twig`` with the paginator as the ``books`` variable.
 
 A paginator can be a simple array, if you disable the pagination, otherwise it is an instance of ``Pagerfanta\Pagerfanta``
-which is a [Library](https://github.com/whiteoctober/Pagerfanta) used to manage the pagination.
+which is a [Library](https://github.com/BabDev/Pagerfanta) used to manage the pagination.
 
 ## Overriding the Template and Criteria
 

--- a/src/Bundle/DependencyInjection/PagerfantaExtension.php
+++ b/src/Bundle/DependencyInjection/PagerfantaExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.8. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in Sylius 2.0.', PagerfantaExtension::class), \E_USER_DEPRECATED);
+@trigger_error(sprintf('The "%s" class is deprecated since sylius/resource-bundle 1.7. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in Sylius 2.0.', PagerfantaExtension::class), \E_USER_DEPRECATED);
 
 /**
  * Container extension to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle

--- a/src/Bundle/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/src/Bundle/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\ResourceBundle\Doctrine\ODM\MongoDB;
 
 use Doctrine\MongoDB\Query\Builder as QueryBuilder;
 use Doctrine\ODM\MongoDB\DocumentRepository as BaseDocumentRepository;
-use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter;
+use Pagerfanta\Doctrine\MongoDBODM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -134,7 +134,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
      */
     public function getPaginator(QueryBuilder $queryBuilder)
     {
-        return new Pagerfanta(new DoctrineODMMongoDBAdapter($queryBuilder));
+        return new Pagerfanta(new QueryAdapter($queryBuilder));
     }
 
     /**

--- a/src/Bundle/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\ResourceBundle\Doctrine\ODM\PHPCR;
 
 use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
-use Pagerfanta\Adapter\DoctrineODMPhpcrAdapter;
+use Pagerfanta\Doctrine\PHPCRODM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -65,7 +65,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
      */
     public function getPaginator(QueryBuilder $queryBuilder)
     {
-        return new Pagerfanta(new DoctrineODMPhpcrAdapter($queryBuilder));
+        return new Pagerfanta(new QueryAdapter($queryBuilder));
     }
 
     /**

--- a/src/Bundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Bundle/Doctrine/ORM/EntityRepository.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Doctrine\ORM;
 use Doctrine\ORM\EntityRepository as BaseEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Adapter\ArrayAdapter;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -59,8 +59,8 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
 
     protected function getPaginator(QueryBuilder $queryBuilder): Pagerfanta
     {
-        // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly (see #3775)
-        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, false, false));
+        // Use output walkers option in the query adapter should be false as it affects performance greatly (see sylius/sylius#3775)
+        return new Pagerfanta(new QueryAdapter($queryBuilder, false, false));
     }
 
     /**

--- a/src/Bundle/Tests/DependencyInjection/PagerfantaExtensionTest.php
+++ b/src/Bundle/Tests/DependencyInjection/PagerfantaExtensionTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection;
 
+use BabDev\PagerfantaBundle\BabDevPagerfantaBundle;
 use BabDev\PagerfantaBundle\DependencyInjection\BabDevPagerfantaExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\PagerfantaExtension;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 
 final class PagerfantaExtensionTest extends AbstractExtensionTestCase
 {
@@ -24,8 +26,13 @@ final class PagerfantaExtensionTest extends AbstractExtensionTestCase
      */
     public function it_prepends_the_white_october_bundle_configuration_to_the_babdev_bundle(): void
     {
-        // TODO: Move Resource-Grid integration to a dedicated compiler pass
-        $this->setParameter('kernel.bundles', []);
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'BabDevPagerfantaBundle' => BabDevPagerfantaBundle::class,
+                'TwigBundle' => TwigBundle::class,
+            ]
+        );
 
         $bundleConfig = [
             'default_view' => 'twitter_bootstrap',

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -24,9 +24,9 @@
 
         "doctrine/common": "^2.6",
         "gedmo/doctrine-extensions": "^2.4",
+        "pagerfanta/core": "^2.4",
         "symfony/event-dispatcher": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
-        "pagerfanta/pagerfanta": "^1.0|^2.0"
     },
     "require-dev": {
         "behat/transliterator": "dev-master",

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -26,7 +26,7 @@
         "gedmo/doctrine-extensions": "^2.4",
         "pagerfanta/core": "^2.4",
         "symfony/event-dispatcher": "^4.4|^5.0",
-        "symfony/property-access": "^4.4|^5.0",
+        "symfony/property-access": "^4.4|^5.0"
     },
     "require-dev": {
         "behat/transliterator": "dev-master",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

As noted [here](https://www.babdev.com/open-source/updates/pagerfanta-package-structure-updates), the latest version of the Pagerfanta package was restructured to support separately installed sub-packages.  So, to help with avoiding deprecation notices and preparing for compatibility with the new major version I expect to push out toward the end of the year, I've bumped the Pagerfanta minimums up to the latest versions, updated the query adapter classes to use the non-deprecated classes, and changed the component to install only the `pagerfanta/core` sub-package since that's all it directly depends on.