### PR TITLE
Fix Winzou sm.factory with Bundle 0.3

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/WinzouStateMachinePass.php
@@ -34,9 +34,21 @@ final class WinzouStateMachinePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $container->setAlias('sm.factory', FactoryInterface::class);
-        $container->setAlias('sm.callback_factory', CallbackFactoryInterface::class);
-        $container->setAlias('sm.callback.cascade_transition', CascadeTransitionCallback::class);
+        if ($container->has('sm.factory')) {
+            $container->setAlias(FactoryInterface::class, 'sm.factory');
+        }else {
+            $container->setAlias('sm.factory', FactoryInterface::class);
+        }
+        if ($container->has('sm.callback_factory')) {
+            $container->setAlias(CallbackFactoryInterface::class, 'sm.callback_factory');
+        }else {
+            $container->setAlias('sm.callback_factory', CallbackFactoryInterface::class);
+        }
+        if ($container->has('sm.callback.cascade_transition')) {
+            $container->setAlias(CascadeTransitionCallback::class, 'sm.callback.cascade_transition');
+        }else {
+            $container->setAlias('sm.callback.cascade_transition', CascadeTransitionCallback::class);
+        }
 
         foreach (['sm.factory', 'sm.callback_factory', 'sm.callback.cascade_transition'] as $id) {
             try {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

When this master version is used with Winzou State Machine Bundle 0.3 and Sylius dev-master, the dependency injection throw this exception:

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                    
  The service "twig" has a dependency on a non-existent service "SM\Factory\FactoryInterface".
```

It's true because the service id is `sm.factory` and a alias is defined with same name.

The realy behavior need is define alias from `sm.factory` to interface if the service id `sm.factory` exists. And define alias fromt interface to `sm.factory` if service id `sm.factory` is not defined.

And same behavior for service `sm.callback_factory` and `sm.callback.cascade_transition`.


