### PR TITLE
Duplicate initialisation of repositories

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
+## UPGRADE FOR `1.7.x`
+
+### FROM `1.6.x` TO `1.7.x`
+
+We switched from dot notation as service id for the repositories to class names to resolve [#217](https://github.com/Sylius/SyliusResourceBundle/issues/217).
+This will cause an issue when referring to a repository via the dot notation in a compiler pass or extension via  
+`getDefinition`. You can still refer the service via dot notation by using `findDefinition` instead.
+
+
 ## UPGRADE FOR `1.3.x`
 
 ### FROM `1.3.x` TO `1.3.13`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,12 +1,3 @@
-## UPGRADE FOR `1.7.x`
-
-### FROM `1.6.x` TO `1.7.x`
-
-We switched from dot notation as service id for the repositories to class names to resolve [#217](https://github.com/Sylius/SyliusResourceBundle/issues/217).
-This will cause an issue when referring to a repository via the dot notation in a compiler pass or extension via  
-`getDefinition`. You can still refer the service via dot notation by using `findDefinition` instead.
-
-
 ## UPGRADE FOR `1.3.x`
 
 ### FROM `1.3.x` TO `1.3.13`

--- a/src/Bundle/Doctrine/ContainerRepositoryFactory.php
+++ b/src/Bundle/Doctrine/ContainerRepositoryFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Doctrine;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ContainerRepositoryFactory as DoctrineContainerRepositoryFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Repository\RepositoryFactory;
+use Doctrine\Persistence\ObjectRepository;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+
+final class ContainerRepositoryFactory implements RepositoryFactory
+{
+    /** @var ObjectRepository[] */
+    private $managedRepositories = [];
+
+    /** @var array */
+    private $genericEntities;
+
+    /** @var DoctrineContainerRepositoryFactory */
+    private $doctrineFactory;
+
+    public function __construct(DoctrineContainerRepositoryFactory $doctrineFactory)
+    {
+        $this->doctrineFactory = $doctrineFactory;
+    }
+
+    public function addGenericEntity(string $entityName): void
+    {
+        $this->genericEntities[$entityName] = $entityName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository(EntityManagerInterface $entityManager, $entityName): ObjectRepository
+    {
+        if (isset($this->genericEntities[$entityName])) {
+            $metadata = $entityManager->getClassMetadata($entityName);
+
+            return $this->getOrCreateRepository($entityManager, $metadata);
+        }
+
+        return $this->doctrineFactory->getRepository($entityManager, $entityName);
+    }
+
+    private function getOrCreateRepository(
+        EntityManagerInterface $entityManager,
+        ClassMetadata $metadata
+    ): ObjectRepository {
+        $repositoryHash = $metadata->getName() . spl_object_hash($entityManager);
+        if (isset($this->managedRepositories[$repositoryHash])) {
+            return $this->managedRepositories[$repositoryHash];
+        }
+
+        return $this->managedRepositories[$repositoryHash] = new EntityRepository($entityManager, $metadata);
+    }
+}

--- a/src/Bundle/Doctrine/ContainerRepositoryFactory.php
+++ b/src/Bundle/Doctrine/ContainerRepositoryFactory.php
@@ -25,8 +25,8 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     /** @var ObjectRepository[] */
     private $managedRepositories = [];
 
-    /** @var array */
-    private $genericEntities;
+    /** @var string[] */
+    private $genericEntities = [];
 
     /** @var DoctrineContainerRepositoryFactory */
     private $doctrineFactory;
@@ -60,6 +60,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
         ClassMetadata $metadata
     ): ObjectRepository {
         $repositoryHash = $metadata->getName() . spl_object_hash($entityManager);
+
         if (isset($this->managedRepositories[$repositoryHash])) {
             return $this->managedRepositories[$repositoryHash];
         }

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -58,7 +58,7 @@
         </service>
 
         <service id="sylius.doctrine.orm.container_repository_factory" decorates="doctrine.orm.container_repository_factory" class="Sylius\Bundle\ResourceBundle\Doctrine\ContainerRepositoryFactory" public="false">
-            <argument type="service" id=".inner" />
+            <argument type="service" id="sylius.doctrine.orm.container_repository_factory.inner" />
         </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -56,5 +56,9 @@
             <argument>Sylius\Bundle\ResourceBundle\Form\Builder\DefaultFormBuilderInterface</argument>
             <argument>form builder</argument>
         </service>
+
+        <service id="sylius.doctrine.orm.container_repository_factory" decorates="doctrine.orm.container_repository_factory" class="Sylius\Bundle\ResourceBundle\Doctrine\ContainerRepositoryFactory" public="false">
+            <argument type="service" id=".inner" />
+        </service>
     </services>
 </container>

--- a/src/Bundle/Tests/Resource/ResourceServicesTest.php
+++ b/src/Bundle/Tests/Resource/ResourceServicesTest.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\Resource;
 
+use AppBundle\Entity\Book;
+use AppBundle\Entity\ComicBook;
+use AppBundle\Repository\BookRepository;
 use Doctrine\ORM\EntityManager;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -39,5 +42,39 @@ final class ResourceServicesTest extends WebTestCase
 
         $productRepository = $client->getContainer()->get('app.factory.book');
         $this->assertTrue($productRepository instanceof FactoryInterface);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_the_same_repository_instance()
+    {
+        $client = parent::createClient();
+        $repository = self::$container->get(BookRepository::class);
+
+        $repositoryAlias = $client->getContainer()->get('app.repository.book');
+        $this->assertSame($repository, $repositoryAlias);
+
+        $em = $client->getContainer()->get('app.manager.book');
+        $repositoryAlias = $em->getRepository(Book::class);
+        $this->assertSame($repository, $repositoryAlias);
+
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $repositoryAlias = $em->getRepository(Book::class);
+        $this->assertSame($repository, $repositoryAlias);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_the_same_repository_instance_for_default_repositories()
+    {
+        $client = parent::createClient();
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $repository = $client->getContainer()->get('app.repository.comic_book');
+        $repositoryAlias = $em->getRepository(ComicBook::class);
+
+        $this->assertInstanceOf(RepositoryInterface::class, $repository);
+        $this->assertSame($repository, $repositoryAlias);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/SyliusResourceBundle/issues/217
| License         | MIT

Accessing a repository via `EntityManger::getReposiory` and direct injection via the dot notation of the repository will yield different instances of the same repository. This is caused by:
* Repositories are not injected into the ServiceLocator of [ContainerRepositoryFactory](https://github.com/doctrine/DoctrineBundle/blob/1.12.x/Repository/ContainerRepositoryFactory.php) as the required tag `doctrine.repository_service` is missing for our generated the repositories
* Even when injected (after adding that `doctrine.repository_service`) the [ContainerRepositoryFactory::getRepository](https://github.com/doctrine/DoctrineBundle/blob/1.12.x/Repository/ContainerRepositoryFactory.php#L35) method cant resolve the repository as its injected with the dot notation and doctrine looks for the repository by class name
* Problem also exists for default repositories but simply tagging them does not work



Solution/Changes;
For the solid repositories:
* **Tag the solid repositories** so they get injected
* **Switch to service id to class name**
* **Create a public alias** to maintain old functionality

For generic default repositories (cant be tagged as all use the same class)
* **Init default repositories via doctrine factory** so its using `ContainerRepositoryFactory` and by that prevent duplicate initialisation
* Decorated `ContainerRepositoryFactory` to be table to return the sylius `EntityRepository` instead of the default doctrine one


