### PR TITLE
fix namespace of `ConfigurationTest`

### DIFF
--- a/src/Bundle/Tests/Configuration/ConfigurationTest.php
+++ b/src/Bundle/Tests/Configuration/ConfigurationTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ResourceBundle\Tests;
+namespace Sylius\Bundle\ResourceBundle\Tests\Configuration;
 
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

fixes composer complaining:
```
Class Sylius\Bundle\ResourceBundle\Tests\ConfigurationTest located in ./vendor/sylius/resource-bundle/src/Bundle/Tests/Configuration/ConfigurationTest.php does not comply with psr-4 autoloading standard. Skipping.
```