### PR TITLE
Allow FOS rest-bundle 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 
         "doctrine/doctrine-bundle": "^1.12|^2.0",
         "doctrine/persistence": "^1.3",
-        "friendsofsymfony/rest-bundle": "^3.0",
+        "friendsofsymfony/rest-bundle": "^2.1|^3.0",
         "jms/serializer-bundle": "^3.5",
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/registry": "^1.2",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

the bundle was upgraded to be compatible with fos/rest v3
but that was about removing the View->setTemplate calls
and replacing them with twig rendering.
all other sylius bundles are using v2 and this causes incompatibility.

This will allow you to release a 1.7 version of the resource bundle, something
currently not possible due to that incompatibility