### PR TITLE
Return a proper 422 HTTP status code when the form submission fails

### DIFF
--- a/src/Bundle/Controller/ResourceController.php
+++ b/src/Bundle/Controller/ResourceController.php
@@ -223,12 +223,12 @@ class ResourceController
             return $initializeEventResponse;
         }
 
-        return $this->render($configuration->getTemplate(ResourceActions::CREATE . '.html'), [
+        return $this->renderForm($configuration->getTemplate(ResourceActions::CREATE . '.html'), [
             'configuration' => $configuration,
             'metadata' => $this->metadata,
             'resource' => $newResource,
             $this->metadata->getName() => $newResource,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 
@@ -310,12 +310,12 @@ class ResourceController
             return $initializeEventResponse;
         }
 
-        return $this->render($configuration->getTemplate(ResourceActions::UPDATE . '.html'), [
+        return $this->renderForm($configuration->getTemplate(ResourceActions::UPDATE . '.html'), [
             'configuration' => $configuration,
             'metadata' => $this->metadata,
             'resource' => $resource,
             $this->metadata->getName() => $resource,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
     }
 


### PR DESCRIPTION
I noticed that the resource controller does not set the 422 http status code when a form submission fails. It is a good practice to do so. Also this will bring support for Symfony UX Turbo, which requires the status code to be set to 422 upon form failure. 

| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT
