### PR TITLE
👬 Resource metadata collection factory

### DIFF
--- a/src/Bundle/test/src/Entity/Author.php
+++ b/src/Bundle/test/src/Entity/Author.php
@@ -22,12 +22,14 @@ final class Author
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $firstName = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $lastName = null;

--- a/src/Bundle/test/src/Entity/Book.php
+++ b/src/Bundle/test/src/Entity/Book.php
@@ -29,13 +29,16 @@ class Book implements ResourceInterface, TranslatableInterface
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $author = null;
@@ -52,6 +55,7 @@ class Book implements ResourceInterface, TranslatableInterface
      * @return string
      *
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\SerializedName("title")
      */
     public function getTitle()

--- a/src/Bundle/test/src/Entity/ComicBook.php
+++ b/src/Bundle/test/src/Entity/ComicBook.php
@@ -23,19 +23,23 @@ class ComicBook implements ResourceInterface
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Until("1.1")
      */
     private ?Author $author = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $title = null;
@@ -63,6 +67,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorFirstName(): ?string
@@ -72,6 +77,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorLastName(): ?string

--- a/src/Component/Metadata/Create.php
+++ b/src/Component/Metadata/Create.php
@@ -23,8 +23,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
             methods: $methods ?? ['GET', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'create',
             template: $template,
+            shortName: $shortName ?? 'create',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -23,8 +23,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             methods: $methods ?? ['DELETE'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'delete',
             template: $template,
+            shortName: $shortName ?? 'delete',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -21,6 +21,7 @@ class HttpOperation extends Operation
     public function __construct(
         protected ?array $methods = null,
         protected ?string $path = null,
+        protected ?string $routeName = null,
         protected ?string $routePrefix = null,
         ?string $template = null,
         ?string $shortName = null,
@@ -59,6 +60,19 @@ class HttpOperation extends Operation
     {
         $self = clone $this;
         $self->path = $path;
+
+        return $self;
+    }
+
+    public function getRouteName(): ?string
+    {
+        return $this->routeName;
+    }
+
+    public function withRouteName(string $routeName): self
+    {
+        $self = clone $this;
+        $self->routeName = $routeName;
 
         return $self;
     }

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -31,8 +31,8 @@ class HttpOperation extends Operation
     ) {
         parent::__construct(
             template: $template,
-            name: $name,
             shortName: $shortName,
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -22,14 +22,16 @@ class HttpOperation extends Operation
         protected ?array $methods = null,
         protected ?string $path = null,
         protected ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
         parent::__construct(
-            name: $name,
             template: $template,
+            name: $name,
+            shortName: $shortName,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Index.php
+++ b/src/Component/Metadata/Index.php
@@ -23,8 +23,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'index',
             template: $template,
+            shortName: $shortName ?? 'index',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -27,8 +27,9 @@ abstract class Operation
     protected $processor;
 
     public function __construct(
-        protected ?string $name = null,
         protected ?string $template = null,
+        protected ?string $shortName = null,
+        protected ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -49,6 +50,19 @@ abstract class Operation
         return $self;
     }
 
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function withTemplate(string $template): self
+    {
+        $self = clone $this;
+        $self->template = $template;
+
+        return $self;
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -62,15 +76,15 @@ abstract class Operation
         return $self;
     }
 
-    public function getTemplate(): ?string
+    public function getShortName(): ?string
     {
-        return $this->template;
+        return $this->shortName;
     }
 
-    public function withTemplate(string $template): self
+    public function withShortName(string $shortName): self
     {
         $self = clone $this;
-        $self->template = $template;
+        $self->shortName = $shortName;
 
         return $self;
     }

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -18,6 +18,8 @@ namespace Sylius\Component\Resource\Metadata;
  */
 abstract class Operation
 {
+    private ?Resource $resource = null;
+
     /** @var string|callable|null */
     protected $provider;
 
@@ -32,6 +34,19 @@ abstract class Operation
     ) {
         $this->provider = $provider;
         $this->processor = $processor;
+    }
+
+    public function getResource(): ?Resource
+    {
+        return $this->resource;
+    }
+
+    public function withResource(Resource $resource): self
+    {
+        $self = clone $this;
+        $self->resource = $resource;
+
+        return $self;
     }
 
     public function getName(): ?string

--- a/src/Component/Metadata/Operations.php
+++ b/src/Component/Metadata/Operations.php
@@ -41,7 +41,7 @@ final class Operations implements \IteratorAggregate, \Countable
         })();
     }
 
-    public function get(string $key): ?Operation
+    public function get(string $key): Operation
     {
         foreach ($this->operations as [$operationName, $operation]) {
             if ($operationName === $key) {
@@ -49,7 +49,7 @@ final class Operations implements \IteratorAggregate, \Countable
             }
         }
 
-        return null;
+        throw new \RuntimeException(sprintf('No Operation with key "%s" was found', $key));
     }
 
     public function add(string $key, Operation $value): self

--- a/src/Component/Metadata/Operations.php
+++ b/src/Component/Metadata/Operations.php
@@ -41,6 +41,17 @@ final class Operations implements \IteratorAggregate, \Countable
         })();
     }
 
+    public function get(string $key): ?Operation
+    {
+        foreach ($this->operations as [$operationName, $operation]) {
+            if ($operationName === $key) {
+                return $operation;
+            }
+        }
+
+        return null;
+    }
+
     public function add(string $key, Operation $value): self
     {
         foreach ($this->operations as $i => [$operationName, $operation]) {

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -20,6 +20,9 @@ final class Resource
 
     public function __construct(
         private ?string $alias = null,
+        private ?string $section = null,
+        private ?string $name = null,
+        private ?string $applicationName = null,
         ?array $operations = null,
     ) {
         $this->operations = null === $operations ? null : new Operations($operations);
@@ -34,6 +37,45 @@ final class Resource
     {
         $self = clone $this;
         $self->alias = $alias;
+
+        return $self;
+    }
+
+    public function getSection(): ?string
+    {
+        return $this->section;
+    }
+
+    public function withSection(string $section): self
+    {
+        $self = clone $this;
+        $self->section = $section;
+
+        return $self;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function withName(string $name): self
+    {
+        $self = clone $this;
+        $self->name = $name;
+
+        return $self;
+    }
+
+    public function getApplicationName(): ?string
+    {
+        return $this->applicationName;
+    }
+
+    public function withApplicationName(string $applicationName): self
+    {
+        $self = clone $this;
+        $self->applicationName = $applicationName;
 
         return $self;
     }

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -80,6 +80,20 @@ final class Resource
         return $self;
     }
 
+    public function hasOperation(string $name): bool
+    {
+        return $this->operations?->has($name) ?? false;
+    }
+
+    public function getOperation(string $name): Operation
+    {
+        if (null === $operations = $this->operations) {
+            throw new \RuntimeException(sprintf('No Operations were found on resource %s"', $this->alias));
+        }
+
+        return $operations->get($name);
+    }
+
     public function getOperations(): ?Operations
     {
         return $this->operations;

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -19,7 +19,7 @@ final class Resource
     private ?Operations $operations;
 
     public function __construct(
-        private ?string $alias = null,
+        private string $alias,
         private ?string $section = null,
         private ?string $name = null,
         private ?string $applicationName = null,
@@ -28,7 +28,7 @@ final class Resource
         $this->operations = null === $operations ? null : new Operations($operations);
     }
 
-    public function getAlias(): ?string
+    public function getAlias(): string
     {
         return $this->alias;
     }

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Metadata;
 
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Resource
 {
     private ?Operations $operations;

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -17,6 +17,7 @@ use Sylius\Component\Resource\Metadata\HttpOperation;
 use Sylius\Component\Resource\Metadata\Operation;
 use Sylius\Component\Resource\Metadata\Operations;
 use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
 use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Component\Resource\Reflection\ClassReflection;
@@ -72,7 +73,9 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             }
 
             if (null === ($resources[$index] ?? null)) {
-                throw new \RuntimeException(sprintf('No Resource attribute was found on %s', $resourceClass));
+                $metadata = $this->resourceRegistry->getByClass($resourceClass);
+
+                $resources[++$index] = new Resource($metadata->getAlias());
             }
 
             if (!is_subclass_of($attribute->getName(), Operation::class)) {

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Metadata\Resource\Factory;
+
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Operations;
+use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Component\Resource\Reflection\ClassReflection;
+use Webmozart\Assert\Assert;
+
+final class AttributesResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+
+        $attributes = ClassReflection::getClassAttributes($resourceClass);
+
+        foreach ($this->buildResourceOperations($attributes, $resourceClass) as $resource) {
+            $resourceMetadataCollection[] = $resource;
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    /**
+     * @param \ReflectionAttribute[] $attributes
+     */
+    private function buildResourceOperations(array $attributes, string $resourceClass): array
+    {
+        /** @var ResourceMetadata[] $resources */
+        $resources = [];
+        $index = -1;
+
+        foreach ($attributes as $attribute) {
+            if (is_a($attribute->getName(), ResourceMetadata::class, true)) {
+                /** @var ResourceMetadata $resource */
+                $resource = $attribute->newInstance();
+                $resources[++$index] = $resource;
+
+                continue;
+            }
+
+            Assert::notNull($resources[$index] ?? null, 'No Resource attribute was found');
+
+            if (!is_subclass_of($attribute->getName(), Operation::class)) {
+                continue;
+            }
+
+            /** @var Operation $operationAttribute */
+            $operationAttribute = $attribute->newInstance();
+
+            [$key, $operation] = $this->getOperationWithDefaults($resources[$index], $operationAttribute);
+
+            $operations = $resources[$index]->getOperations() ?? new Operations();
+
+            $resources[$index] = $resources[$index]->withOperations($operations);
+            $resources[$index] = $resources[$index]->withOperations($operations->add($key, $operation));
+        }
+
+        return $resources;
+    }
+
+    private function getOperationWithDefaults(ResourceMetadata $resource, Operation $operation): array
+    {
+        $operationName = $operation->getName();
+
+        return [$operationName, $operation];
+    }
+}

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -37,6 +37,8 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
 
     /**
      * @param \ReflectionAttribute[] $attributes
+     *
+     * @return ResourceMetadata[]
      */
     private function buildResourceOperations(array $attributes, string $resourceClass): array
     {

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -92,8 +92,7 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         $operationName = $operation->getName();
 
         if (null !== $section = $resource->getSection()) {
-            $operationName = $section . '_' . $operationName;
-            $operation = $operation->withName($operationName);
+            $operation = $operation->withSection($section);
         }
 
         return [$operationName, $operation];

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -50,9 +50,9 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
                 /** @var ResourceMetadata $resource */
                 $resource = $attribute->newInstance();
                 $resources[++$index] = $resource;
-
                 $operations = [];
 
+                /** @var Operation $operation */
                 foreach ($resource->getOperations() ?? new Operations() as $operation) {
                     [$key, $operation] = $this->getOperationWithDefaults($resources[$index], $operation);
                     $operations[$key] = $operation;

--- a/src/Component/Metadata/Resource/Factory/ResourceMetadataCollectionFactoryInterface.php
+++ b/src/Component/Metadata/Resource/Factory/ResourceMetadataCollectionFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Metadata\Resource\Factory;
+
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+
+interface ResourceMetadataCollectionFactoryInterface
+{
+    /**
+     * Creates a resource metadata.
+     *
+     * @param class-string $resourceClass
+     */
+    public function create(string $resourceClass): ResourceMetadataCollection;
+}

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -24,14 +24,10 @@ final class ResourceMetadataCollection extends \ArrayObject
         foreach ($this->getIterator() as $current) {
             if (
                 $current->getAlias() !== $resourceAlias ||
-                $section !== $current->getSection() ||
-                null === ($operation = $current->getOperations()?->get($name))
+                $current->getSection() !== $section ||
             ) {
-                continue;
+                return $operation;
             }
-
-            return $operation;
-        }
 
         throw new \RuntimeException(sprintf(
             'Operation "%s" for "%s" resource was not found.',

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -18,13 +18,14 @@ use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
 
 final class ResourceMetadataCollection extends \ArrayObject
 {
-    public function getOperation(string $resourceAlias, string $name): Operation
+    public function getOperation(string $resourceAlias, string $name, ?string $section = null): Operation
     {
         /** @var ResourceMetadata $current */
         foreach ($this->getIterator() as $current) {
             if (
                 $current->getAlias() !== $resourceAlias ||
-                null === $operation = $current->getOperations()?->get($name)
+                $section !== $current->getSection() ||
+                null === ($operation = $current->getOperations()?->get($name))
             ) {
                 continue;
             }

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -31,10 +31,19 @@ final class ResourceMetadataCollection extends \ArrayObject
             }
         }
 
+        if (null === $section)  {
+            throw new \RuntimeException(sprintf(
+                'Operation "%s" for "%s" resource was not found.',
+                $resourceAlias,
+                $name,
+            ));
+        }
+
         throw new \RuntimeException(sprintf(
-            'Operation "%s" for "%s" resource was not found.',
+            'Operation "%s" for "%s" resource with section "%s" was not found.',
             $resourceAlias,
             $name,
+            $section,
         ));
     }
 }

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -18,32 +18,22 @@ use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
 
 final class ResourceMetadataCollection extends \ArrayObject
 {
-    public function getOperation(string $resourceAlias, string $name, ?string $section = null): Operation
+    public function getOperation(string $resourceAlias, string $name): Operation
     {
         /** @var ResourceMetadata $current */
         foreach ($this->getIterator() as $current) {
             if (
                 $current->getAlias() === $resourceAlias &&
-                $current->getSection() === $section &&
                 $current->hasOperation($name)
             ) {
                 return $current->getOperation($name);
             }
         }
 
-        if (null === $section) {
-            throw new \RuntimeException(sprintf(
-                'Operation "%s" for "%s" resource was not found.',
-                $resourceAlias,
-                $name,
-            ));
-        }
-
         throw new \RuntimeException(sprintf(
-            'Operation "%s" for "%s" resource with section "%s" was not found.',
+            'Operation "%s" for "%s" resource was not found.',
             $resourceAlias,
             $name,
-            $section,
         ));
     }
 }

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -22,15 +22,18 @@ final class ResourceMetadataCollection extends \ArrayObject
     {
         /** @var ResourceMetadata $current */
         foreach ($this->getIterator() as $current) {
-            if ($current->getAlias() !== $resourceAlias) {
+            if (
+                $current->getAlias() !== $resourceAlias ||
+                null === $operation = $current->getOperations()?->get($name)
+            ) {
                 continue;
             }
 
-            return $current->getOperations()?->get($name);
+            return $operation;
         }
 
         throw new \RuntimeException(sprintf(
-            'Operation "%" for "%s" resource was not found.',
+            'Operation "%s" for "%s" resource was not found.',
             $resourceAlias,
             $name,
         ));

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -29,6 +29,10 @@ final class ResourceMetadataCollection extends \ArrayObject
             return $current->getOperations()?->get($name);
         }
 
-        return null;
+        throw new \RuntimeException(sprintf(
+            'Operation "%" for "%s" resource was not found.',
+            $resourceAlias,
+            $name,
+        ));
     }
 }

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -18,7 +18,7 @@ use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
 
 final class ResourceMetadataCollection extends \ArrayObject
 {
-    public function getOperation(string $resourceAlias, string $name): ?Operation
+    public function getOperation(string $resourceAlias, string $name): Operation
     {
         /** @var ResourceMetadata $current */
         foreach ($this->getIterator() as $current) {

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Metadata\Resource;
+
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
+
+final class ResourceMetadataCollection extends \ArrayObject
+{
+    public function getOperation(string $resourceAlias, string $name): ?Operation
+    {
+        /** @var ResourceMetadata $current */
+        foreach ($this->getIterator() as $current) {
+            if ($current->getAlias() !== $resourceAlias) {
+                continue;
+            }
+
+            return $current->getOperations()?->get($name);
+        }
+
+        return null;
+    }
+}

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -31,7 +31,7 @@ final class ResourceMetadataCollection extends \ArrayObject
             }
         }
 
-        if (null === $section)  {
+        if (null === $section) {
             throw new \RuntimeException(sprintf(
                 'Operation "%s" for "%s" resource was not found.',
                 $resourceAlias,

--- a/src/Component/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Component/Metadata/Resource/ResourceMetadataCollection.php
@@ -23,11 +23,13 @@ final class ResourceMetadataCollection extends \ArrayObject
         /** @var ResourceMetadata $current */
         foreach ($this->getIterator() as $current) {
             if (
-                $current->getAlias() !== $resourceAlias ||
-                $current->getSection() !== $section ||
+                $current->getAlias() === $resourceAlias &&
+                $current->getSection() === $section &&
+                $current->hasOperation($name)
             ) {
-                return $operation;
+                return $current->getOperation($name);
             }
+        }
 
         throw new \RuntimeException(sprintf(
             'Operation "%s" for "%s" resource was not found.',

--- a/src/Component/Metadata/Show.php
+++ b/src/Component/Metadata/Show.php
@@ -23,8 +23,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'show',
             template: $template,
+            shortName: $shortName ?? 'show',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -23,8 +23,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
             methods: $methods ?? ['GET', 'PUT'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'update',
             template: $template,
+            shortName: $shortName ?? 'update',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Reflection/ClassReflection.php
+++ b/src/Component/Reflection/ClassReflection.php
@@ -60,7 +60,7 @@ final class ClassReflection
      *
      * @return \ReflectionAttribute[]
      */
-    public static function getClassAttributes(string $className, string $attributeName): array
+    public static function getClassAttributes(string $className, ?string $attributeName = null): array
     {
         $reflectionClass = new \ReflectionClass($className);
 

--- a/src/Component/Symfony/Routing/Factory/OperationRouteNameFactory.php
+++ b/src/Component/Symfony/Routing/Factory/OperationRouteNameFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Symfony\Routing\Factory;
+
+use Sylius\Component\Resource\Metadata\Operation;
+
+final class OperationRouteNameFactory
+{
+    public function createRouteName(Operation $operation, ?string $shortName = null): string
+    {
+        $resource = $operation->getResource();
+
+        if (null === $resource) {
+            throw new \RuntimeException(sprintf('No resource was found on the operation "%s"', $operation->getShortName() ?? ''));
+        }
+
+        $section = $resource->getSection();
+        $sectionPrefix = $section ? $section . '_' : '';
+
+        return sprintf(
+            '%s_%s%s_%s',
+            $resource->getApplicationName() ?? '',
+            $sectionPrefix,
+            $resource->getName() ?? '',
+            $shortName ?? $operation->getShortName() ?? '',
+        );
+    }
+}

--- a/src/Component/Tests/Dummy/DummyMultiResourcesWithOperations.php
+++ b/src/Component/Tests/Dummy/DummyMultiResourcesWithOperations.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+
+#[Resource(alias: 'app.order')]
+#[Index]
+#[Create]
+#[Resource(alias: 'app.cart')]
+#[Index]
+#[Show]
+final class DummyMultiResourcesWithOperations
+{
+}

--- a/src/Component/Tests/Dummy/DummyOperationsWithoutResource.php
+++ b/src/Component/Tests/Dummy/DummyOperationsWithoutResource.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+
+#[Index]
+#[Create]
+final class DummyOperationsWithoutResource
+{
+}

--- a/src/Component/Tests/Dummy/DummyResource.php
+++ b/src/Component/Tests/Dummy/DummyResource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Resource;
+
+#[Resource(alias: 'app.dummy')]
+final class DummyResource
+{
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithOperations.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithOperations.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy')]
+#[Index]
+#[Create]
+#[Update]
+#[Show]
+final class DummyResourceWithOperations
+{
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithSections.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithSections.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+
+#[Resource(alias: 'app.dummy', section: 'admin')]
+#[Index]
+#[Create]
+#[Resource(alias: 'app.dummy', section: 'shop')]
+#[Index]
+#[Show]
+final class DummyResourceWithSections
+{
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithSectionsAndNestedOperations.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithSectionsAndNestedOperations.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+
+#[Resource(
+    alias: 'app.dummy',
+    section: 'admin',
+    operations: [
+        new Index(),
+        new Create(),
+    ],
+)]
+#[Resource(
+    alias: 'app.dummy',
+    section: 'shop',
+    operations: [
+        new Index(),
+        new Show(),
+    ],
+)]
+final class DummyResourceWithSectionsAndNestedOperations
+{
+}

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -43,7 +43,7 @@ final class CreateSpec extends ObjectBehavior
 
     function it_could_have_a_resource(): void
     {
-        $resource = new Resource();
+        $resource = new Resource(alias: 'app.book');
 
         $this->withResource($resource)
             ->getResource()

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -51,9 +51,9 @@ final class CreateSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_create_name_by_default(): void
+    function it_has_create_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('create');
+        $this->getShortName()->shouldReturn('create');
     }
 
     function it_has_get_and_post_methods_by_default(): void

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class CreateSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class CreateSpec extends ObjectBehavior
     function it_implements_create_operation_interface(): void
     {
         $this->shouldImplement(CreateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_create_name_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -51,9 +51,9 @@ final class DeleteSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_delete_name_by_default(): void
+    function it_has_delete_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('delete');
+        $this->getShortName()->shouldReturn('delete');
     }
 
     function it_has_delete_methods_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Delete;
 use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class DeleteSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class DeleteSpec extends ObjectBehavior
     function it_implements_delete_operation_interface(): void
     {
         $this->shouldImplement(DeleteOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_delete_name_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -43,7 +43,7 @@ final class DeleteSpec extends ObjectBehavior
 
     function it_could_have_a_resource(): void
     {
-        $resource = new Resource();
+        $resource = new Resource(alias: 'app.book');
 
         $this->withResource($resource)
             ->getResource()

--- a/src/Component/spec/Metadata/HttpOperationSpec.php
+++ b/src/Component/spec/Metadata/HttpOperationSpec.php
@@ -90,7 +90,7 @@ final class HttpOperationSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith(null, null, null, 'create');
+        $this->beConstructedWith(null, null, null, null, null, 'create');
 
         $this->getName()->shouldReturn('create');
     }

--- a/src/Component/spec/Metadata/HttpOperationSpec.php
+++ b/src/Component/spec/Metadata/HttpOperationSpec.php
@@ -90,7 +90,7 @@ final class HttpOperationSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith(null, null, null, null, null, 'create');
+        $this->beConstructedWith(null, null, null, null, null, null, 'create');
 
         $this->getName()->shouldReturn('create');
     }

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class IndexSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class IndexSpec extends ObjectBehavior
     function it_implements_collection_operation_interface(): void
     {
         $this->shouldImplement(CollectionOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_index_name_by_default(): void

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -51,9 +51,9 @@ final class IndexSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_index_name_by_default(): void
+    function it_has_index_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('index');
+        $this->getShortName()->shouldReturn('index');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -43,7 +43,7 @@ final class IndexSpec extends ObjectBehavior
 
     function it_could_have_a_resource(): void
     {
-        $resource = new Resource();
+        $resource = new Resource(alias: 'app.book');
 
         $this->withResource($resource)
             ->getResource()

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -142,7 +142,7 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
 
     function it_creates_multi_resources_metadata_with_sections_and_nested_operations(): void
     {
-        if (PHP_VERSION_ID < 80100) {
+        if (\PHP_VERSION_ID < 80100) {
             throw new SkippingException();
         }
 

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -116,27 +116,27 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
         $operations->shouldHaveType(Operations::class);
 
         $operations->count()->shouldReturn(2);
-        $operations->has('admin_index')->shouldReturn(true);
-        $operations->has('admin_create')->shouldReturn(true);
+        $operations->has('index')->shouldReturn(true);
+        $operations->has('create')->shouldReturn(true);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'admin_index');
+        $operation = $metadataCollection->getOperation('app.dummy', 'index', 'admin');
         $operation->shouldHaveType(Index::class);
-        $operation->getName()->shouldReturn('admin_index');
+        $operation->getName()->shouldReturn('index');
         $operation->getMethods()->shouldReturn(['GET']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'admin_create');
+        $operation = $metadataCollection->getOperation('app.dummy', 'create', 'admin');
         $operation->shouldHaveType(Create::class);
-        $operation->getName()->shouldReturn('admin_create');
+        $operation->getName()->shouldReturn('create');
         $operation->getMethods()->shouldReturn(['GET', 'POST']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'shop_index');
+        $operation = $metadataCollection->getOperation('app.dummy', 'index', 'shop');
         $operation->shouldHaveType(Index::class);
-        $operation->getName()->shouldReturn('shop_index');
+        $operation->getName()->shouldReturn('index');
         $operation->getMethods()->shouldReturn(['GET']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'shop_show');
+        $operation = $metadataCollection->getOperation('app.dummy', 'show', 'shop');
         $operation->shouldHaveType(Show::class);
-        $operation->getName()->shouldReturn('shop_show');
+        $operation->getName()->shouldReturn('show');
         $operation->getMethods()->shouldReturn(['GET']);
     }
 
@@ -159,27 +159,27 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
         $operations->shouldHaveType(Operations::class);
 
         $operations->count()->shouldReturn(2);
-        $operations->has('admin_index')->shouldReturn(true);
-        $operations->has('admin_create')->shouldReturn(true);
+        $operations->has('index')->shouldReturn(true);
+        $operations->has('create')->shouldReturn(true);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'admin_index');
+        $operation = $metadataCollection->getOperation('app.dummy', 'index', 'admin');
         $operation->shouldHaveType(Index::class);
-        $operation->getName()->shouldReturn('admin_index');
+        $operation->getName()->shouldReturn('index');
         $operation->getMethods()->shouldReturn(['GET']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'admin_create');
+        $operation = $metadataCollection->getOperation('app.dummy', 'create', 'admin');
         $operation->shouldHaveType(Create::class);
-        $operation->getName()->shouldReturn('admin_create');
+        $operation->getName()->shouldReturn('create');
         $operation->getMethods()->shouldReturn(['GET', 'POST']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'shop_index');
+        $operation = $metadataCollection->getOperation('app.dummy', 'index', 'shop');
         $operation->shouldHaveType(Index::class);
-        $operation->getName()->shouldReturn('shop_index');
+        $operation->getName()->shouldReturn('index');
         $operation->getMethods()->shouldReturn(['GET']);
 
-        $operation = $metadataCollection->getOperation('app.dummy', 'shop_show');
+        $operation = $metadataCollection->getOperation('app.dummy', 'show', 'shop');
         $operation->shouldHaveType(Show::class);
-        $operation->getName()->shouldReturn('shop_show');
+        $operation->getName()->shouldReturn('show');
         $operation->getMethods()->shouldReturn(['GET']);
     }
 

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -24,6 +24,7 @@ use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
 use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
 use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyOperationsWithoutResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResource;
@@ -35,7 +36,7 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
 {
     function let(RegistryInterface $resourceRegistry): void
     {
-        $this->beConstructedWith($resourceRegistry);
+        $this->beConstructedWith($resourceRegistry, new OperationRouteNameFactory());
     }
 
     function it_is_initializable(): void

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -143,7 +143,7 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
     function it_creates_multi_resources_metadata_with_sections_and_nested_operations(): void
     {
         if (\PHP_VERSION_ID < 80100) {
-            throw new SkippingException();
+            throw new SkippingException('Nested attributes are supported since PHP 8.1');
         }
 
         $metadataCollection = $this->create(DummyResourceWithSectionsAndNestedOperations::class);

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Resource\Metadata\Resource\Factory;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Operations;
 use Sylius\Component\Resource\Metadata\Resource;
@@ -21,8 +22,11 @@ use Sylius\Component\Resource\Metadata\Resource\Factory\AttributesResourceMetada
 use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
+use Sylius\Component\Resource\Tests\Dummy\DummyOperationsWithoutResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSections;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSectionsAndNestedOperations;
 
 class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
 {
@@ -94,5 +98,90 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
         $operation->shouldHaveType(Show::class);
         $operation->getName()->shouldReturn('show');
         $operation->getMethods()->shouldReturn(['GET']);
+    }
+
+    function it_creates_multi_resources_metadata_with_sections(): void
+    {
+        $metadataCollection = $this->create(DummyResourceWithSections::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $metadataCollection->count()->shouldReturn(2);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(2);
+        $operations->has('admin_index')->shouldReturn(true);
+        $operations->has('admin_create')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'admin_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('admin_index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'admin_create');
+        $operation->shouldHaveType(Create::class);
+        $operation->getName()->shouldReturn('admin_create');
+        $operation->getMethods()->shouldReturn(['GET', 'POST']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'shop_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('shop_index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'shop_show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getName()->shouldReturn('shop_show');
+        $operation->getMethods()->shouldReturn(['GET']);
+    }
+
+    function it_creates_multi_resources_metadata_with_sections_and_nested_operations(): void
+    {
+        $metadataCollection = $this->create(DummyResourceWithSectionsAndNestedOperations::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $metadataCollection->count()->shouldReturn(2);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(2);
+        $operations->has('admin_index')->shouldReturn(true);
+        $operations->has('admin_create')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'admin_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('admin_index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'admin_create');
+        $operation->shouldHaveType(Create::class);
+        $operation->getName()->shouldReturn('admin_create');
+        $operation->getMethods()->shouldReturn(['GET', 'POST']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'shop_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('shop_index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'shop_show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getName()->shouldReturn('shop_show');
+        $operation->getMethods()->shouldReturn(['GET']);
+    }
+
+    function it_throws_a_runtime_exception_when_no_resource_attribute_was_found(): void
+    {
+        $this->shouldThrow(new \RuntimeException(sprintf('No Resource attribute was found on %s', DummyOperationsWithoutResource::class)))
+            ->during('create', [DummyOperationsWithoutResource::class])
+        ;
     }
 }

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Resource\Metadata\Resource\Factory;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\Index;
@@ -141,6 +142,10 @@ class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
 
     function it_creates_multi_resources_metadata_with_sections_and_nested_operations(): void
     {
+        if (PHP_VERSION_ID < 80100) {
+            throw new SkippingException();
+        }
+
         $metadataCollection = $this->create(DummyResourceWithSectionsAndNestedOperations::class);
         $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
 

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Metadata\Resource\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Operations;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
+use Sylius\Component\Resource\Tests\Dummy\DummyResource;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
+
+class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(AttributesResourceMetadataCollectionFactory::class);
+    }
+
+    function it_creates_resource_metadata(): void
+    {
+        $metadataCollection = $this->create(DummyResource::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $metadataCollection->count()->shouldReturn(1);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+    }
+
+    function it_creates_resource_metadata_with_operations(): void
+    {
+        $metadataCollection = $this->create(DummyResourceWithOperations::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('index')->shouldReturn(true);
+        $operations->has('create')->shouldReturn(true);
+        $operations->has('update')->shouldReturn(true);
+        $operations->has('show')->shouldReturn(true);
+    }
+
+    function it_creates_multi_resources_metadata_with_operations(): void
+    {
+        $metadataCollection = $this->create(DummyMultiResourcesWithOperations::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $metadataCollection->count()->shouldReturn(2);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.order');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(2);
+        $operations->has('index')->shouldReturn(true);
+        $operations->has('create')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.order', 'index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.cart', 'index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('index');
+        $operation->getMethods()->shouldReturn(['GET']);
+
+        $operation = $metadataCollection->getOperation('app.cart', 'show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getName()->shouldReturn('show');
+        $operation->getMethods()->shouldReturn(['GET']);
+    }
+}

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -21,6 +21,11 @@ use Sylius\Component\Resource\Metadata\Update;
 
 final class ResourceSpec extends ObjectBehavior
 {
+    function let(): void
+    {
+        $this->beConstructedWith('app.book');
+    }
+
     function it_is_initializable(): void
     {
         $this->shouldHaveType(Resource::class);
@@ -102,21 +107,21 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_section(): void
     {
-        $this->beConstructedWith('app.book', 'admin');
+        $this->beConstructedWith(null, 'admin');
 
         $this->getSection()->shouldReturn('admin');
     }
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith('app.book', null, 'book');
+        $this->beConstructedWith(null, null, 'book');
 
         $this->getName()->shouldReturn('book');
     }
 
     function it_can_be_constructed_with_an_application_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, 'app');
+        $this->beConstructedWith(null, null, null, 'app');
 
         $this->getApplicationName()->shouldReturn('app');
     }

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -31,9 +31,9 @@ final class ResourceSpec extends ObjectBehavior
         $this->shouldHaveType(Resource::class);
     }
 
-    function it_has_no_alias_by_default(): void
+    function it_can_get_alias(): void
     {
-        $this->getAlias()->shouldReturn(null);
+        $this->getAlias()->shouldReturn('app.book');
     }
 
     function it_could_have_an_alias(): void
@@ -107,21 +107,21 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_section(): void
     {
-        $this->beConstructedWith(null, 'admin');
+        $this->beConstructedWith('app.book', 'admin');
 
         $this->getSection()->shouldReturn('admin');
     }
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith(null, null, 'book');
+        $this->beConstructedWith('app.book', null, 'book');
 
         $this->getName()->shouldReturn('book');
     }
 
     function it_can_be_constructed_with_an_application_name(): void
     {
-        $this->beConstructedWith(null, null, null, 'app');
+        $this->beConstructedWith('app.book', null, null, 'app');
 
         $this->getApplicationName()->shouldReturn('app');
     }
@@ -130,7 +130,7 @@ final class ResourceSpec extends ObjectBehavior
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith(null, null, null, null, $operations);
+        $this->beConstructedWith('app.book', null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -39,6 +39,45 @@ final class ResourceSpec extends ObjectBehavior
         ;
     }
 
+    function it_has_no_section_by_default(): void
+    {
+        $this->getSection()->shouldReturn(null);
+    }
+
+    function it_could_have_a_section(): void
+    {
+        $this->withSection('admin')
+            ->getSection()
+            ->shouldReturn('admin')
+        ;
+    }
+
+    function it_has_no_name_by_default(): void
+    {
+        $this->getName()->shouldReturn(null);
+    }
+
+    function it_could_have_a_name(): void
+    {
+        $this->withName('book')
+            ->getName()
+            ->shouldReturn('book')
+        ;
+    }
+
+    function it_has_no_application_name_by_default(): void
+    {
+        $this->getApplicationName()->shouldReturn(null);
+    }
+
+    function it_could_have_an_application_name(): void
+    {
+        $this->withApplicationName('app')
+            ->getApplicationName()
+            ->shouldReturn('app')
+        ;
+    }
+
     function it_has_no_operations_by_default(): void
     {
         $this->getOperations()->shouldReturn(null);
@@ -61,11 +100,32 @@ final class ResourceSpec extends ObjectBehavior
         $this->getAlias()->shouldReturn('app.book');
     }
 
+    function it_can_be_constructed_with_a_section(): void
+    {
+        $this->beConstructedWith('app.book', 'admin');
+
+        $this->getSection()->shouldReturn('admin');
+    }
+
+    function it_can_be_constructed_with_a_name(): void
+    {
+        $this->beConstructedWith('app.book', null, 'book');
+
+        $this->getName()->shouldReturn('book');
+    }
+
+    function it_can_be_constructed_with_an_application_name(): void
+    {
+        $this->beConstructedWith('app.book', null, null, 'app');
+
+        $this->getApplicationName()->shouldReturn('app');
+    }
+
     function it_can_be_constructed_with_operations(): void
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith(null, $operations);
+        $this->beConstructedWith(null, null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Metadata\ShowOperationInterface;
 
@@ -33,6 +34,21 @@ final class ShowSpec extends ObjectBehavior
     function it_implements_show_operation_interface(): void
     {
         $this->shouldImplement(ShowOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_show_name_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -51,9 +51,9 @@ final class ShowSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_show_name_by_default(): void
+    function it_has_show_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('show');
+        $this->getShortName()->shouldReturn('show');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -43,7 +43,7 @@ final class ShowSpec extends ObjectBehavior
 
     function it_could_have_a_resource(): void
     {
-        $resource = new Resource();
+        $resource = new Resource(alias: 'app.book');
 
         $this->withResource($resource)
             ->getResource()

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -53,7 +53,7 @@ final class UpdateSpec extends ObjectBehavior
 
     function it_has_update_name_by_default(): void
     {
-        $this->getName()->shouldReturn('update');
+        $this->getShortName()->shouldReturn('update');
     }
 
     function it_has_get_and_put_methods_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -43,7 +43,7 @@ final class UpdateSpec extends ObjectBehavior
 
     function it_could_have_a_resource(): void
     {
-        $resource = new Resource();
+        $resource = new Resource(alias: 'app.book');
 
         $this->withResource($resource)
             ->getResource()

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Update;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
@@ -33,6 +34,21 @@ final class UpdateSpec extends ObjectBehavior
     function it_implements_update_operation_interface(): void
     {
         $this->shouldImplement(UpdateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_update_name_by_default(): void

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Symfony\Routing\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+
+final class OperationRouteNameFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(OperationRouteNameFactory::class);
+    }
+
+    function it_create_a_route_name(): void
+    {
+        $resource = new Resource(name: 'book', applicationName: 'app');
+        $operation = (new Create())->withResource($resource);
+
+        $this->createRouteName($operation)->shouldReturn('app_book_create');
+    }
+
+    function it_create_a_route_name_with_a_section(): void
+    {
+        $resource = new Resource(name: 'book', applicationName: 'app', section: 'admin');
+        $operation = (new Create())->withResource($resource);
+
+        $this->createRouteName($operation)->shouldReturn('app_admin_book_create');
+    }
+
+    function it_throws_an_exception_when_operation_has_no_resource(): void
+    {
+        $operation = new Create();
+
+        $this->shouldThrow(new \RuntimeException('No resource was found on the operation "create"'))
+            ->during('createRouteName', [$operation])
+        ;
+    }
+}

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
@@ -27,7 +27,7 @@ final class OperationRouteNameFactorySpec extends ObjectBehavior
 
     function it_create_a_route_name(): void
     {
-        $resource = new Resource(name: 'book', applicationName: 'app');
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
         $operation = (new Create())->withResource($resource);
 
         $this->createRouteName($operation)->shouldReturn('app_book_create');
@@ -35,7 +35,7 @@ final class OperationRouteNameFactorySpec extends ObjectBehavior
 
     function it_create_a_route_name_with_a_section(): void
     {
-        $resource = new Resource(name: 'book', applicationName: 'app', section: 'admin');
+        $resource = new Resource(alias: 'app.book', section: 'admin', name: 'book', applicationName: 'app');
         $operation = (new Create())->withResource($resource);
 
         $this->createRouteName($operation)->shouldReturn('app_admin_book_create');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

The whole code is a lot inspired by https://github.com/api-platform/core/blob/main/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php

**One attribute per line**

```php
#[Resource(alias: 'app.book', section: 'admin')]
#[Index]
#[Create]
#[Resource(alias: 'app.book', section: 'shop')]
#[Index]
#[Show]
final class BookResource
{
}
```

**Nested operations**

```php
#[Resource(
    alias: 'app.book', 
    section: 'admin',
    operations: [
        new Index(),
        new Create(),
    ],
)]
#[Resource(
    alias: 'app.book', 
    section: 'shop',
    operations: [
        new Index(),
        new Show(),
    ],
)]
final class BookResource
{
}
```

**Without resource attribute**

On this next example, it will search for a resource with `getByClass` method on the resource registry.

```php
#[Index]
#[Create]
final class BookResource
{
}
```