### PR TITLE
Fix namespace of `WinzouStateMachinePassTest`

### DIFF
--- a/src/Bundle/Tests/DependencyInjection/Compiler/WinzouStateMachinePassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/WinzouStateMachinePassTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ResourceBundle\test\src\Tests\DependencyInjection\Compiler;
+namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\Assert;
 use SM\Callback\CallbackFactoryInterface;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

fixes composer complaining:
```
Class Sylius\Bundle\ResourceBundle\test\src\Tests\DependencyInjection\Compiler\WinzouStateMachinePassTest located in ./vendor/sylius/resource-bundle/src/Bundle/Tests/DependencyInjection/Compiler/WinzouStateMachinePassTest.php does not comply with psr-4 autoloading standard. Skipping.
```
