### PR TITLE
Remove resource when redirect on delete

### DIFF
--- a/src/Bundle/Controller/ResourceController.php
+++ b/src/Bundle/Controller/ResourceController.php
@@ -374,7 +374,7 @@ class ResourceController
             return $postEventResponse;
         }
 
-        return $this->redirectHandler->redirectToIndex($configuration, $resource);
+        return $this->redirectHandler->redirectToIndex($configuration);
     }
 
     public function bulkDeleteAction(Request $request): Response

--- a/src/Bundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Bundle/spec/Controller/ResourceControllerSpec.php
@@ -1923,7 +1923,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $postEvent->getResponse()->willReturn(null);
 
         $flashHelper->addSuccessFlash($configuration, ResourceActions::DELETE, $resource)->shouldBeCalled();
-        $redirectHandler->redirectToIndex($configuration, $resource)->willReturn($redirectResponse);
+        $redirectHandler->redirectToIndex($configuration)->willReturn($redirectResponse);
 
         $this->deleteAction($request)->shouldReturn($redirectResponse);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Hi team :wave: 

I add this issue when trying to call deleteAction on a custom entity. 

The fact is my entity is strongly typed, and there is no nullable id on it : 

```php
class Entity implement ResourceInterface
{ 
    private int $id;
    
    public function getId(): int
    { 
        return $this->id;
    }
}
```

Passing the resource on this redirectToIndex force it to look in the resource for any id parameters ([here](https://github.com/Sylius/SyliusResourceBundle/blob/master/src/Bundle/Controller/RequestConfiguration.php#L535)), and it's raised an exception while trying to access to a property not initialized.

I guess on a deleteAction, it's not mandatory to retrieve the previous id, so we can safely remove it ? 

I just submit quickly this patch to see if every tests passes, if it's not the case, i'll look deeper what happen. 
WDYT ?