### PR TITLE
[Symfony 6] Fix session storage

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,7 @@ parameters:
         - %currentWorkingDirectory%/src/Component/vendor/*
 
     ignoreErrors:
+        - '/Call to an undefined method Symfony\\Component\\HttpFoundation\\RequestStack::getSession\(\)/'
         - '/Call to method getArguments\(\) on an unknown class ReflectionAttribute./'
         - '/Call to an undefined method ReflectionClass::getAttributes\(\)./'
         - '/Class Doctrine\\Bundle\\MongoDBBundle/'

--- a/src/Bundle/Resources/config/services/storage.xml
+++ b/src/Bundle/Resources/config/services/storage.xml
@@ -16,7 +16,8 @@
         <defaults public="true" />
 
         <service id="sylius.storage.session" class="Sylius\Bundle\ResourceBundle\Storage\SessionStorage">
-            <argument type="service" id="session" />
+            <argument type="service" id="session" on-invalid="null" />
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="sylius.storage.cookie" class="Sylius\Bundle\ResourceBundle\Storage\CookieStorage">

--- a/src/Bundle/Storage/SessionStorage.php
+++ b/src/Bundle/Storage/SessionStorage.php
@@ -14,39 +14,48 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Storage;
 
 use Sylius\Component\Resource\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class SessionStorage implements StorageInterface
 {
-    private SessionInterface $session;
+    private ?SessionInterface $session;
 
-    public function __construct(SessionInterface $session)
+    private RequestStack $requestStack;
+
+    public function __construct(?SessionInterface $session, RequestStack $requestStack)
     {
         $this->session = $session;
+        $this->requestStack = $requestStack;
     }
 
     public function has(string $name): bool
     {
-        return $this->session->has($name);
+        return $this->getSession()->has($name);
     }
 
     public function get(string $name, $default = null)
     {
-        return $this->session->get($name, $default);
+        return $this->getSession()->get($name, $default);
     }
 
     public function set(string $name, $value): void
     {
-        $this->session->set($name, $value);
+        $this->getSession()->set($name, $value);
     }
 
     public function remove(string $name): void
     {
-        $this->session->remove($name);
+        $this->getSession()->remove($name);
     }
 
     public function all(): array
     {
-        return $this->session->all();
+        return $this->getSession()->all();
+    }
+
+    private function getSession(): SessionInterface
+    {
+        return $this->session ?: $this->requestStack->getSession();
     }
 }

--- a/src/Bundle/spec/Storage/SessionStorageSpec.php
+++ b/src/Bundle/spec/Storage/SessionStorageSpec.php
@@ -15,19 +15,45 @@ namespace spec\Sylius\Bundle\ResourceBundle\Storage;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Kernel;
 
 final class SessionStorageSpec extends ObjectBehavior
 {
-    function let(): void
+    function let(RequestStack $requestStack): void
     {
-        $this->beConstructedWith(new Session(new MockArraySessionStorage()));
+        $this->beConstructedWith(new Session(new MockArraySessionStorage()), $requestStack);
     }
 
     function it_is_a_storage(): void
     {
         $this->shouldImplement(StorageInterface::class);
+    }
+
+    function its_session_can_be_retrieved_from_container(RequestStack $requestStack): void
+    {
+        if (Kernel::MAJOR_VERSION > 4) {
+            $requestStack->getSession()->shouldNotBeCalled();
+        }
+
+        $this->beConstructedWith(new Session(new MockArraySessionStorage()), $requestStack);
+
+        $this->get('name');
+    }
+
+    function its_session_can_be_retrieved_from_request_stack(RequestStack $requestStack): void
+    {
+        if (Kernel::MAJOR_VERSION === 4) {
+            return;
+        }
+
+        $requestStack->getSession()->shouldBeCalled();
+
+        $this->beConstructedWith(null, $requestStack);
+
+        $this->get('name');
     }
 
     function it_does_not_have_a_named_value_if_it_was_not_set_previously(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (for Symfony 6)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On Symfony 6, there is no session service, you have to get it from the request
https://symfony.com/doc/current/session.html#basic-usage

This has been introduced since 5.3
* [5.2 documentation](https://symfony.com/doc/5.2/session.html)
* [5.3 documentation](https://symfony.com/doc/5.3/session.html)
