### PR TITLE
Require symfony/routing and symfony/http-foundation 4.4 and 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,8 @@
         "symfony/expression-language": "^4.4 || ^5.4",
         "symfony/form": "^4.4 || ^5.4",
         "symfony/framework-bundle": "^4.4 || ^5.4",
+        "symfony/http-foundation": "^4.4 || ^5.4",
+        "symfony/routing": "^4.4 || ^5.4",
         "symfony/security-csrf": "^4.4 || ^5.4",
         "symfony/translation": "^4.4 || ^5.4",
         "symfony/twig-bundle": "^4.4 || ^5.4",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This bundle will still [not support Symfony 6](https://github.com/Sylius/SyliusResourceBundle/pull/329) before the next minor release, so we should make it explicit it does not work with those two symfony 6 components (`Sylius\Bundle\ResourceBundle\Controller\Parameters` declaration incompatibility and `Symfony\Component\Routing\RouteCollectionBuilder` class inexistence) 🖖 