### PR TITLE
Bump doctrine/persistance version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.3",
         "babdev/pagerfanta-bundle": "^2.5",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
-        "doctrine/persistence": "^1.3",
+        "doctrine/persistence": "^1.3 || ^2.0",
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/registry": "^1.2",
         "symfony/config": "^4.4 || ^5.1",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Allow doctrine/persistance:^2 for symfony 5.