### PR TITLE
When using winzouStateMachineBundle 0.4, the old named services are aliases, so need to be marked public as well

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
@@ -28,9 +28,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class WinzouStateMachinePass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('sm.factory') && !$container->hasDefinition(FactoryInterface::class)) {
@@ -51,13 +48,22 @@ final class WinzouStateMachinePass implements CompilerPassInterface
             $container->setAlias('sm.callback.cascade_transition', CascadeTransitionCallback::class);
         }
 
-        foreach (['sm.factory', 'sm.callback_factory', 'sm.callback.cascade_transition'] as $id) {
-            if ($container->has($id)) {
-                $container->findDefinition($id)->setPublic(true);
-            }
+        $services = [
+            'sm.factory',
+            'sm.callback_factory',
+            'sm.callback.cascade_transition',
+            FactoryInterface::class,
+            CallbackFactoryInterface::class,
+            CascadeTransitionCallback::class,
+        ];
 
+        foreach ($services as $id) {
             if ($container->hasAlias($id)) {
                 $container->getAlias($id)->setPublic(true);
+            }
+
+            if ($container->hasDefinition($id)) {
+                $container->getDefinition($id)->setPublic(true);
             }
         }
     }

--- a/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
@@ -18,7 +18,6 @@ use SM\Callback\CascadeTransitionCallback;
 use SM\Factory\FactoryInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * Marks WinzouStateMachineBundle's services as public for compatibility with both Symfony 3.4 and 4.0+.
@@ -53,9 +52,12 @@ final class WinzouStateMachinePass implements CompilerPassInterface
         }
 
         foreach (['sm.factory', 'sm.callback_factory', 'sm.callback.cascade_transition'] as $id) {
-            try {
+            if ($container->has($id)) {
                 $container->findDefinition($id)->setPublic(true);
-            } catch (ServiceNotFoundException $exception) {
+            }
+
+            if ($container->hasAlias($id)) {
+                $container->getAlias($id)->setPublic(true);
             }
         }
     }

--- a/src/Bundle/test/src/Tests/DependencyInjection/Compiler/WinzouStateMachinePassTest.php
+++ b/src/Bundle/test/src/Tests/DependencyInjection/Compiler/WinzouStateMachinePassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\test\src\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\Assert;
+use SM\Callback\CallbackFactoryInterface;
+use SM\Callback\CascadeTransitionCallback;
+use SM\Factory\FactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class WinzouStateMachinePassTest extends WebTestCase
+{
+    /** @test */
+    public function all_winzou_services_are_public(): void
+    {
+        /** @var ContainerBuilder $container */
+        $container = self::createClient()->getContainer();
+
+        $services = [
+            'sm.factory',
+            'sm.callback_factory',
+            'sm.callback.cascade_transition',
+            FactoryInterface::class,
+            CallbackFactoryInterface::class,
+            CascadeTransitionCallback::class,
+        ];
+
+        foreach ($services as $id) {
+            Assert::assertNotNull(
+                $container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                sprintf('Service "%s" could not be found', $id)
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

In winzouStateMachineBundle 0.4, the `sm.factory`, `sm.callback_factory`, and `sm.callback.cascade_transition` IDs are aliases and not real services.  So, the aliases need to be made public as well otherwise they won't be available through the container once it's compiled.