### PR TITLE
Add operation with short name

### DIFF
--- a/src/Bundle/test/src/Entity/Author.php
+++ b/src/Bundle/test/src/Entity/Author.php
@@ -22,12 +22,14 @@ final class Author
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $firstName = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $lastName = null;

--- a/src/Bundle/test/src/Entity/Book.php
+++ b/src/Bundle/test/src/Entity/Book.php
@@ -29,13 +29,16 @@ class Book implements ResourceInterface, TranslatableInterface
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $author = null;
@@ -52,6 +55,7 @@ class Book implements ResourceInterface, TranslatableInterface
      * @return string
      *
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\SerializedName("title")
      */
     public function getTitle()

--- a/src/Bundle/test/src/Entity/ComicBook.php
+++ b/src/Bundle/test/src/Entity/ComicBook.php
@@ -23,19 +23,23 @@ class ComicBook implements ResourceInterface
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Until("1.1")
      */
     private ?Author $author = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $title = null;
@@ -63,6 +67,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorFirstName(): ?string
@@ -72,6 +77,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorLastName(): ?string

--- a/src/Component/Metadata/Create.php
+++ b/src/Component/Metadata/Create.php
@@ -23,8 +23,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
             methods: $methods ?? ['GET', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'create',
             template: $template,
+            shortName: $shortName ?? 'create',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -23,8 +23,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             methods: $methods ?? ['DELETE'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'delete',
             template: $template,
+            shortName: $shortName ?? 'delete',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -22,14 +22,16 @@ class HttpOperation extends Operation
         protected ?array $methods = null,
         protected ?string $path = null,
         protected ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
         parent::__construct(
-            name: $name,
             template: $template,
+            name: $name,
+            shortName: $shortName,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Index.php
+++ b/src/Component/Metadata/Index.php
@@ -23,8 +23,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'index',
             template: $template,
+            shortName: $shortName ?? 'index',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -27,8 +27,9 @@ abstract class Operation
     protected $processor;
 
     public function __construct(
-        protected ?string $name = null,
         protected ?string $template = null,
+        protected ?string $shortName = null,
+        protected ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -49,6 +50,19 @@ abstract class Operation
         return $self;
     }
 
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function withTemplate(string $template): self
+    {
+        $self = clone $this;
+        $self->template = $template;
+
+        return $self;
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -62,15 +76,15 @@ abstract class Operation
         return $self;
     }
 
-    public function getTemplate(): ?string
+    public function getShortName(): ?string
     {
-        return $this->template;
+        return $this->shortName;
     }
 
-    public function withTemplate(string $template): self
+    public function withShortName(string $shortName): self
     {
         $self = clone $this;
-        $self->template = $template;
+        $self->shortName = $shortName;
 
         return $self;
     }

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -18,6 +18,8 @@ namespace Sylius\Component\Resource\Metadata;
  */
 abstract class Operation
 {
+    private ?Resource $resource = null;
+
     /** @var string|callable|null */
     protected $provider;
 
@@ -32,6 +34,19 @@ abstract class Operation
     ) {
         $this->provider = $provider;
         $this->processor = $processor;
+    }
+
+    public function getResource(): ?Resource
+    {
+        return $this->resource;
+    }
+
+    public function withResource(Resource $resource): self
+    {
+        $self = clone $this;
+        $self->resource = $resource;
+
+        return $self;
     }
 
     public function getName(): ?string

--- a/src/Component/Metadata/Show.php
+++ b/src/Component/Metadata/Show.php
@@ -23,8 +23,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'show',
             template: $template,
+            shortName: $shortName ?? 'show',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -23,8 +23,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
             methods: $methods ?? ['GET', 'PUT'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'update',
             template: $template,
+            shortName: $shortName ?? 'update',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -51,9 +51,9 @@ final class CreateSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_create_name_by_default(): void
+    function it_has_create_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('create');
+        $this->getShortName()->shouldReturn('create');
     }
 
     function it_has_get_and_post_methods_by_default(): void

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class CreateSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class CreateSpec extends ObjectBehavior
     function it_implements_create_operation_interface(): void
     {
         $this->shouldImplement(CreateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_create_name_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -51,9 +51,9 @@ final class DeleteSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_delete_name_by_default(): void
+    function it_has_delete_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('delete');
+        $this->getShortName()->shouldReturn('delete');
     }
 
     function it_has_delete_methods_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Delete;
 use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class DeleteSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class DeleteSpec extends ObjectBehavior
     function it_implements_delete_operation_interface(): void
     {
         $this->shouldImplement(DeleteOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_delete_name_by_default(): void

--- a/src/Component/spec/Metadata/HttpOperationSpec.php
+++ b/src/Component/spec/Metadata/HttpOperationSpec.php
@@ -90,7 +90,7 @@ final class HttpOperationSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith(null, null, null, 'create');
+        $this->beConstructedWith(null, null, null, null, null, 'create');
 
         $this->getName()->shouldReturn('create');
     }

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class IndexSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class IndexSpec extends ObjectBehavior
     function it_implements_collection_operation_interface(): void
     {
         $this->shouldImplement(CollectionOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_index_name_by_default(): void

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -51,9 +51,9 @@ final class IndexSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_index_name_by_default(): void
+    function it_has_index_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('index');
+        $this->getShortName()->shouldReturn('index');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Metadata\ShowOperationInterface;
 
@@ -33,6 +34,21 @@ final class ShowSpec extends ObjectBehavior
     function it_implements_show_operation_interface(): void
     {
         $this->shouldImplement(ShowOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_show_name_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -51,9 +51,9 @@ final class ShowSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_show_name_by_default(): void
+    function it_has_show_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('show');
+        $this->getShortName()->shouldReturn('show');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -53,7 +53,7 @@ final class UpdateSpec extends ObjectBehavior
 
     function it_has_update_name_by_default(): void
     {
-        $this->getName()->shouldReturn('update');
+        $this->getShortName()->shouldReturn('update');
     }
 
     function it_has_get_and_put_methods_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Update;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
@@ -33,6 +34,21 @@ final class UpdateSpec extends ObjectBehavior
     function it_implements_update_operation_interface(): void
     {
         $this->shouldImplement(UpdateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_update_name_by_default(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The name for the operation should be unique. For http operations, it will be built by default with the route name.
The `'create`, `index`, `show` will now be stored into the short name.
It will be important to build the route name based on "application name, section, resource name & operation short name".

We'll keep the name for all types of operations.