### PR TITLE
Allow downgrading pagerfanta to version 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "babdev/pagerfanta-bundle": "^3.0",
+        "babdev/pagerfanta-bundle": "^2.5 || ^3.0",
         "doctrine/collections": "^1.6",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/event-manager": "^1.1",
@@ -47,6 +47,7 @@
         "symfony/twig-bundle": "^4.4 || ^5.4",
         "symfony/validator": "^4.4 || ^5.4",
         "symfony/yaml": "^4.4 || ^5.4",
+        "pagerfanta/pagerfanta": "^2.4 || ^3.0",
         "webmozart/assert": "^1.8",
         "willdurand/hateoas-bundle": "^2.0",
         "winzou/state-machine-bundle": "^0.6"
@@ -58,7 +59,6 @@
         "doctrine/orm": "^2.5",
         "lchrusciel/api-test-case": "^5.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2.1",
-        "pagerfanta/pagerfanta": "^3.0",
         "pamil/phpspec-skip-example-extension": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #415 
| License         | MIT

Allow user downgrading to pagerfanta version `2.*`
