### PR TITLE
Add back winzou/state-machine to required packages of the component

### DIFF
--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -33,7 +33,8 @@
         "gedmo/doctrine-extensions": "^2.4",
         "pagerfanta/core": "^2.4",
         "symfony/event-dispatcher": "^4.4 || ^5.1",
-        "symfony/property-access": "^4.4 || ^5.1"
+        "symfony/property-access": "^4.4 || ^5.1",
+        "winzou/state-machine": "^0.3 || ^0.4"
     },
     "require-dev": {
         "behat/transliterator": "^1.3",


### PR DESCRIPTION
Fixes a BC break introduced in v1.7.0.