### PR TITLE
Add request option

### DIFF
--- a/src/Component/Context/Option/RequestOption.php
+++ b/src/Component/Context/Option/RequestOption.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Context\Option;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestOption
+{
+    public function __construct(private Request $request)
+    {
+    }
+
+    public function request(): Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -33,6 +33,7 @@
         "gedmo/doctrine-extensions": "^2.4.12 || ^3.0",
         "pagerfanta/core": "^3.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
         "symfony/property-access": "^5.4 || ^6.0",
         "winzou/state-machine": "^0.4"
     },

--- a/src/Component/spec/Context/Option/RequestOptionSpec.php
+++ b/src/Component/spec/Context/Option/RequestOptionSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Context\Option;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Context\Option\RequestOption;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestOptionSpec extends ObjectBehavior
+{
+    function let(Request $request): void
+    {
+        $this->beConstructedWith($request);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RequestOption::class);
+    }
+
+    function it_contains_request(Request $request): void
+    {
+        $this->request()->shouldReturn($request);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

After what we talked about on #527 

Building a context with some options:

```php
$context = new Context(new RequestOption($request));
$context->with(new MetadataOption($metadata), new RequestConfigurationOption($configuration));
```

This context will be used to get the Request from the context.