### PR TITLE
Skip registering controllers as a services if there is no custom class defined

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterFqcnControllersPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterFqcnControllersPass.php
@@ -35,6 +35,10 @@ final class RegisterFqcnControllersPass implements CompilerPassInterface
         foreach ($resources as $alias => $configuration) {
             $metadata = Metadata::fromAliasAndConfiguration($alias, $configuration);
 
+            if (!$metadata->hasClass('controller')) {
+                continue;
+            }
+
             $this->validateSyliusResource($metadata->getClass('model'));
             $controllerFqcn = $metadata->getClass('controller');
 

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFqcnControllersPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterFqcnControllersPassTest.php
@@ -49,6 +49,29 @@ final class RegisterFqcnControllersPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
+    public function it_skips_the_alias_if_controller_class_is_not_defined(): void
+    {
+        $this->setDefinition('sylius.resource_registry', new Definition());
+        $this->setDefinition('app.controller.book', new Definition());
+
+        $this->setParameter(
+            'sylius.resources',
+            [
+                'app.book' => [
+                    'driver' => 'doctrine/orm',
+                    'classes' => ['model' => BookTestClass::class],
+                ],
+            ]
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService(BookTestController::class);
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_exception_if_class_does_not_implement_resource_interface(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -58,7 +81,7 @@ final class RegisterFqcnControllersPassTest extends AbstractCompilerPassTestCase
             [
                 'app.normalClass' => [
                     'driver' => 'doctrine/orm',
-                    'classes' => ['model' => NormalClass::class],
+                    'classes' => ['model' => NormalClass::class, 'controller' => BookTestController::class],
                 ],
             ]
         );


### PR DESCRIPTION
See https://github.com/Sylius/Sylius/runs/2147994657?check_suite_focus=true.