### PR TITLE
[Minor] Add symfony.lock to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /composer.phar
 /composer.lock
 
+/symfony.lock
+
 /.phpunit.result.cache


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Useful, when one tries to duplicate GitHub workflow behavior to restrict a specific Symfony version