### PR TITLE
Fix form listener to run only on create/update operations

### DIFF
--- a/src/Component/Symfony/EventListener/FormListener.php
+++ b/src/Component/Symfony/EventListener/FormListener.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
 use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
+use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 use Sylius\Component\Resource\Symfony\Form\Factory\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -37,7 +39,7 @@ final class FormListener
 
         if (
             $controllerResult instanceof Response ||
-            null === $operation ||
+            !($operation instanceof CreateOperationInterface || $operation instanceof UpdateOperationInterface) ||
             null == $operation->getFormType()
         ) {
             return;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT
