### PR TITLE
[Symfony 6] Get session from request stack

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,7 @@ parameters:
         - %currentWorkingDirectory%/src/Component/vendor/*
 
     ignoreErrors:
+        - '/Call to an undefined method Symfony\\Component\\HttpFoundation\\RequestStack::getSession\(\)/'
         - '/Call to method getArguments\(\) on an unknown class ReflectionAttribute./'
         - '/Call to an undefined method ReflectionClass::getAttributes\(\)./'
         - '/Class Doctrine\\Bundle\\MongoDBBundle/'

--- a/src/Bundle/Controller/FlashHelper.php
+++ b/src/Bundle/Controller/FlashHelper.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -29,9 +30,13 @@ final class FlashHelper implements FlashHelperInterface
 
     private string $defaultLocale;
 
-    public function __construct(SessionInterface $session, TranslatorInterface $translator, string $defaultLocale)
-    {
-        $this->session = $session;
+    public function __construct(
+        ?SessionInterface $session,
+        TranslatorInterface $translator,
+        string $defaultLocale,
+        RequestStack $requestStack
+    ) {
+        $this->session = $session ?: $requestStack->getSession();
         $this->translator = $translator;
         $this->defaultLocale = $defaultLocale;
     }

--- a/src/Bundle/Resources/config/services/controller.xml
+++ b/src/Bundle/Resources/config/services/controller.xml
@@ -40,9 +40,10 @@
         </service>
         <service id="sylius.resource_controller.authorization_checker.disabled" class="Sylius\Bundle\ResourceBundle\Controller\DisabledAuthorizationChecker" public="false" />
         <service id="sylius.resource_controller.flash_helper" class="Sylius\Bundle\ResourceBundle\Controller\FlashHelper" public="false">
-            <argument type="service" id="session" />
+            <argument type="service" id="session" on-invalid="null" />
             <argument type="service" id="translator" />
             <argument>%locale%</argument>
+            <argument type="service" id="request_stack" />
         </service>
         <service id="sylius.resource_controller.event_dispatcher" class="Sylius\Bundle\ResourceBundle\Controller\EventDispatcher" public="false">
             <argument type="service" id="event_dispatcher" />

--- a/src/Bundle/Resources/config/services/storage.xml
+++ b/src/Bundle/Resources/config/services/storage.xml
@@ -16,7 +16,8 @@
         <defaults public="true" />
 
         <service id="sylius.storage.session" class="Sylius\Bundle\ResourceBundle\Storage\SessionStorage">
-            <argument type="service" id="session" />
+            <argument type="service" id="session" on-invalid="null" />
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="sylius.storage.cookie" class="Sylius\Bundle\ResourceBundle\Storage\CookieStorage">

--- a/src/Bundle/Storage/SessionStorage.php
+++ b/src/Bundle/Storage/SessionStorage.php
@@ -14,15 +14,16 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Storage;
 
 use Sylius\Component\Resource\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class SessionStorage implements StorageInterface
 {
     private SessionInterface $session;
 
-    public function __construct(SessionInterface $session)
+    public function __construct(?SessionInterface $session, RequestStack $requestStack)
     {
-        $this->session = $session;
+        $this->session = $session ?: $requestStack->getSession();
     }
 
     public function has(string $name): bool

--- a/src/Bundle/spec/Controller/FlashHelperSpec.php
+++ b/src/Bundle/spec/Controller/FlashHelperSpec.php
@@ -20,21 +20,49 @@ use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\ResourceActions;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class FlashHelperSpec extends ObjectBehavior
 {
-    function let(SessionInterface $session, TranslatorInterface $translator): void
+    function let(SessionInterface $session, RequestStack $requestStack, TranslatorInterface $translator): void
     {
-        $this->beConstructedWith($session, $translator, 'en');
+        $this->beConstructedWith($session, $translator, 'en', $requestStack);
     }
 
-    function it_implements_flash_helper_interface(): void
+    function it_implements_flash_helper_interface(RequestStack $requestStack, SessionInterface $session): void
     {
+        $this->shouldImplement(FlashHelperInterface::class);
+    }
+
+    function its_session_can_be_retrieved_from_container(SessionInterface $session, RequestStack $requestStack, TranslatorInterface $translator): void
+    {
+        if (Kernel::MAJOR_VERSION > 4) {
+            $requestStack->getSession()->shouldNotBeCalled();
+        }
+
+        $this->beConstructedWith($session, $translator, 'en', $requestStack);
+
+        $this->shouldImplement(FlashHelperInterface::class);
+    }
+
+    function its_session_can_be_retrieved_from_request_stack(SessionInterface $session, RequestStack $requestStack, TranslatorInterface $translator): void
+    {
+        if (Kernel::MAJOR_VERSION === 4) {
+            return;
+        }
+
+        $requestStack->getSession()->willReturn($session);
+
+        $requestStack->getSession()->shouldBeCalled();
+
+        $this->beConstructedWith(null, $translator, 'en', $requestStack);
+
         $this->shouldImplement(FlashHelperInterface::class);
     }
 

--- a/src/Bundle/spec/Storage/SessionStorageSpec.php
+++ b/src/Bundle/spec/Storage/SessionStorageSpec.php
@@ -15,18 +15,44 @@ namespace spec\Sylius\Bundle\ResourceBundle\Storage;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Kernel;
 
 final class SessionStorageSpec extends ObjectBehavior
 {
-    function let(): void
+    function let(RequestStack $requestStack): void
     {
-        $this->beConstructedWith(new Session(new MockArraySessionStorage()));
+        $this->beConstructedWith(new Session(new MockArraySessionStorage()), $requestStack);
     }
 
     function it_is_a_storage(): void
     {
+        $this->shouldImplement(StorageInterface::class);
+    }
+
+    function its_session_can_be_retrieved_from_container(RequestStack $requestStack): void
+    {
+        if (Kernel::MAJOR_VERSION > 4) {
+            $requestStack->getSession()->shouldNotBeCalled();
+        }
+
+        $this->beConstructedWith(new Session(new MockArraySessionStorage()), $requestStack);
+
+        $this->shouldImplement(StorageInterface::class);
+    }
+
+    function its_session_can_be_retrieved_from_request_stack(RequestStack $requestStack): void
+    {
+        if (Kernel::MAJOR_VERSION === 4) {
+            return;
+        }
+
+        $requestStack->getSession()->shouldBeCalled();
+
+        $this->beConstructedWith(null, $requestStack);
+
         $this->shouldImplement(StorageInterface::class);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (Symfony 6)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On Symfony 6, there is no session service, you have to get it from the request
https://symfony.com/doc/current/session.html#basic-usage

This has been introduced since 5.3
* [5.2 documentation](https://symfony.com/doc/5.2/session.html)
* [5.3 documentation](https://symfony.com/doc/5.3/session.html)