### PR TITLE
Update doctrine/orm and fix deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "sylius/resource": "self.version"
     },
     "require-dev": {
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.14",
         "lchrusciel/api-test-case": "^5.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2.1",
         "pagerfanta/pagerfanta": "^3.0",
@@ -77,7 +77,7 @@
         "rector/rector": "^0.13.5"
     },
     "suggest": {
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.14",
         "sylius/locale": "^1.0"
     },
     "config": {

--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -69,7 +69,7 @@ final class ORMTranslatableListener implements EventSubscriber
         }
     }
 
-    public function postLoad(LifecycleEventArgs $args): void
+    public function postLoad(PostLoadEventArgs $args): void
     {
         $entity = $args->getObject();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Other option is to add this to psalm configuration 
```
<DeprecatedClass>
            <errorLevel type="info">
                <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs" /> <!-- deprecated in doctrine/orm 2.14 -->
            </errorLevel>
</DeprecatedClass>
```