### PR TITLE
Make CsrfTokenManager public

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,12 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.0", "8.1"]
-                symfony: ["^5.4", "^6.0"]
+                symfony: ["^5.4", "~6.0.0", "~6.1.0"]
                 twig: ["^2.12", "^3.0"]
+                exclude:
+                    -
+                        php: "8.0"
+                        symfony: "~6.1.0"
 
         steps:
             -

--- a/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;

--- a/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * TODO Remove on sylius/resource-bundle 2.0
+ */
+final class CsrfTokenManagerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('security.csrf.token_manager')) {
+            return;
+        }
+
+        $csrdTokenManagerDefinition = $container->getDefinition('security.csrf.token_manager');
+        $csrdTokenManagerDefinition->setPublic(true);
+    }
+}

--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle;
 
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\CsrfTokenManagerPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\DoctrineContainerRepositoryFactoryPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\DoctrineTargetEntitiesResolverPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\Helper\TargetEntitiesResolver;
@@ -41,15 +42,16 @@ final class SyliusResourceBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new WinzouStateMachinePass());
-        $container->addCompilerPass(new RegisterStateMachinePass());
-        $container->addCompilerPass(new RegisterResourcesPass());
-        $container->addCompilerPass(new RegisterFqcnControllersPass());
-        $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(new TargetEntitiesResolver()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new CsrfTokenManagerPass());
         $container->addCompilerPass(new DoctrineContainerRepositoryFactoryPass());
-        $container->addCompilerPass(new RegisterResourceRepositoryPass());
+        $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(new TargetEntitiesResolver()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RegisterFormBuilderPass());
+        $container->addCompilerPass(new RegisterFqcnControllersPass());
+        $container->addCompilerPass(new RegisterResourceRepositoryPass());
+        $container->addCompilerPass(new RegisterResourcesPass());
+        $container->addCompilerPass(new RegisterStateMachinePass());
         $container->addCompilerPass(new TwigPass());
+        $container->addCompilerPass(new WinzouStateMachinePass());
 
         $container->registerExtension(new PagerfantaExtension(true));
         $container->addCompilerPass(new PagerfantaBridgePass(true), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1); // Should run after all passes from BabDevPagerfantaBundle

--- a/src/Bundle/test/src/Tests/Controller/ScienceBookUiTest.php
+++ b/src/Bundle/test/src/Tests/Controller/ScienceBookUiTest.php
@@ -48,11 +48,11 @@ final class ScienceBookUiTest extends ApiTestCase
         $content = $response->getContent();
         $this->assertStringContainsString('<h1>Books</h1>', $content);
         $this->assertStringContainsString(
-            sprintf('<tr><td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td></tr>', $scienceBooks['science-book1']->getId()),
+            sprintf('<td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td>', $scienceBooks['science-book1']->getId()),
             $content,
         );
         $this->assertStringContainsString(
-            sprintf('<tr><td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td></tr>', $scienceBooks['science-book2']->getId()),
+            sprintf('<td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td>', $scienceBooks['science-book2']->getId()),
             $content,
         );
     }
@@ -112,6 +112,22 @@ final class ScienceBookUiTest extends ApiTestCase
     }
 
     /** @test */
+    public function it_allows_deleting_a_book(): void
+    {
+        $this->loadFixturesFromFile('single_science_book.yml');
+
+        $this->client->request('GET', '/science-books/');
+        $this->client->submitForm('Delete');
+
+        $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);
+
+        /** @var ScienceBook[] $books */
+        $books = static::getContainer()->get('app.repository.science_book')->findAll();
+
+        $this->assertEmpty($books);
+    }
+
+    /** @test */
     public function it_allows_filtering_books(): void
     {
         $scienceBooks = $this->loadFixturesFromFile('science_books.yml');
@@ -123,11 +139,11 @@ final class ScienceBookUiTest extends ApiTestCase
         $content = $response->getContent();
         $this->assertStringContainsString('<h1>Books</h1>', $content);
         $this->assertStringContainsString(
-            sprintf('<tr><td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td></tr>', $scienceBooks['science-book1']->getId()),
+            sprintf('<td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td>', $scienceBooks['science-book1']->getId()),
             $content,
         );
         $this->assertStringNotContainsString(
-            sprintf('<tr><td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td></tr>', $scienceBooks['science-book2']->getId()),
+            sprintf('<td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td>', $scienceBooks['science-book2']->getId()),
             $content,
         );
     }

--- a/src/Bundle/test/src/Tests/DataFixtures/ORM/single_science_book.yml
+++ b/src/Bundle/test/src/Tests/DataFixtures/ORM/single_science_book.yml
@@ -1,0 +1,9 @@
+App\Entity\ScienceBook:
+    science-book1:
+        title: "A Brief History of Time"
+        author: "@stephen-hawking"
+
+App\Entity\Author:
+    stephen-hawking:
+        firstName: "Stephen"
+        lastName: "Hawking"

--- a/src/Bundle/test/templates/ScienceBook/index.html.twig
+++ b/src/Bundle/test/templates/ScienceBook/index.html.twig
@@ -5,11 +5,20 @@
             <td>ID</td>
             <td>Title</td>
             <td>Author</td>
+            <td>Actions</td>
         </tr>
     </thead>
     <tbody>
     {% for book in resources.data %}
-        <tr><td>{{ book.id }}</td><td>{{ book.title }}</td><td>{{ book.authorFirstName }} {{ book.authorLastName }}</td></tr>
+        <tr><td>{{ book.id }}</td><td>{{ book.title }}</td><td>{{ book.authorFirstName }} {{ book.authorLastName }}</td>
+            <td>
+                <form action="{{ path('app_science_book_delete', {'id': book.id}) }}" method="POST">
+                    <input type="hidden" name="_method" value="DELETE"/>
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token(book.id) }}" />
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/SyliusResourceBundle/issues/477
| License         | MIT

We, unfortunately, rely on this service to be public in the `ResourceController` :/ 

I've covered the bug with a test (by adding a "delete" button to the test UI) and added explicit Symfony 6.0 and 6.1 testing in the workflow 🖖 

Thank you, @dannyvw, for reporting this bug! 🏅 