### PR TITLE
[DOCS] Change configuration to correct one

### DIFF
--- a/docs/state_machine.md
+++ b/docs/state_machine.md
@@ -10,7 +10,7 @@ But you can configure it explicitly:
 ## Configuring Symfony workflow as state machine`
 
 ```yaml
-sylius_resources:
+sylius_resource:
     settings:
         state_machine_component: symfony
 ```
@@ -22,7 +22,7 @@ If Winzou state machine is on your requirements you have nothing to do even if S
 But you can configure it explicitly:
 
 ```yaml
-sylius_resources:
+sylius_resource:
     settings:
         state_machine_component: winzou
 ```


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| License         | MIT

I think there is an issue in documentation with the configuration reference, In Configuration class ConfigTree is 'sylius_resource' rather than `sylius_resources` used in doc. This is a fix for it. 

PR added for 1.9 branch as this is the version from which this config started :tada: 