### PR TITLE
Configure templates dir on resource

### DIFF
--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -22,6 +22,7 @@ final class Resource
         private string $alias,
         private ?string $section = null,
         private ?string $formType = null,
+        private ?string $templatesDir = null,
         private ?string $name = null,
         private ?string $applicationName = null,
         ?array $operations = null,
@@ -90,6 +91,19 @@ final class Resource
     {
         $self = clone $this;
         $self->applicationName = $applicationName;
+
+        return $self;
+    }
+
+    public function getTemplatesDir(): ?string
+    {
+        return $this->templatesDir;
+    }
+
+    public function withTemplatesDir(string $templatesDir): self
+    {
+        $self = clone $this;
+        $self->templatesDir = $templatesDir;
 
         return $self;
     }

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -122,6 +122,12 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
     {
         $resourceConfiguration = $this->resourceRegistry->get($resource->getAlias());
 
+        if (null === $operation->getTemplate()) {
+            $templateDir = $resource->getTemplatesDir() ?? '';
+            $template = sprintf('%s/%s.html.twig', $templateDir, $operation->getShortName() ?? '');
+            $operation = $operation->withTemplate($template);
+        }
+
         if (null === $resource->getApplicationName()) {
             $resource = $resource->withApplicationName($resourceConfiguration->getApplicationName());
         }

--- a/src/Component/Symfony/EventListener/FormListener.php
+++ b/src/Component/Symfony/EventListener/FormListener.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
 use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
+use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 use Sylius\Component\Resource\Symfony\Form\Factory\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -37,7 +39,7 @@ final class FormListener
 
         if (
             $controllerResult instanceof Response ||
-            null === $operation ||
+            !($operation instanceof CreateOperationInterface || $operation instanceof UpdateOperationInterface) ||
             null == $operation->getFormType()
         ) {
             return;

--- a/src/Component/Tests/Dummy/DummyResourceWithTemplatesDir.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithTemplatesDir.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy', templatesDir: 'book')]
+#[Create]
+#[Update]
+#[Index]
+#[Show]
+final class DummyResourceWithTemplatesDir
+{
+}

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -33,6 +33,7 @@ use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithFormType;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSections;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSectionsAndNestedOperations;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithTemplatesDir;
 
 final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
 {
@@ -334,5 +335,60 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
         $operation->getMethods()->shouldReturn(['GET', 'PUT']);
         $operation->getRepository()->shouldReturn('app.repository.dummy');
         $operation->getFormType()->shouldReturn('App\Form\DummyType');
+    }
+
+    function it_creates_resource_metadata_with_templates_dir(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithTemplatesDir::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->shouldHaveType(Create::class);
+        $operation->getName()->shouldReturn('app_dummy_create');
+        $operation->getMethods()->shouldReturn(['GET', 'POST']);
+        $operation->getRepository()->shouldReturn('app.repository.dummy');
+        $operation->getTemplate()->shouldReturn('book/create.html.twig');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->shouldHaveType(Update::class);
+        $operation->getName()->shouldReturn('app_dummy_update');
+        $operation->getMethods()->shouldReturn(['GET', 'PUT']);
+        $operation->getRepository()->shouldReturn('app.repository.dummy');
+        $operation->getTemplate()->shouldReturn('book/update.html.twig');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getName()->shouldReturn('app_dummy_index');
+        $operation->getMethods()->shouldReturn(['GET']);
+        $operation->getRepository()->shouldReturn('app.repository.dummy');
+        $operation->getTemplate()->shouldReturn('book/index.html.twig');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getName()->shouldReturn('app_dummy_show');
+        $operation->getMethods()->shouldReturn(['GET']);
+        $operation->getRepository()->shouldReturn('app.repository.dummy');
+        $operation->getTemplate()->shouldReturn('book/show.html.twig');
     }
 }

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -114,14 +114,14 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, 'book');
+        $this->beConstructedWith('app.book', null, null, null, 'book');
 
         $this->getName()->shouldReturn('book');
     }
 
     function it_can_be_constructed_with_an_application_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, null, 'app');
+        $this->beConstructedWith('app.book', null, null, null, null, 'app');
 
         $this->getApplicationName()->shouldReturn('app');
     }
@@ -133,11 +133,18 @@ final class ResourceSpec extends ObjectBehavior
         $this->getFormType()->shouldReturn('App\Form\DummyType');
     }
 
+    function it_can_be_constructed_with_a_templates_dir(): void
+    {
+        $this->beConstructedWith('app.book', null, null, 'book');
+
+        $this->getTemplatesDir()->shouldReturn('book');
+    }
+
     function it_can_be_constructed_with_operations(): void
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith('app.book', null, null, null, null, $operations);
+        $this->beConstructedWith('app.book', null, null, null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

```php
#[Resource(
    alias: 'app.book',
    section: 'admin',
    templatesDir: 'book',
    operations: [
        new Create(
            //template: 'book/create.html.twig',
            provider: Provider::class,
            responder: BookCreationResponder::class,
        ),
    ],
)]
```