### PR TITLE
Adjust when some runtime deprecation notices are triggered and use Symfony's `trigger_deprecation()` helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "jms/serializer-bundle": "^3.5 || ^4.0",
         "sylius/registry": "^1.2",
         "symfony/config": "^5.4 || ^6.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/expression-language": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",

--- a/src/Bundle/AbstractResourceBundle.php
+++ b/src/Bundle/AbstractResourceBundle.php
@@ -104,10 +104,12 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
     {
         switch ($driverType) {
             case SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM:
-                @trigger_error(sprintf(
-                    'The "%s" driver is deprecated in Sylius 1.3. Doctrine MongoDB and PHPCR will no longer be supported in Sylius 2.0.',
-                    $driverType,
-                ), \E_USER_DEPRECATED);
+                trigger_deprecation(
+                    'sylius/resource-bundle',
+                    '1.3',
+                    'The "%s" driver is deprecated. Doctrine MongoDB and PHPCR will no longer be supported in 2.0.',
+                    SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM,
+                );
 
                 $mappingsPassClassname = DoctrineMongoDBMappingsPass::class;
 
@@ -117,10 +119,12 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
 
                 break;
             case SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM:
-                @trigger_error(sprintf(
-                    'The "%s" driver is deprecated in Sylius 1.3. Doctrine MongoDB and PHPCR will no longer be supported in Sylius 2.0.',
-                    $driverType,
-                ), \E_USER_DEPRECATED);
+                trigger_deprecation(
+                    'sylius/resource-bundle',
+                    '1.3',
+                    'The "%s" driver is deprecated. Doctrine MongoDB and PHPCR will no longer be supported in 2.0.',
+                    SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM,
+                );
 
                 $mappingsPassClassname = DoctrinePhpcrMappingsPass::class;
 

--- a/src/Bundle/Controller/ControllerTrait.php
+++ b/src/Bundle/Controller/ControllerTrait.php
@@ -208,7 +208,7 @@ trait ControllerTrait
     protected function renderView(string $view, array $parameters = []): string
     {
         if ($this->container->has('templating')) {
-            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+            @trigger_error('Using the "templating" service is deprecated since Symfony 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
 
             return $this->container->get('templating')->render($view, $parameters);
         }
@@ -228,7 +228,7 @@ trait ControllerTrait
     protected function render(string $view, array $parameters = [], Response $response = null): Response
     {
         if ($this->container->has('templating')) {
-            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+            @trigger_error('Using the "templating" service is deprecated since Symfony 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
 
             $content = $this->container->get('templating')->render($view, $parameters);
         } elseif ($this->container->has('twig')) {
@@ -254,7 +254,7 @@ trait ControllerTrait
     protected function stream(string $view, array $parameters = [], StreamedResponse $response = null): StreamedResponse
     {
         if ($this->container->has('templating')) {
-            @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
+            @trigger_error('Using the "templating" service is deprecated since Symfony 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
 
             $templating = $this->container->get('templating');
 

--- a/src/Bundle/Controller/FlashHelper.php
+++ b/src/Bundle/Controller/FlashHelper.php
@@ -42,7 +42,14 @@ final class FlashHelper implements FlashHelperInterface
         }
 
         if ($requestStack instanceof SessionInterface) {
-            @trigger_error(sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.9 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.10',
+                'Passing an instance of "%s" as the first constructor argument for "%s" is deprecated and will not be supported in 2.0. Pass an instance of "%s" instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
 
         $this->requestStack = $requestStack;

--- a/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolver.php
+++ b/src/Bundle/DependencyInjection/Compiler/Helper/TargetEntitiesResolver.php
@@ -48,16 +48,13 @@ final class TargetEntitiesResolver implements TargetEntitiesResolverInterface
                 $model = $this->getModel($alias, $configuration);
                 $interface = $configuration['classes']['interface'];
 
-                @trigger_error(
-                    sprintf(
-                        'Specifying interface for resources is deprecated since ResourceBundle v1.6 and will be removed in v2.0. ' .
-                        'Please rely on autodiscovering entity interfaces instead. ' .
-                        'Triggered by resource "%s" with model "%s" and interface "%s".',
-                        $alias,
-                        $model,
-                        $interface,
-                    ),
-                    \E_USER_DEPRECATED,
+                trigger_deprecation(
+                    'sylius/resource-bundle',
+                    '1.6',
+                    'Specifying the interface for resources is deprecated and will be removed in 2.0. Please rely on auto-discovering interfaces instead. Triggered by resource "%s" with model "%s" and interface "%s".',
+                    $alias,
+                    $model,
+                    $interface,
                 );
 
                 $interfaces[$interface] = $model;

--- a/src/Bundle/DependencyInjection/Compiler/PagerfantaBridgePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/PagerfantaBridgePass.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.8. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in Sylius 2.0.', PagerfantaBridgePass::class), \E_USER_DEPRECATED);
-
 /**
  * Compiler pass to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
  *
@@ -26,8 +24,21 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class PagerfantaBridgePass implements CompilerPassInterface
 {
+    public function __construct(private bool $internalUse = false)
+    {
+    }
+
     public function process(ContainerBuilder $container): void
     {
+        if (false === $this->internalUse) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.7',
+                'The "%s" class is deprecated. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in 2.0.',
+                self::class,
+            );
+        }
+
         $this->changeViewFactoryClass($container);
         $this->aliasRenamedServices($container);
     }

--- a/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
@@ -22,13 +22,23 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DoctrineODMDriver::class), \E_USER_DEPRECATED);
-
 final class DoctrineODMDriver extends AbstractDoctrineDriver
 {
     public function getType(): string
     {
         return SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM;
+    }
+
+    public function load(ContainerBuilder $container, MetadataInterface $metadata): void
+    {
+        trigger_deprecation(
+            'sylius/resource-bundle',
+            '1.3',
+            'The "%s" class is deprecated. Doctrine MongoDB and PHPCR will no longer be supported in 2.0.',
+            self::class,
+        );
+
+        parent::load($container, $metadata);
     }
 
     protected function addRepository(ContainerBuilder $container, MetadataInterface $metadata): void

--- a/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
@@ -24,13 +24,19 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DoctrinePHPCRDriver::class), \E_USER_DEPRECATED);
-
 final class DoctrinePHPCRDriver extends AbstractDoctrineDriver
 {
     public function load(ContainerBuilder $container, MetadataInterface $metadata): void
     {
+        trigger_deprecation(
+            'sylius/resource-bundle',
+            '1.3',
+            'The "%s" class is deprecated. Doctrine MongoDB and PHPCR will no longer be supported in 2.0.',
+            self::class,
+        );
+
         parent::load($container, $metadata);
+
         $this->addResourceListeners($container, $metadata);
     }
 

--- a/src/Bundle/DependencyInjection/PagerfantaConfiguration.php
+++ b/src/Bundle/DependencyInjection/PagerfantaConfiguration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.8. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in Sylius 2.0.', PagerfantaConfiguration::class), \E_USER_DEPRECATED);
-
 /**
  * Container configuration to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
  *
@@ -34,6 +32,7 @@ final class PagerfantaConfiguration implements ConfigurationInterface
 
         /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->getRootNode();
+        $rootNode->setDeprecated('sylius/resource-bundle', '1.7', 'The "%node%" configuration node is deprecated, migrate your configuration to the "babdev_pagerfanta" configuration node.');
 
         $this->addExceptionsStrategySection($rootNode);
 

--- a/src/Bundle/DependencyInjection/PagerfantaExtension.php
+++ b/src/Bundle/DependencyInjection/PagerfantaExtension.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-@trigger_error(sprintf('The "%s" class is deprecated since sylius/resource-bundle 1.7. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in Sylius 2.0.', PagerfantaExtension::class), \E_USER_DEPRECATED);
-
 /**
  * Container extension to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
  *
@@ -26,6 +24,10 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 final class PagerfantaExtension extends Extension implements PrependExtensionInterface
 {
+    public function __construct(private bool $internalUse = false)
+    {
+    }
+
     public function getAlias(): string
     {
         return 'white_october_pagerfanta';
@@ -38,6 +40,15 @@ final class PagerfantaExtension extends Extension implements PrependExtensionInt
 
     public function load(array $configs, ContainerBuilder $container): void
     {
+        if (false === $this->internalUse) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.7',
+                'The "%s" class is deprecated. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in 2.0.',
+                self::class,
+            );
+        }
+
         $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
 
         $container->setParameter('white_october_pagerfanta.default_view', $config['default_view']);

--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -99,10 +99,12 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
 
         foreach ($drivers as $driver) {
             if (in_array($driver, [SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM, SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM], true)) {
-                @trigger_error(sprintf(
-                    'The "%s" driver is deprecated in Sylius 1.3. Doctrine MongoDB and PHPCR will no longer be supported in Sylius 2.0.',
+                trigger_deprecation(
+                    'sylius/resource-bundle',
+                    '1.3',
+                    'The "%s" driver is deprecated. Doctrine MongoDB and PHPCR will no longer be supported in 2.0.',
                     $driver,
-                ), \E_USER_DEPRECATED);
+                );
             }
 
             $loader->load(sprintf('services/integrations/%s.xml', $driver));

--- a/src/Bundle/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/src/Bundle/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -20,7 +20,7 @@ use Pagerfanta\Pagerfanta;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DocumentRepository::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', DocumentRepository::class);
 
 /**
  * Doctrine ODM driver resource manager.

--- a/src/Bundle/Doctrine/ODM/MongoDB/TranslatableRepository.php
+++ b/src/Bundle/Doctrine/ODM/MongoDB/TranslatableRepository.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Doctrine\ODM\MongoDB;
 use Doctrine\MongoDB\Query\Builder as QueryBuilder;
 use Sylius\Component\Resource\Repository\TranslatableRepositoryInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', TranslatableRepository::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', TranslatableRepository::class);
 
 /**
  * Doctrine ORM driver translatable entity repository.

--- a/src/Bundle/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -20,7 +20,7 @@ use Pagerfanta\Pagerfanta;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DocumentRepository::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', DocumentRepository::class);
 
 /**
  * Doctrine PHPCR-ODM driver document repository.

--- a/src/Bundle/Doctrine/ODM/PHPCR/EventListener/DefaultParentListener.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/EventListener/DefaultParentListener.php
@@ -18,7 +18,7 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use PHPCR\Util\NodeHelper;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DefaultParentListener::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', DefaultParentListener::class);
 
 /**
  * Automatically set the parent brefore the creation.

--- a/src/Bundle/Doctrine/ODM/PHPCR/EventListener/NameFilterListener.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/EventListener/NameFilterListener.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Doctrine\ODM\PHPCR\EventListener;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', NameFilterListener::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', NameFilterListener::class);
 
 /**
  * Filter the node name field, replacing invalid characters with a substitute

--- a/src/Bundle/Doctrine/ODM/PHPCR/EventListener/NameResolverListener.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/EventListener/NameResolverListener.php
@@ -17,7 +17,7 @@ use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', NameResolverListener::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', NameResolverListener::class);
 
 /**
  * Handles the resolution of the PHPCR node name field.

--- a/src/Bundle/Doctrine/ODM/PHPCR/Form/Builder/DefaultFormBuilder.php
+++ b/src/Bundle/Doctrine/ODM/PHPCR/Form/Builder/DefaultFormBuilder.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\ResourceBundle\Form\Builder\DefaultFormBuilderInterface;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', DefaultFormBuilder::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', DefaultFormBuilder::class);
 
 class DefaultFormBuilder implements DefaultFormBuilderInterface
 {

--- a/src/Bundle/EventListener/ODMMappedSuperClassSubscriber.php
+++ b/src/Bundle/EventListener/ODMMappedSuperClassSubscriber.php
@@ -18,7 +18,7 @@ use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', ODMMappedSuperClassSubscriber::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', ODMMappedSuperClassSubscriber::class);
 
 /**
  * Doctrine listener used to manipulate mappings.

--- a/src/Bundle/EventListener/ODMRepositoryClassSubscriber.php
+++ b/src/Bundle/EventListener/ODMRepositoryClassSubscriber.php
@@ -17,7 +17,7 @@ use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', ODMRepositoryClassSubscriber::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', ODMRepositoryClassSubscriber::class);
 
 final class ODMRepositoryClassSubscriber extends AbstractDoctrineSubscriber
 {

--- a/src/Bundle/EventListener/ODMTranslatableListener.php
+++ b/src/Bundle/EventListener/ODMTranslatableListener.php
@@ -21,7 +21,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sylius\Component\Resource\Model\TranslatableInterface;
 use Sylius\Component\Resource\Model\TranslationInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.', ODMTranslatableListener::class), \E_USER_DEPRECATED);
+trigger_deprecation('sylius/resource-bundle', '1.3', 'The "%s" class is deprecated. Doctrine MongoDB and PHPCR support will no longer be supported in 2.0.', ODMTranslatableListener::class);
 
 final class ODMTranslatableListener implements EventSubscriber
 {

--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -191,13 +191,12 @@ final class ORMTranslatableListener implements EventSubscriber
     private function processTranslatableEntityLocaleAssigner(object $translatableEntityLocaleAssigner): TranslatableEntityLocaleAssignerInterface
     {
         if ($translatableEntityLocaleAssigner instanceof ContainerInterface) {
-            @trigger_error(
-                sprintf(
-                    'Passing an instance of "%s" is deprecated since 1.4. Use "%s" instead.',
-                    ContainerInterface::class,
-                    TranslatableEntityLocaleAssignerInterface::class,
-                ),
-                \E_USER_DEPRECATED,
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.4',
+                'Passing an instance of "%s" is deprecated. Use "%s" instead.',
+                ContainerInterface::class,
+                TranslatableEntityLocaleAssignerInterface::class,
             );
 
             /** @var object $translatableEntityLocaleAssigner */

--- a/src/Bundle/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Bundle/ExpressionLanguage/ExpressionLanguage.php
@@ -27,7 +27,14 @@ final class ExpressionLanguage extends BaseExpressionLanguage
     {
         if (null !== $cache) {
             if ($cache instanceof ParserCacheInterface) {
-                @trigger_error(sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.2 and will be removed in 2.0. Pass an instance of %s instead.', ParserCacheInterface::class, self::class, CacheItemPoolInterface::class), \E_USER_DEPRECATED);
+                trigger_deprecation(
+                    'sylius/resource-bundle',
+                    '1.2',
+                    'Passing an instance of "%s" as the first constructor argument of "%s" is deprecated. Pass an instance of "%s" instead.',
+                    ParserCacheInterface::class,
+                    self::class,
+                    CacheItemPoolInterface::class,
+                );
 
                 /** @var CacheItemPoolInterface $cache */
                 $cache = new ParserCacheAdapter($cache);

--- a/src/Bundle/Storage/SessionStorage.php
+++ b/src/Bundle/Storage/SessionStorage.php
@@ -33,7 +33,14 @@ final class SessionStorage implements StorageInterface
         }
 
         if ($requestStack instanceof SessionInterface) {
-            @trigger_error(sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.9 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.10',
+                'Passing an instance of "%s" as the constructor argument for "%s" is deprecated and will not be supported in 2.0. Pass an instance of "%s" instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
 
         $this->requestStack = $requestStack;

--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -51,8 +51,8 @@ final class SyliusResourceBundle extends Bundle
         $container->addCompilerPass(new RegisterFormBuilderPass());
         $container->addCompilerPass(new TwigPass());
 
-        $container->registerExtension(new PagerfantaExtension());
-        $container->addCompilerPass(new PagerfantaBridgePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1); // Should run after all passes from BabDevPagerfantaBundle
+        $container->registerExtension(new PagerfantaExtension(true));
+        $container->addCompilerPass(new PagerfantaBridgePass(true), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1); // Should run after all passes from BabDevPagerfantaBundle
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #448
| License         | MIT

This PR will do two things:

1) Adjusts when some runtime deprecations (especially for those which are unfixable in consuming applications) to be triggered when the deprecated element is actually used instead of arbitrarily emitting them when the file is loaded
2) Uses Symfony's `trigger_deprecation()` helper for runtime deprecations; this is designed to be a "pluggable" function that can allow someone to customize the functionality in their applications if so desired (plus the function's signature forces key information at the front of each message which makes scanning the messages a bit better IMO)