### PR TITLE
Add form attribute on SyliusCrudRoute

### DIFF
--- a/src/Bundle/Routing/RouteAttributesFactory.php
+++ b/src/Bundle/Routing/RouteAttributesFactory.php
@@ -56,6 +56,10 @@ final class RouteAttributesFactory implements RouteAttributesFactoryInterface
                 $syliusOptions['serialization_version'] = $arguments['serializationVersion'];
             }
 
+            if (isset($arguments['form'])) {
+                $syliusOptions['form'] = $arguments['form'];
+            }
+
             $route = new Route(
                 $arguments['path'],
                 [

--- a/src/Bundle/Tests/Routing/RoutesAttributesLoaderTest.php
+++ b/src/Bundle/Tests/Routing/RoutesAttributesLoaderTest.php
@@ -317,4 +317,28 @@ final class RoutesAttributesLoaderTest extends KernelTestCase
         $this->assertEquals('/book/{id}', $route->getPath());
         $this->assertEquals(['https'], $route->getSchemes());
     }
+
+    /**
+     * @test
+     */
+    public function it_generates_routes_from_resource_with_form(): void
+    {
+        self::bootKernel(['environment' => 'test_with_attributes']);
+
+        $container = static::$container;
+
+        $attributesLoader = $container->get('sylius.routing.loader.routes_attributes');
+
+        $routesCollection = $attributesLoader->__invoke();
+
+        $route = $routesCollection->get('register_user_with_form');
+        $this->assertNotNull($route);
+        $this->assertEquals('/users/register', $route->getPath());
+        $this->assertEquals([
+            '_controller' => 'app.controller.user:createAction',
+            '_sylius' => [
+                'form' => 'App\Form\Type\RegisterType',
+            ],
+        ], $route->getDefaults());
+    }
 }

--- a/src/Bundle/spec/Routing/RouteAttributesFactorySpec.php
+++ b/src/Bundle/spec/Routing/RouteAttributesFactorySpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\ResourceBundle\Routing;
 
+use App\Entity\Route\RegisterUserWithForm;
 use App\Entity\Route\ShowBook;
 use App\Entity\Route\ShowBookWithCriteria;
 use App\Entity\Route\ShowBookWithHost;
@@ -236,5 +237,21 @@ final class RouteAttributesFactorySpec extends ObjectBehavior
         $route = $routeCollection->get('show_book_with_schemes');
         Assert::eq($route->getPath(), '/book/{id}');
         Assert::eq($route->getSchemes(), ['https']);
+    }
+
+    function it_generates_routes_from_resource_with_form(): void
+    {
+        $routeCollection = new RouteCollection();
+
+        $this->createRouteForClass($routeCollection, RegisterUserWithForm::class);
+
+        $route = $routeCollection->get('register_user_with_form');
+        Assert::eq($route->getPath(), '/users/register');
+        Assert::eq($route->getDefaults(), [
+            '_controller' => 'app.controller.user:createAction',
+            '_sylius' => [
+                'form' => 'App\Form\Type\RegisterType',
+            ],
+        ]);
     }
 }

--- a/src/Bundle/spec/Routing/RoutesAttributesLoaderSpec.php
+++ b/src/Bundle/spec/Routing/RoutesAttributesLoaderSpec.php
@@ -39,7 +39,7 @@ final class RoutesAttributesLoaderSpec extends ObjectBehavior
 
     function it_generates_routes_from_paths(RouteAttributesFactoryInterface $routeAttributesFactory): void
     {
-        $routeAttributesFactory->createRouteForClass(Argument::type(RouteCollection::class), Argument::type('string'))->shouldBeCalledTimes(13);
+        $routeAttributesFactory->createRouteForClass(Argument::type(RouteCollection::class), Argument::type('string'))->shouldBeCalledTimes(14);
 
         $this->__invoke();
     }

--- a/src/Bundle/test/config/doctrine/User.orm.yml
+++ b/src/Bundle/test/config/doctrine/User.orm.yml
@@ -1,0 +1,16 @@
+App\Entity\User:
+    type: mappedSuperclass
+    table: app_user
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+    fields:
+        username:
+            type: string
+            length: 255
+        password:
+            type: string
+            length: 255

--- a/src/Bundle/test/src/Entity/Route/RegisterUserWithForm.php
+++ b/src/Bundle/test/src/Entity/Route/RegisterUserWithForm.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity\Route;
+
+use App\Entity\User;
+use App\Form\Type\RegisterType;
+use Sylius\Component\Resource\Annotation\SyliusRoute;
+
+#[SyliusRoute(
+    name: 'register_user_with_form',
+    path: '/users/register',
+    methods: ['GET', 'POST'],
+    controller: 'app.controller.user:createAction',
+    form: RegisterType::class
+)]
+final class RegisterUserWithForm extends User
+{
+}

--- a/src/Bundle/test/src/Entity/User.php
+++ b/src/Bundle/test/src/Entity/User.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+class User implements ResourceInterface
+{
+    private ?int $id = null;
+
+    private ?string $username = null;
+
+    private ?string $password = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(?string $password): void
+    {
+        $this->password = $password;
+    }
+}

--- a/src/Bundle/test/src/Form/Type/RegisterType.php
+++ b/src/Bundle/test/src/Form/Type/RegisterType.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+
+final class RegisterType extends AbstractType
+{
+}

--- a/src/Component/Annotation/SyliusRoute.php
+++ b/src/Component/Annotation/SyliusRoute.php
@@ -46,6 +46,8 @@ final class SyliusRoute
 
     public ?array $vars = null;
 
+    public ?string $form = null;
+
     public function __construct(
         ?string $name = null,
         ?string $path = null,
@@ -61,7 +63,8 @@ final class SyliusRoute
         ?string $host = null,
         ?array $schemes = null,
         ?int $priority = null,
-        ?array $vars = null
+        ?array $vars = null,
+        ?string $form = null
     ) {
         $this->name = $name;
         $this->path = $path;
@@ -78,5 +81,6 @@ final class SyliusRoute
         $this->schemes = $schemes;
         $this->vars = $vars;
         $this->priority = $priority;
+        $this->form = $form;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

It's a missing feature between yaml and attributes routes.

```php
<?php 

#[SyliusRoute(
    name: 'register',
    path: '/users/register',
    methods: ['GET', 'POST'],
    controller: 'app.controller.user:createAction',
    form: RegisterType::class
)]
class User