### PR TITLE
docs: fix a wrong yaml indentation in the reference documentation causing the yaml to be invalid

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,7 +12,9 @@ sylius_resource:
                 repository: ~
                 factory: Sylius\Component\Resource\Factory\Factory
                 form: Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType
-                    validation_groups: [sylius]
+                #form:
+                    #options:
+                        #validation_groups: [sylius]
             options:
                 object_manager: default
             templates:
@@ -25,7 +27,9 @@ sylius_resource:
                     repository: ~
                     factory: Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType
-                        validation_groups: [sylius]
+                    #form:
+                        #options:
+                            #validation_groups: [sylius]
                 templates:
                     form: Book/Translation/_form.html.twig
                 options: ~


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Fixes #484 
| License         | MIT

Hi,

this pr fixes a wrong yaml indentation in the reference documentation causing the yaml to be invalid.



Thank you very much
