### PR TITLE
Add operation route name factory

### DIFF
--- a/src/Bundle/test/src/Entity/Author.php
+++ b/src/Bundle/test/src/Entity/Author.php
@@ -22,12 +22,14 @@ final class Author
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $firstName = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $lastName = null;

--- a/src/Bundle/test/src/Entity/Book.php
+++ b/src/Bundle/test/src/Entity/Book.php
@@ -29,13 +29,16 @@ class Book implements ResourceInterface, TranslatableInterface
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $author = null;
@@ -52,6 +55,7 @@ class Book implements ResourceInterface, TranslatableInterface
      * @return string
      *
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\SerializedName("title")
      */
     public function getTitle()

--- a/src/Bundle/test/src/Entity/ComicBook.php
+++ b/src/Bundle/test/src/Entity/ComicBook.php
@@ -23,19 +23,23 @@ class ComicBook implements ResourceInterface
 {
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("integer")
+     *
      * @Serializer\XmlAttribute
      */
     private int $id;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Until("1.1")
      */
     private ?Author $author = null;
 
     /**
      * @Serializer\Expose
+     *
      * @Serializer\Type("string")
      */
     private ?string $title = null;
@@ -63,6 +67,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorFirstName(): ?string
@@ -72,6 +77,7 @@ class ComicBook implements ResourceInterface
 
     /**
      * @Serializer\VirtualProperty()
+     *
      * @Serializer\Since("1.1")
      */
     public function getAuthorLastName(): ?string

--- a/src/Component/Metadata/Create.php
+++ b/src/Component/Metadata/Create.php
@@ -23,8 +23,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Create extends HttpOperation implements CreateOperationInterface
             methods: $methods ?? ['GET', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'create',
             template: $template,
+            shortName: $shortName ?? 'create',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -23,8 +23,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             methods: $methods ?? ['DELETE'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'delete',
             template: $template,
+            shortName: $shortName ?? 'delete',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -22,14 +22,16 @@ class HttpOperation extends Operation
         protected ?array $methods = null,
         protected ?string $path = null,
         protected ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
         parent::__construct(
-            name: $name,
             template: $template,
+            name: $name,
+            shortName: $shortName,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Index.php
+++ b/src/Component/Metadata/Index.php
@@ -23,8 +23,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Index extends HttpOperation implements CollectionOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'index',
             template: $template,
+            shortName: $shortName ?? 'index',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -27,8 +27,9 @@ abstract class Operation
     protected $processor;
 
     public function __construct(
-        protected ?string $name = null,
         protected ?string $template = null,
+        protected ?string $shortName = null,
+        protected ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -49,6 +50,19 @@ abstract class Operation
         return $self;
     }
 
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function withTemplate(string $template): self
+    {
+        $self = clone $this;
+        $self->template = $template;
+
+        return $self;
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -62,15 +76,15 @@ abstract class Operation
         return $self;
     }
 
-    public function getTemplate(): ?string
+    public function getShortName(): ?string
     {
-        return $this->template;
+        return $this->shortName;
     }
 
-    public function withTemplate(string $template): self
+    public function withShortName(string $shortName): self
     {
         $self = clone $this;
-        $self->template = $template;
+        $self->shortName = $shortName;
 
         return $self;
     }

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -18,6 +18,8 @@ namespace Sylius\Component\Resource\Metadata;
  */
 abstract class Operation
 {
+    private ?Resource $resource = null;
+
     /** @var string|callable|null */
     protected $provider;
 
@@ -32,6 +34,19 @@ abstract class Operation
     ) {
         $this->provider = $provider;
         $this->processor = $processor;
+    }
+
+    public function getResource(): ?Resource
+    {
+        return $this->resource;
+    }
+
+    public function withResource(Resource $resource): self
+    {
+        $self = clone $this;
+        $self->resource = $resource;
+
+        return $self;
     }
 
     public function getName(): ?string

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -20,6 +20,9 @@ final class Resource
 
     public function __construct(
         private ?string $alias = null,
+        private ?string $section = null,
+        private ?string $name = null,
+        private ?string $applicationName = null,
         ?array $operations = null,
     ) {
         $this->operations = null === $operations ? null : new Operations($operations);
@@ -34,6 +37,45 @@ final class Resource
     {
         $self = clone $this;
         $self->alias = $alias;
+
+        return $self;
+    }
+
+    public function getSection(): ?string
+    {
+        return $this->section;
+    }
+
+    public function withSection(string $section): self
+    {
+        $self = clone $this;
+        $self->section = $section;
+
+        return $self;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function withName(string $name): self
+    {
+        $self = clone $this;
+        $self->name = $name;
+
+        return $self;
+    }
+
+    public function getApplicationName(): ?string
+    {
+        return $this->applicationName;
+    }
+
+    public function withApplicationName(string $applicationName): self
+    {
+        $self = clone $this;
+        $self->applicationName = $applicationName;
 
         return $self;
     }

--- a/src/Component/Metadata/Show.php
+++ b/src/Component/Metadata/Show.php
@@ -23,8 +23,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Show extends HttpOperation implements ShowOperationInterface
             methods: $methods ?? ['GET'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'show',
             template: $template,
+            shortName: $shortName ?? 'show',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -23,8 +23,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
         ?array $methods = null,
         ?string $path = null,
         ?string $routePrefix = null,
-        ?string $name = null,
         ?string $template = null,
+        ?string $shortName = null,
+        ?string $name = null,
         string|callable|null $provider = null,
         string|callable|null $processor = null,
     ) {
@@ -32,8 +33,9 @@ final class Update extends HttpOperation implements UpdateOperationInterface
             methods: $methods ?? ['GET', 'PUT'],
             path: $path,
             routePrefix: $routePrefix,
-            name: $name ?? 'update',
             template: $template,
+            shortName: $shortName ?? 'update',
+            name: $name,
             provider: $provider,
             processor: $processor,
         );

--- a/src/Component/Symfony/Routing/Factory/OperationRouteNameFactory.php
+++ b/src/Component/Symfony/Routing/Factory/OperationRouteNameFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Symfony\Routing\Factory;
+
+use Sylius\Component\Resource\Metadata\Operation;
+
+final class OperationRouteNameFactory
+{
+    public function createRouteName(Operation $operation, ?string $shortName = null): string
+    {
+        $resource = $operation->getResource();
+
+        if (null === $resource) {
+            throw new \RuntimeException(sprintf('No resource was found on the operation "%s"', $operation->getShortName() ?? ''));
+        }
+
+        $section = $resource->getSection();
+        $sectionPrefix = $section ? $section . '_' : '';
+
+        return sprintf(
+            '%s_%s%s_%s',
+            $resource->getApplicationName() ?? '',
+            $sectionPrefix,
+            $resource->getName() ?? '',
+            $shortName ?? $operation->getShortName() ?? '',
+        );
+    }
+}

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -51,9 +51,9 @@ final class CreateSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_create_name_by_default(): void
+    function it_has_create_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('create');
+        $this->getShortName()->shouldReturn('create');
     }
 
     function it_has_get_and_post_methods_by_default(): void

--- a/src/Component/spec/Metadata/CreateSpec.php
+++ b/src/Component/spec/Metadata/CreateSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class CreateSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class CreateSpec extends ObjectBehavior
     function it_implements_create_operation_interface(): void
     {
         $this->shouldImplement(CreateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_create_name_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -51,9 +51,9 @@ final class DeleteSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_delete_name_by_default(): void
+    function it_has_delete_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('delete');
+        $this->getShortName()->shouldReturn('delete');
     }
 
     function it_has_delete_methods_by_default(): void

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Delete;
 use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class DeleteSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class DeleteSpec extends ObjectBehavior
     function it_implements_delete_operation_interface(): void
     {
         $this->shouldImplement(DeleteOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_delete_name_by_default(): void

--- a/src/Component/spec/Metadata/HttpOperationSpec.php
+++ b/src/Component/spec/Metadata/HttpOperationSpec.php
@@ -90,7 +90,7 @@ final class HttpOperationSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith(null, null, null, 'create');
+        $this->beConstructedWith(null, null, null, null, null, 'create');
 
         $this->getName()->shouldReturn('create');
     }

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 
 final class IndexSpec extends ObjectBehavior
 {
@@ -33,6 +34,21 @@ final class IndexSpec extends ObjectBehavior
     function it_implements_collection_operation_interface(): void
     {
         $this->shouldImplement(CollectionOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_index_name_by_default(): void

--- a/src/Component/spec/Metadata/IndexSpec.php
+++ b/src/Component/spec/Metadata/IndexSpec.php
@@ -51,9 +51,9 @@ final class IndexSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_index_name_by_default(): void
+    function it_has_index_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('index');
+        $this->getShortName()->shouldReturn('index');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -39,6 +39,45 @@ final class ResourceSpec extends ObjectBehavior
         ;
     }
 
+    function it_has_no_section_by_default(): void
+    {
+        $this->getSection()->shouldReturn(null);
+    }
+
+    function it_could_have_a_section(): void
+    {
+        $this->withSection('admin')
+            ->getSection()
+            ->shouldReturn('admin')
+        ;
+    }
+
+    function it_has_no_name_by_default(): void
+    {
+        $this->getName()->shouldReturn(null);
+    }
+
+    function it_could_have_a_name(): void
+    {
+        $this->withName('book')
+            ->getName()
+            ->shouldReturn('book')
+        ;
+    }
+
+    function it_has_no_application_name_by_default(): void
+    {
+        $this->getApplicationName()->shouldReturn(null);
+    }
+
+    function it_could_have_an_application_name(): void
+    {
+        $this->withApplicationName('app')
+            ->getApplicationName()
+            ->shouldReturn('app')
+        ;
+    }
+
     function it_has_no_operations_by_default(): void
     {
         $this->getOperations()->shouldReturn(null);
@@ -61,11 +100,32 @@ final class ResourceSpec extends ObjectBehavior
         $this->getAlias()->shouldReturn('app.book');
     }
 
+    function it_can_be_constructed_with_a_section(): void
+    {
+        $this->beConstructedWith('app.book', 'admin');
+
+        $this->getSection()->shouldReturn('admin');
+    }
+
+    function it_can_be_constructed_with_a_name(): void
+    {
+        $this->beConstructedWith('app.book', null, 'book');
+
+        $this->getName()->shouldReturn('book');
+    }
+
+    function it_can_be_constructed_with_an_application_name(): void
+    {
+        $this->beConstructedWith('app.book', null, null, 'app');
+
+        $this->getApplicationName()->shouldReturn('app');
+    }
+
     function it_can_be_constructed_with_operations(): void
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith(null, $operations);
+        $this->beConstructedWith(null, null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Metadata\ShowOperationInterface;
 
@@ -33,6 +34,21 @@ final class ShowSpec extends ObjectBehavior
     function it_implements_show_operation_interface(): void
     {
         $this->shouldImplement(ShowOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_show_name_by_default(): void

--- a/src/Component/spec/Metadata/ShowSpec.php
+++ b/src/Component/spec/Metadata/ShowSpec.php
@@ -51,9 +51,9 @@ final class ShowSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_show_name_by_default(): void
+    function it_has_show_short_name_by_default(): void
     {
-        $this->getName()->shouldReturn('show');
+        $this->getShortName()->shouldReturn('show');
     }
 
     function it_has_get_methods_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -53,7 +53,7 @@ final class UpdateSpec extends ObjectBehavior
 
     function it_has_update_name_by_default(): void
     {
-        $this->getName()->shouldReturn('update');
+        $this->getShortName()->shouldReturn('update');
     }
 
     function it_has_get_and_put_methods_by_default(): void

--- a/src/Component/spec/Metadata/UpdateSpec.php
+++ b/src/Component/spec/Metadata/UpdateSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Update;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
@@ -33,6 +34,21 @@ final class UpdateSpec extends ObjectBehavior
     function it_implements_update_operation_interface(): void
     {
         $this->shouldImplement(UpdateOperationInterface::class);
+    }
+
+    function it_has_no_resource_by_default(): void
+    {
+        $this->getResource()->shouldReturn(null);
+    }
+
+    function it_could_have_a_resource(): void
+    {
+        $resource = new Resource();
+
+        $this->withResource($resource)
+            ->getResource()
+            ->shouldReturn($resource)
+        ;
     }
 
     function it_has_update_name_by_default(): void

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteNameFactorySpec.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Symfony\Routing\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+
+final class OperationRouteNameFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(OperationRouteNameFactory::class);
+    }
+
+    function it_create_a_route_name(): void
+    {
+        $resource = new Resource(name: 'book', applicationName: 'app');
+        $operation = (new Create())->withResource($resource);
+
+        $this->createRouteName($operation)->shouldReturn('app_book_create');
+    }
+
+    function it_create_a_route_name_with_a_section(): void
+    {
+        $resource = new Resource(name: 'book', applicationName: 'app', section: 'admin');
+        $operation = (new Create())->withResource($resource);
+
+        $this->createRouteName($operation)->shouldReturn('app_admin_book_create');
+    }
+
+    function it_throws_an_exception_when_operation_has_no_resource(): void
+    {
+        $operation = new Create();
+
+        $this->shouldThrow(new \RuntimeException('No resource was found on the operation "create"'))
+            ->during('createRouteName', [$operation])
+        ;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It will be used to build the default route name and default route redirections.
This factory will be used on the next PR #534 like this :

```php
            if (null === $routeName = $operation->getRouteName()) {
                $routeName = $this->operationRouteNameFactory->createRouteName($operation);
                $operation = $operation->withRouteName($routeName);
            }
```