### PR TITLE
[Symfony 6] Fix flash helper

### DIFF
--- a/src/Bundle/Controller/FlashHelper.php
+++ b/src/Bundle/Controller/FlashHelper.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -23,17 +24,24 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class FlashHelper implements FlashHelperInterface
 {
-    private SessionInterface $session;
+    private ?SessionInterface $session;
 
     private TranslatorInterface $translator;
 
     private string $defaultLocale;
 
-    public function __construct(SessionInterface $session, TranslatorInterface $translator, string $defaultLocale)
-    {
+    private RequestStack $requestStack;
+
+    public function __construct(
+        ?SessionInterface $session,
+        TranslatorInterface $translator,
+        string $defaultLocale,
+        RequestStack $requestStack
+    ) {
         $this->session = $session;
         $this->translator = $translator;
         $this->defaultLocale = $defaultLocale;
+        $this->requestStack = $requestStack;
     }
 
     public function addSuccessFlash(
@@ -90,7 +98,7 @@ final class FlashHelper implements FlashHelperInterface
         }
 
         /** @var FlashBagInterface $flashBag */
-        $flashBag = $this->session->getBag('flashes');
+        $flashBag = $this->getSession()->getBag('flashes');
         $flashBag->add($type, $message);
     }
 
@@ -125,5 +133,10 @@ final class FlashHelper implements FlashHelperInterface
         }
 
         return ['%resource%' => ucfirst($metadata->getHumanizedName())];
+    }
+
+    private function getSession(): SessionInterface
+    {
+        return $this->session ?: $this->requestStack->getSession();
     }
 }

--- a/src/Bundle/Resources/config/services/controller.xml
+++ b/src/Bundle/Resources/config/services/controller.xml
@@ -40,9 +40,10 @@
         </service>
         <service id="sylius.resource_controller.authorization_checker.disabled" class="Sylius\Bundle\ResourceBundle\Controller\DisabledAuthorizationChecker" public="false" />
         <service id="sylius.resource_controller.flash_helper" class="Sylius\Bundle\ResourceBundle\Controller\FlashHelper" public="false">
-            <argument type="service" id="session" />
+            <argument type="service" id="session" on-invalid="null" />
             <argument type="service" id="translator" />
             <argument>%locale%</argument>
+            <argument type="service" id="request_stack" />
         </service>
         <service id="sylius.resource_controller.event_dispatcher" class="Sylius\Bundle\ResourceBundle\Controller\EventDispatcher" public="false">
             <argument type="service" id="event_dispatcher" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (for Symfony 6)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On Symfony 6, there is no session service, you have to get it from the request
https://symfony.com/doc/current/session.html#basic-usage

This has been introduced since 5.3
* [5.2 documentation](https://symfony.com/doc/5.2/session.html)
* [5.3 documentation](https://symfony.com/doc/5.3/session.html)
