### PR TITLE
Add resource on operations

### DIFF
--- a/src/Bundle/test/src/Entity/Author.php
+++ b/src/Bundle/test/src/Entity/Author.php
@@ -22,12 +22,14 @@ final class Author
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $firstName = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $lastName = null;

--- a/src/Bundle/test/src/Entity/Book.php
+++ b/src/Bundle/test/src/Entity/Book.php
@@ -29,13 +29,16 @@ class Book implements ResourceInterface, TranslatableInterface
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $author = null;
@@ -52,6 +55,7 @@ class Book implements ResourceInterface, TranslatableInterface
      * @return string
      *
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\SerializedName("title")
      */
     public function getTitle()

--- a/src/Bundle/test/src/Entity/ComicBook.php
+++ b/src/Bundle/test/src/Entity/ComicBook.php
@@ -23,19 +23,23 @@ class ComicBook implements ResourceInterface
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Until("1.1")
      */
     private ?Author $author = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $title = null;
@@ -63,6 +67,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorFirstName(): ?string
@@ -72,6 +77,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorLastName(): ?string

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -18,6 +18,8 @@ namespace Sylius\Component\Resource\Metadata;
  */
 abstract class Operation
 {
+    private ?Resource $resource = null;
+
     /** @var string|callable|null */
     protected $provider;
 
@@ -32,6 +34,19 @@ abstract class Operation
     ) {
         $this->provider = $provider;
         $this->processor = $processor;
+    }
+
+    public function getResource(): ?Resource
+    {
+        return $this->resource;
+    }
+
+    public function withResource(Resource $resource): self
+    {
+        $self = clone $this;
+        $self->resource = $resource;
+
+        return $self;
     }
 
     public function getName(): ?string

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class CreateSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class CreateSpec extends ObjectBehavior
     function it_implements_create_operation_interface(): void
     {
         $this->shouldImplement(CreateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_create_name_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Delete;
 use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class DeleteSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class DeleteSpec extends ObjectBehavior
     function it_implements_delete_operation_interface(): void
     {
         $this->shouldImplement(DeleteOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_delete_name_by_default(): void

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class IndexSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class IndexSpec extends ObjectBehavior
     function it_implements_collection_operation_interface(): void
     {
         $this->shouldImplement(CollectionOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_index_name_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Metadata\ShowOperationInterface;
 
@@ -33,6 +34,21 @@ final class ShowSpec extends ObjectBehavior
     function it_implements_show_operation_interface(): void
     {
         $this->shouldImplement(ShowOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_show_name_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Update;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
@@ -33,6 +34,21 @@ final class UpdateSpec extends ObjectBehavior
     function it_implements_update_operation_interface(): void
     {
         $this->shouldImplement(UpdateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_update_name_by_default(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

On the next PRs, section cannot be set to the operation itself but only on the resource.
We'll store more information on the resource such as name & plurial name.

Moreover, getting resource information from the operation itself will be important to get another operation linked to the same context.

Example: 
- getting the  `app_book_show` from the `app_book_create` operation.
- getting the `app_admin_book_show` from the `app_admin_book_create` operation.

This feature example will be useful for redirection.

So we'll see that kind of things later :
```php
final class OperationRouteNameFactory
{
    public function createRouteName(Operation $operation, ?string $shortName = null): string
    {
        $resource = $operation->getResource();

        if (null === $resource) {
            throw new \RuntimeException(sprintf('No resource was found on the operation "%s"', $operation->getShortName() ?? ''));
        }

        $section = $resource->getSection();
        $sectionPrefix = $section ? $section . '_' : '';

        return sprintf(
            '%s_%s%s_%s',
            $resource->getApplicationName() ?? '',
            $sectionPrefix,
            $resource->getName() ?? '',
            $shortName ?? $operation->getShortName() ?? '',
        );
    }
}
```

or things like that for the resource name & plurial name usage:
```php
        if ($operation instanceof CollectionOperationInterface) {
            $context['resources'] = $data;
            $context[$operation->getResource()?->getPluralName() ?? ''] = $data;
        } else {
            $context['resource'] = $data;
            $context[$operation->getResource()?->getName() ?? ''] = $data;
        }
```