### PR TITLE
Use backslash for templates and form

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -172,7 +172,7 @@ app_admin_book:
     resource: |
         alias: app.book
         section: admin
-        templates: Admin/Book
+        templates: Admin\Book
     type: sylius.resource
     prefix: /admin
 ```
@@ -191,7 +191,7 @@ If you want to use a custom form:
 app_book:
     resource: |
         alias: app.book
-        form: App/Form/Type/AdminBookType
+        form: App\Form\Type\AdminBookType
     type: sylius.resource
 ```
 ``create`` and ``update`` actions will use ``App/Form/Type/AdminBookType`` form type.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes, kind of :)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #157
| License         | MIT


Using:
```yaml
templates: App/Project/Crud
```
would lead to an error:
```
[Application] Oct 30 14:49:50 |CRITICA| PHP    Uncaught Exception: The file "alias: harvest.harvest_project section: admin templates: Admin/Project" does not exist in /Users/jacques/Sites/operandi/apps/sylius/config/../src/Resources/config/app/routing/admin.yaml (which is being imported from "/Users/jacques/Sites/operandi/apps/sylius/config/routes.yaml").
```

I tried everything until I saw the use of backslash on another project… I tried and it works fine.

So, I've updated the documentation.

Also, the form is incorrect as well, but not related, I think since we use backslashes for PHP classes.