### PR TITLE
Replace AbstractController with ControllerTrait & ContainerAwareInterface

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -17,6 +17,7 @@ services:
 
 parameters:
     exclude_files:
+        - 'src/Bundle/Controller/ControllerTrait.php'
         - 'src/Bundle/test/app/cache/*'
         - 'src/Bundle/test/var/*'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     excludes_analyse:
+        - %currentWorkingDirectory%/src/Bundle/Controller/ControllerTrait.php
         - %currentWorkingDirectory%/src/Bundle/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/src/Bundle/DependencyInjection/PagerfantaConfiguration.php
         - %currentWorkingDirectory%/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,7 @@
             <directory name="src/Bundle/Tests" />
             <directory name="src/Component/spec" />
             <directory name="src/Component/vendor" />
+            <file name="src/Bundle/Controller/ControllerTrait.php" />
             <file name="src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php" />
             <file name="src/Bundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php" />
             <file name="src/Bundle/EventListener/ODM*.php" />

--- a/src/Bundle/Controller/ControllerTrait.php
+++ b/src/Bundle/Controller/ControllerTrait.php
@@ -1,0 +1,440 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Controller;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
+use Psr\Link\LinkInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
+use Symfony\Component\WebLink\GenericLinkProvider;
+
+/**
+ * Common features needed in controllers.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
+ *
+ * @property ContainerInterface $container
+ */
+trait ControllerTrait
+{
+    /**
+     * Returns true if the service id is defined.
+     *
+     * @final
+     */
+    protected function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+
+    /**
+     * Gets a container service by its id.
+     *
+     * @return object The service
+     *
+     * @final
+     */
+    protected function get(string $id)
+    {
+        return $this->container->get($id);
+    }
+
+    /**
+     * Generates a URL from the given parameters.
+     *
+     * @see UrlGeneratorInterface
+     *
+     * @final
+     */
+    protected function generateUrl(string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
+    {
+        return $this->container->get('router')->generate($route, $parameters, $referenceType);
+    }
+
+    /**
+     * Forwards the request to another controller.
+     *
+     * @param string $controller The controller name (a string like Bundle\BlogBundle\Controller\PostController::indexAction)
+     *
+     * @final
+     */
+    protected function forward(string $controller, array $path = [], array $query = []): Response
+    {
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+        $path['_controller'] = $controller;
+        $subRequest = $request->duplicate($query, null, $path);
+
+        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given URL.
+     *
+     * @final
+     */
+    protected function redirect(string $url, int $status = 302): RedirectResponse
+    {
+        return new RedirectResponse($url, $status);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given route with the given parameters.
+     *
+     * @final
+     */
+    protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): RedirectResponse
+    {
+        return $this->redirect($this->generateUrl($route, $parameters), $status);
+    }
+
+    /**
+     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
+     *
+     * @final
+     */
+    protected function json($data, int $status = 200, array $headers = [], array $context = []): JsonResponse
+    {
+        if ($this->container->has('serializer')) {
+            $json = $this->container->get('serializer')->serialize($data, 'json', array_merge([
+                'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
+            ], $context));
+
+            return new JsonResponse($json, $status, $headers, true);
+        }
+
+        return new JsonResponse($data, $status, $headers);
+    }
+
+    /**
+     * Returns a BinaryFileResponse object with original or customized file name and disposition header.
+     *
+     * @param \SplFileInfo|string $file File object or path to file to be sent as response
+     *
+     * @final
+     */
+    protected function file($file, string $fileName = null, string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT): BinaryFileResponse
+    {
+        $response = new BinaryFileResponse($file);
+        $response->setContentDisposition($disposition, null === $fileName ? $response->getFile()->getFilename() : $fileName);
+
+        return $response;
+    }
+
+    /**
+     * Adds a flash message to the current session for type.
+     *
+     * @throws \LogicException
+     *
+     * @final
+     */
+    protected function addFlash(string $type, $message)
+    {
+        if (!$this->container->has('session')) {
+            throw new \LogicException('You can not use the addFlash method if sessions are disabled. Enable them in "config/packages/framework.yaml".');
+        }
+
+        $this->container->get('session')->getFlashBag()->add($type, $message);
+    }
+
+    /**
+     * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
+     *
+     * @throws \LogicException
+     *
+     * @final
+     */
+    protected function isGranted($attributes, $subject = null): bool
+    {
+        if (!$this->container->has('security.authorization_checker')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+        }
+
+        return $this->container->get('security.authorization_checker')->isGranted($attributes, $subject);
+    }
+
+    /**
+     * Throws an exception unless the attributes are granted against the current authentication token and optionally
+     * supplied subject.
+     *
+     * @throws AccessDeniedException
+     *
+     * @final
+     */
+    protected function denyAccessUnlessGranted($attributes, $subject = null, string $message = 'Access Denied.')
+    {
+        if (!$this->isGranted($attributes, $subject)) {
+            $exception = $this->createAccessDeniedException($message);
+            $exception->setAttributes($attributes);
+            $exception->setSubject($subject);
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * Returns a rendered view.
+     *
+     * @final
+     */
+    protected function renderView(string $view, array $parameters = []): string
+    {
+        if ($this->container->has('templating')) {
+            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+
+            return $this->container->get('templating')->render($view, $parameters);
+        }
+
+        if (!$this->container->has('twig')) {
+            throw new \LogicException('You can not use the "renderView" method if the Templating Component or the Twig Bundle are not available. Try running "composer require symfony/twig-bundle".');
+        }
+
+        return $this->container->get('twig')->render($view, $parameters);
+    }
+
+    /**
+     * Renders a view.
+     *
+     * @final
+     */
+    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    {
+        if ($this->container->has('templating')) {
+            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+
+            $content = $this->container->get('templating')->render($view, $parameters);
+        } elseif ($this->container->has('twig')) {
+            $content = $this->container->get('twig')->render($view, $parameters);
+        } else {
+            throw new \LogicException('You can not use the "render" method if the Templating Component or the Twig Bundle are not available. Try running "composer require symfony/twig-bundle".');
+        }
+
+        if (null === $response) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
+     * Streams a view.
+     *
+     * @final
+     */
+    protected function stream(string $view, array $parameters = [], StreamedResponse $response = null): StreamedResponse
+    {
+        if ($this->container->has('templating')) {
+            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+
+            $templating = $this->container->get('templating');
+
+            $callback = function () use ($templating, $view, $parameters) {
+                $templating->stream($view, $parameters);
+            };
+        } elseif ($this->container->has('twig')) {
+            $twig = $this->container->get('twig');
+
+            $callback = function () use ($twig, $view, $parameters) {
+                $twig->display($view, $parameters);
+            };
+        } else {
+            throw new \LogicException('You can not use the "stream" method if the Templating Component or the Twig Bundle are not available. Try running "composer require symfony/twig-bundle".');
+        }
+
+        if (null === $response) {
+            return new StreamedResponse($callback);
+        }
+
+        $response->setCallback($callback);
+
+        return $response;
+    }
+
+    /**
+     * Returns a NotFoundHttpException.
+     *
+     * This will result in a 404 response code. Usage example:
+     *
+     *     throw $this->createNotFoundException('Page not found!');
+     *
+     * @final
+     */
+    protected function createNotFoundException(string $message = 'Not Found', \Throwable $previous = null): NotFoundHttpException
+    {
+        return new NotFoundHttpException($message, $previous);
+    }
+
+    /**
+     * Returns an AccessDeniedException.
+     *
+     * This will result in a 403 response code. Usage example:
+     *
+     *     throw $this->createAccessDeniedException('Unable to access this page!');
+     *
+     * @throws \LogicException If the Security component is not available
+     *
+     * @final
+     */
+    protected function createAccessDeniedException(string $message = 'Access Denied.', \Throwable $previous = null): AccessDeniedException
+    {
+        if (!class_exists(AccessDeniedException::class)) {
+            throw new \LogicException('You can not use the "createAccessDeniedException" method if the Security component is not available. Try running "composer require symfony/security-bundle".');
+        }
+
+        return new AccessDeniedException($message, $previous);
+    }
+
+    /**
+     * Creates and returns a Form instance from the type of the form.
+     *
+     * @final
+     */
+    protected function createForm(string $type, $data = null, array $options = []): FormInterface
+    {
+        return $this->container->get('form.factory')->create($type, $data, $options);
+    }
+
+    /**
+     * Creates and returns a form builder instance.
+     *
+     * @final
+     */
+    protected function createFormBuilder($data = null, array $options = []): FormBuilderInterface
+    {
+        return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
+    }
+
+    /**
+     * Shortcut to return the Doctrine Registry service.
+     *
+     * @return ManagerRegistry
+     *
+     * @throws \LogicException If DoctrineBundle is not available
+     *
+     * @final
+     */
+    protected function getDoctrine()
+    {
+        if (!$this->container->has('doctrine')) {
+            throw new \LogicException('The DoctrineBundle is not registered in your application. Try running "composer require symfony/orm-pack".');
+        }
+
+        return $this->container->get('doctrine');
+    }
+
+    /**
+     * Get a user from the Security Token Storage.
+     *
+     * @return UserInterface|object|null
+     *
+     * @throws \LogicException If SecurityBundle is not available
+     *
+     * @see TokenInterface::getUser()
+     *
+     * @final
+     */
+    protected function getUser()
+    {
+        if (!$this->container->has('security.token_storage')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+        }
+
+        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
+            return null;
+        }
+
+        if (!\is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
+            return null;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Checks the validity of a CSRF token.
+     *
+     * @param string      $id    The id used when generating the token
+     * @param string|null $token The actual token sent with the request that should be validated
+     *
+     * @final
+     */
+    protected function isCsrfTokenValid(string $id, ?string $token): bool
+    {
+        if (!$this->container->has('security.csrf.token_manager')) {
+            throw new \LogicException('CSRF protection is not enabled in your application. Enable it with the "csrf_protection" key in "config/packages/framework.yaml".');
+        }
+
+        return $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($id, $token));
+    }
+
+    /**
+     * Dispatches a message to the bus.
+     *
+     * @param object|Envelope  $message The message or the message pre-wrapped in an envelope
+     * @param StampInterface[] $stamps
+     *
+     * @final
+     */
+    protected function dispatchMessage($message, array $stamps = []): Envelope
+    {
+        if (!$this->container->has('messenger.default_bus')) {
+            $message = class_exists(Envelope::class) ? 'You need to define the "messenger.default_bus" configuration option.' : 'Try running "composer require symfony/messenger".';
+            throw new \LogicException('The message bus is not enabled in your application. '.$message);
+        }
+
+        return $this->container->get('messenger.default_bus')->dispatch($message, $stamps);
+    }
+
+    /**
+     * Adds a Link HTTP header to the current response.
+     *
+     * @see https://tools.ietf.org/html/rfc5988
+     *
+     * @final
+     */
+    protected function addLink(Request $request, LinkInterface $link)
+    {
+        if (!class_exists(AddLinkHeaderListener::class)) {
+            throw new \LogicException('You can not use the "addLink" method if the WebLink component is not available. Try running "composer require symfony/web-link".');
+        }
+
+        if (null === $linkProvider = $request->attributes->get('_links')) {
+            $request->attributes->set('_links', new GenericLinkProvider([$link]));
+
+            return;
+        }
+
+        $request->attributes->set('_links', $linkProvider->withLink($link));
+    }
+}

--- a/src/Bundle/Controller/ResourceController.php
+++ b/src/Bundle/Controller/ResourceController.php
@@ -23,7 +23,8 @@ use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\ResourceActions;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -31,8 +32,11 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class ResourceController extends AbstractController
+class ResourceController
 {
+    use ControllerTrait;
+    use ContainerAwareTrait;
+
     /** @var MetadataInterface */
     protected $metadata;
 
@@ -507,6 +511,22 @@ class ResourceController extends AbstractController
         }
 
         return $this->redirectHandler->redirectToResource($configuration, $resource);
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getParameter(string $name)
+    {
+        if (!$this->container instanceof ContainerInterface) {
+            throw new \RuntimeException(sprintf(
+                'Container passed to "%s" has to implements "%s".',
+                self::class,
+                ContainerInterface::class
+            ));
+        }
+
+        return $this->container->getParameter($name);
     }
 
     /**

--- a/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
@@ -58,8 +58,6 @@ abstract class AbstractDriver implements DriverInterface
 
     protected function addController(ContainerBuilder $container, MetadataInterface $metadata): void
     {
-        $viewHandler = new Reference('sylius.resource_controller.view_handler', ContainerInterface::NULL_ON_INVALID_REFERENCE);
-
         $definition = new Definition($metadata->getClass('controller'));
         $definition
             ->setPublic(true)

--- a/src/Bundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Bundle/spec/Controller/ResourceControllerSpec.php
@@ -39,7 +39,6 @@ use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\ResourceActions;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Form;
@@ -98,11 +97,6 @@ final class ResourceControllerSpec extends ObjectBehavior
         );
 
         $this->setContainer($container);
-    }
-
-    function it_extends_base_Symfony_controller(): void
-    {
-        $this->shouldHaveType(AbstractController::class);
     }
 
     function it_throws_a_403_exception_if_user_is_unauthorized_to_view_a_single_resource(


### PR DESCRIPTION
We can't use `AbstractController` if we want to keep BC - `AbstractController` requires a service locator with predefined dependencies and `ResourceController` requires a container with all public services for BC purposes.