### PR TITLE
[Maintenance] Drop Sf4 ACL on parameters class due to lack of its support

### DIFF
--- a/src/Bundle/Controller/Parameters.php
+++ b/src/Bundle/Controller/Parameters.php
@@ -33,7 +33,7 @@ if (Kernel::MAJOR_VERSION === 6) {
             return $result;
         }
     }
-} elseif (Kernel::MAJOR_VERSION === 5) {
+} else {
     class Parameters extends ParameterBag
     {
         /**
@@ -42,26 +42,6 @@ if (Kernel::MAJOR_VERSION === 6) {
          * @return mixed
          */
         public function get(string $key, $default = null)
-        {
-            $result = parent::get($key, $default);
-
-            if (null === $result && $default !== null && $this->has($key)) {
-                $result = $default;
-            }
-
-            return $result;
-        }
-    }
-} else {
-    class Parameters extends ParameterBag
-    {
-        /**
-         * @param string $key
-         * @param mixed $default
-         *
-         * @return mixed
-         */
-        public function get($key, $default = null)
         {
             $result = parent::get($key, $default);
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Continuation of #430 and #428
| License         | MIT
