### PR TITLE
[Maintenance] Out-of-date phpstan/phpdoc-parser conflict removed, docker static analysis memory limit increased

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -2,8 +2,3 @@
 
 This document explains why certain conflicts were added to `composer.json` and
 references related issues.
-
-- `"phpstan/phpdoc-parser": "^1.6.0"`:
-
-  Usage of ^1.6 versions leads to following error: https://issuehint.com/issue/slevomat/coding-standard/1379. To remove it, Sylius-Labs/ECS 
-  requires bump of Slevomat lib - "slevomat/coding-standard"

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "analyse": [
             "@composer validate --strict",
             "vendor/bin/ecs check src",
-            "vendor/bin/phpstan analyse --ansi -c phpstan.neon -l max src"
+            "vendor/bin/phpstan analyse --ansi --memory-limit=256M -c phpstan.neon -l max src"
         ],
         "fix": [
             "vendor/bin/ecs check src --fix"

--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,6 @@
     "replace": {
         "sylius/resource": "self.version"
     },
-    "conflict": {
-        "phpstan/phpdoc-parser": "^1.6.0"
-    },
     "require-dev": {
         "doctrine/orm": "^2.5",
         "lchrusciel/api-test-case": "^5.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | partially https://github.com/Sylius/PayPalPlugin/commit/5cb7c0e560275c172a09d959f455f72e4f2d98e6
| License         | MIT

This conflict mainly causes the problem with the incorrect version (at the moment of creating this PR `alpha`(which causes the problem with adding products to the cart) instead of `beta`) installed on the apps that depends on this bundle

The conflicted version is already bumped here:
https://github.com/SyliusLabs/CodingStandard/commit/456379a9f145eb3a120fde468c17826be2032100

==========
This package is struggling with the memory limit on the docker build, in [Sylius](https://github.com/Sylius/Sylius/blob/1.12/.docker/test/php.ini#L2) we have a `php.ini` config that overrides the default value, here I proposed a simpler solution for adding a flag with an increased memory limit value