### PR TITLE
Fix route loaders

### DIFF
--- a/src/Bundle/Routing/CrudRoutesAttributesLoader.php
+++ b/src/Bundle/Routing/CrudRoutesAttributesLoader.php
@@ -15,10 +15,11 @@ namespace Sylius\Bundle\ResourceBundle\Routing;
 
 use Sylius\Component\Resource\Annotation\SyliusCrudRoutes;
 use Sylius\Component\Resource\Reflection\ClassReflection;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Yaml\Yaml;
 
-final class CrudRoutesAttributesLoader
+final class CrudRoutesAttributesLoader implements RouteLoaderInterface
 {
     private array $mapping;
 

--- a/src/Bundle/Routing/RoutesAttributesLoader.php
+++ b/src/Bundle/Routing/RoutesAttributesLoader.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Routing;
 
 use Sylius\Component\Resource\Reflection\ClassReflection;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
 
-final class RoutesAttributesLoader
+final class RoutesAttributesLoader implements RouteLoaderInterface
 {
     private array $mapping;
 

--- a/src/Bundle/spec/Routing/CrudRoutesAttributesLoaderSpec.php
+++ b/src/Bundle/spec/Routing/CrudRoutesAttributesLoaderSpec.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\ResourceBundle\Routing\ResourceLoader;
 use Sylius\Bundle\ResourceBundle\Routing\RouteFactoryInterface;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -37,6 +38,11 @@ final class CrudRoutesAttributesLoaderSpec extends ObjectBehavior
     function it_is_initializable(): void
     {
         $this->shouldHaveType(CrudRoutesAttributesLoader::class);
+    }
+
+    function it_is_a_route_loader(): void
+    {
+        $this->shouldImplement(RouteLoaderInterface::class);
     }
 
     function it_generates_routes_from_resource(

--- a/src/Bundle/spec/Routing/RoutesAttributesLoaderSpec.php
+++ b/src/Bundle/spec/Routing/RoutesAttributesLoaderSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Routing\RouteAttributesFactoryInterface;
 use Sylius\Bundle\ResourceBundle\Routing\RoutesAttributesLoader;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
 
 final class RoutesAttributesLoaderSpec extends ObjectBehavior
@@ -29,6 +30,11 @@ final class RoutesAttributesLoaderSpec extends ObjectBehavior
     function it_is_initializable(): void
     {
         $this->shouldHaveType(RoutesAttributesLoader::class);
+    }
+
+    function it_is_a_route_loader(): void
+    {
+        $this->shouldImplement(RouteLoaderInterface::class);
     }
 
     function it_generates_routes_from_paths(RouteAttributesFactoryInterface $routeAttributesFactory): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Without this interface, the routes are not re-generating on a change without clearing the cache.