### PR TITLE
Configure default responder

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,10 +29,12 @@ parameters:
 
     ignoreErrors:
         - '/Call to method getArguments\(\) on an unknown class ReflectionAttribute./'
+        - '/Call to method isChangeTrackingDeferredExplicit\(\) on an unknown class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata./'
         - '/Call to an undefined method ReflectionClass::getAttributes\(\)./'
         - '/Class Doctrine\\Bundle\\MongoDBBundle/'
         - '/Class Doctrine\\Bundle\\PHPCRBundle/'
         - '/Class Doctrine\\Common\\Persistence\\ObjectManager not found\./'
+        - '/Class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata not found\./'
         - '/Class Symfony\\Component\\ExpressionLanguage\\ParserCache\\ParserCacheInterface not found/'
         - '/Instantiated class Symfony\\Component\\ExpressionLanguage\\ParserCache\\ParserCacheAdapter not found/'
         - '/Method Symfony\\Component\\DependencyInjection\\Alias::setDeprecated\(\)/'
@@ -79,3 +81,4 @@ parameters:
         - '/Parameter #4 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\./'
         - '/Parameter #1 \$submittedData of method Symfony\\Component\\Form\\FormInterface::submit\(\) expects array\|string\|null, mixed given\./'
         - '/Parameter #2 \$callback of function preg_replace_callback expects callable\(array<int\|string, string>\): string, Closure\(array\): mixed given\./'
+        - '/Unable to resolve the template type T in call to method Doctrine\\Persistence\\ObjectManager::getClassMetadata\(\)/'

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,8 @@
     <issueHandlers>
         <ArgumentTypeCoercion>
             <errorLevel type="suppress">
+                <referencedFunction name="Doctrine\Persistence\ManagerRegistry::getManagerForClass" />
+                <referencedFunction name="Doctrine\Persistence\ObjectManager::getClassMetadata" />
                 <referencedFunction name="ReflectionClass::getAttributes" />
             </errorLevel>
         </ArgumentTypeCoercion>
@@ -122,6 +124,12 @@
             </errorLevel>
         </MoreSpecificImplementedParamType>
 
+        <PossiblyFalseOperand>
+            <errorLevel type="suppress">
+                <file name="src/Component/Reflection/ClassInfoTrait.php" />
+            </errorLevel>
+        </PossiblyFalseOperand>
+
         <PossiblyNullArgument>
             <errorLevel type="suppress">
                 <file name="src/Bundle/Grid/Parser/OptionsParser.php" />
@@ -176,6 +184,7 @@
                 <referencedClass name="Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass" />
                 <referencedClass name="Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappingsPass" />
                 <referencedClass name="Doctrine\Common\Persistence\ObjectManager" />
+                <referencedClass name="Doctrine\ODM\MongoDB\Mapping\ClassMetadata" />
                 <referencedClass name="Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheAdapter" />
                 <referencedClass name="Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface" />
             </errorLevel>

--- a/src/Component/Doctrine/Common/Metadata/Resource/Factory/DoctrineResourceMetadataCollectionFactory.php
+++ b/src/Component/Doctrine/Common/Metadata/Resource/Factory/DoctrineResourceMetadataCollectionFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Doctrine\Common\Metadata\Resource\Factory;
+
+use Sylius\Component\Resource\Doctrine\Common\State\PersistProcessor;
+use Sylius\Component\Resource\Doctrine\Common\State\RemoveProcessor;
+use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Operations;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
+use Sylius\Component\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+
+class DoctrineResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private RegistryInterface $resourceRegistry,
+        private ResourceMetadataCollectionFactoryInterface $decorated,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceCollectionMetadata = $this->decorated->create($resourceClass);
+
+        /** @var ResourceMetadata $resource */
+        foreach ($resourceCollectionMetadata->getIterator() as $i => $resource) {
+            $operations = $resource->getOperations() ?? new Operations();
+
+            /** @var Operation $operation */
+            foreach ($operations as $operation) {
+                /** @var string $key */
+                $key = $operation->getName();
+
+                $operations->add($key, $this->addDefaults($resource, $operation));
+            }
+
+            $resource = $resource->withOperations($operations);
+
+            $resourceCollectionMetadata[$i] = $resource;
+        }
+
+        return $resourceCollectionMetadata;
+    }
+
+    private function addDefaults(ResourceMetadata $resource, Operation $operation): Operation
+    {
+        $metadata = $this->resourceRegistry->get($resource->getAlias());
+
+        if (str_starts_with($metadata->getDriver(), 'doctrine/')) {
+            $operation = $operation->withProcessor($this->getProcessor($operation));
+        }
+
+        return $operation;
+    }
+
+    private function getProcessor(Operation $operation): callable|string
+    {
+        if (null !== $processor = $operation->getProcessor()) {
+            return $processor;
+        }
+
+        if ($operation instanceof DeleteOperationInterface) {
+            return RemoveProcessor::class;
+        }
+
+        return PersistProcessor::class;
+    }
+}

--- a/src/Component/Doctrine/Common/State/PersistProcessor.php
+++ b/src/Component/Doctrine/Common/State/PersistProcessor.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Doctrine\Common\State;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager as DoctrineObjectManager;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Reflection\ClassInfoTrait;
+use Sylius\Component\Resource\State\ProcessorInterface;
+
+final class PersistProcessor implements ProcessorInterface
+{
+    use ClassInfoTrait;
+
+    public function __construct(private ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, Context $context): mixed
+    {
+        if (!is_object($data) || !$manager = $this->getManager($data)) {
+            return $data;
+        }
+
+        if (!$manager->contains($data) || $this->isDeferredExplicit($manager, $data)) {
+            $manager->persist($data);
+        }
+
+        $manager->flush();
+        $manager->refresh($data);
+
+        return $data;
+    }
+
+    /**
+     * Gets the Doctrine object manager associated with given data.
+     */
+    private function getManager(object $data): ?DoctrineObjectManager
+    {
+        return $this->managerRegistry->getManagerForClass($this->getObjectClass($data));
+    }
+
+    /**
+     * Checks if doctrine does not manage data automatically.
+     */
+    private function isDeferredExplicit(DoctrineObjectManager $manager, object $data): bool
+    {
+        $classMetadata = $manager->getClassMetadata($this->getObjectClass($data));
+        if (($classMetadata instanceof ClassMetadataInfo || $classMetadata instanceof ClassMetadata) && method_exists($classMetadata, 'isChangeTrackingDeferredExplicit')) {
+            return $classMetadata->isChangeTrackingDeferredExplicit();
+        }
+
+        return false;
+    }
+}

--- a/src/Component/Doctrine/Common/State/RemoveProcessor.php
+++ b/src/Component/Doctrine/Common/State/RemoveProcessor.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Doctrine\Common\State;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager as DoctrineObjectManager;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Reflection\ClassInfoTrait;
+use Sylius\Component\Resource\State\ProcessorInterface;
+
+final class RemoveProcessor implements ProcessorInterface
+{
+    use ClassInfoTrait;
+
+    public function __construct(private ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, Context $context): mixed
+    {
+        if (!\is_object($data) || !$manager = $this->getManager($data)) {
+            return null;
+        }
+
+        $manager->remove($data);
+        $manager->flush();
+
+        return null;
+    }
+
+    /**
+     * Gets the Doctrine object manager associated with given data.
+     */
+    private function getManager(object $data): ?DoctrineObjectManager
+    {
+        return $this->managerRegistry->getManagerForClass($this->getObjectClass($data));
+    }
+}

--- a/src/Component/Metadata/Create.php
+++ b/src/Component/Metadata/Create.php
@@ -35,6 +35,7 @@ final class Create extends HttpOperation implements CreateOperationInterface
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             methods: $methods ?? ['GET', 'POST'],
@@ -52,6 +53,7 @@ final class Create extends HttpOperation implements CreateOperationInterface
             write: $write,
             formType: $formType,
             formOptions: $formOptions,
+            redirectToRoute: $redirectToRoute,
         );
     }
 }

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -35,6 +35,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             methods: $methods ?? ['DELETE'],
@@ -52,6 +53,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             write: $write,
             formType: $formType,
             formOptions: $formOptions,
+            redirectToRoute: $redirectToRoute,
         );
     }
 }

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -35,6 +35,7 @@ class HttpOperation extends Operation
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        protected ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             template: $template,
@@ -100,6 +101,19 @@ class HttpOperation extends Operation
     {
         $self = clone $this;
         $self->routePrefix = $routePrefix;
+
+        return $self;
+    }
+
+    public function getRedirectToRoute(): ?string
+    {
+        return $this->redirectToRoute;
+    }
+
+    public function withRedirectToRoute(string $redirectToRoute): self
+    {
+        $self = clone $this;
+        $self->redirectToRoute = $redirectToRoute;
 
         return $self;
     }

--- a/src/Component/Metadata/Index.php
+++ b/src/Component/Metadata/Index.php
@@ -35,6 +35,7 @@ final class Index extends HttpOperation implements CollectionOperationInterface
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             methods: $methods ?? ['GET'],
@@ -52,6 +53,7 @@ final class Index extends HttpOperation implements CollectionOperationInterface
             write: $write,
             formType: $formType,
             formOptions: $formOptions,
+            redirectToRoute: $redirectToRoute,
         );
     }
 }

--- a/src/Component/Metadata/Operation.php
+++ b/src/Component/Metadata/Operation.php
@@ -45,6 +45,8 @@ abstract class Operation
         protected ?bool $write = null,
         protected ?string $formType = null,
         protected ?array $formOptions = null,
+        protected ?string $resourceName = null,
+        protected ?string $resourcePluralName = null,
     ) {
         $this->provider = $provider;
         $this->processor = $processor;

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -24,6 +24,7 @@ final class Resource
         private ?string $formType = null,
         private ?string $templatesDir = null,
         private ?string $name = null,
+        private ?string $pluralName = null,
         private ?string $applicationName = null,
         ?array $operations = null,
     ) {
@@ -69,6 +70,19 @@ final class Resource
         return $self;
     }
 
+    public function getTemplatesDir(): ?string
+    {
+        return $this->templatesDir;
+    }
+
+    public function withTemplatesDir(string $templatesDir): self
+    {
+        $self = clone $this;
+        $self->templatesDir = $templatesDir;
+
+        return $self;
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -82,6 +96,19 @@ final class Resource
         return $self;
     }
 
+    public function getPluralName(): ?string
+    {
+        return $this->pluralName;
+    }
+
+    public function withPluralName(string $pluralName): self
+    {
+        $self = clone $this;
+        $self->pluralName = $pluralName;
+
+        return $self;
+    }
+
     public function getApplicationName(): ?string
     {
         return $this->applicationName;
@@ -91,19 +118,6 @@ final class Resource
     {
         $self = clone $this;
         $self->applicationName = $applicationName;
-
-        return $self;
-    }
-
-    public function getTemplatesDir(): ?string
-    {
-        return $this->templatesDir;
-    }
-
-    public function withTemplatesDir(string $templatesDir): self
-    {
-        $self = clone $this;
-        $self->templatesDir = $templatesDir;
 
         return $self;
     }
@@ -133,5 +147,19 @@ final class Resource
         $self->operations = $operations;
 
         return $self;
+    }
+
+    public function getRouteName(string $shortName): string
+    {
+        $section = $this->getSection();
+        $sectionPrefix = $section ? $section . '_' : '';
+
+        return sprintf(
+            '%s_%s%s_%s',
+            $this->getApplicationName() ?? '',
+            $sectionPrefix,
+            $this->getName() ?? '',
+            $shortName,
+        );
     }
 }

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -22,6 +22,7 @@ use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
 use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Component\Resource\Reflection\ClassReflection;
 use Sylius\Component\Resource\Symfony\Request\State\Provider;
+use Sylius\Component\Resource\Symfony\Request\State\TwigResponder;
 use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
 
 final class AttributesResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
@@ -170,6 +171,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
 
             if (null === $operation->getProvider()) {
                 $operation = $operation->withProvider(Provider::class);
+            }
+
+            if (null === $operation->getResponder()) {
+                $operation = $operation->withResponder(TwigResponder::class);
             }
 
             $operation = $operation->withName($routeName);

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -60,6 +60,8 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             if (is_a($attribute->getName(), ResourceMetadata::class, true)) {
                 /** @var ResourceMetadata $resource */
                 $resource = $attribute->newInstance();
+                $resourceConfiguration = $this->resourceRegistry->get($resource->getAlias());
+                $resource = $this->getResourceWithDefaults($resource, $resourceConfiguration);
                 $resources[++$index] = $resource;
                 $operations = [];
 
@@ -123,18 +125,24 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
     {
         $resourceConfiguration = $this->resourceRegistry->get($resource->getAlias());
 
+        if (null === $resource->getName()) {
+            $resourceName = $resourceConfiguration->getName();
+
+            $resource = $resource->withName($resourceName);
+            $operation = $operation->withResource($resource);
+        }
+
+        if (null === $resource->getPluralName()) {
+            $resourcePluralName = $resourceConfiguration->getPluralName();
+
+            $resource = $resource->withPluralName($resourcePluralName);
+            $operation = $operation->withResource($resource);
+        }
+
         if (null === $operation->getTemplate()) {
             $templateDir = $resource->getTemplatesDir() ?? '';
             $template = sprintf('%s/%s.html.twig', $templateDir, $operation->getShortName() ?? '');
             $operation = $operation->withTemplate($template);
-        }
-
-        if (null === $resource->getApplicationName()) {
-            $resource = $resource->withApplicationName($resourceConfiguration->getApplicationName());
-        }
-
-        if (null === $resource->getName()) {
-            $resource = $resource->withName($resourceConfiguration->getName());
         }
 
         $operation = $operation->withResource($resource);

--- a/src/Component/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactory.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Metadata\Resource\Factory;
+
+use Sylius\Component\Resource\Metadata\CreateOperationInterface;
+use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
+use Sylius\Component\Resource\Metadata\HttpOperation;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\Operations;
+use Sylius\Component\Resource\Metadata\Resource as ResourceMetadata;
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
+use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+
+final class RedirectResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private OperationRouteNameFactory $operationRouteNameFactory,
+        private ResourceMetadataCollectionFactoryInterface $decorated,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceCollectionMetadata = $this->decorated->create($resourceClass);
+
+        /** @var ResourceMetadata $resource */
+        foreach ($resourceCollectionMetadata->getIterator() as $i => $resource) {
+            $operations = $resource->getOperations() ?? new Operations();
+
+            /** @var Operation $operation */
+            foreach ($operations as $operation) {
+                if (!$operation instanceof HttpOperation) {
+                    continue;
+                }
+
+                /** @var string $key */
+                $key = $operation->getName();
+
+                $operations->add($key, $this->addDefaults($resource, $operation));
+            }
+
+            $resource = $resource->withOperations($operations);
+
+            $resourceCollectionMetadata[$i] = $resource;
+        }
+
+        return $resourceCollectionMetadata;
+    }
+
+    private function addDefaults(ResourceMetadata $resource, HttpOperation $operation): Operation
+    {
+        if (null !== $operation->getRedirectToRoute()) {
+            return $operation;
+        }
+
+        if ($operation instanceof CreateOperationInterface || $operation instanceof UpdateOperationInterface) {
+            $newOperation = $this->setRedirectIfRouteExists($resource, $operation, 'show');
+
+            if (null !== $newOperation) {
+                return $newOperation;
+            }
+
+            $newOperation = $this->setRedirectIfRouteExists($resource, $operation, 'index');
+
+            if (null !== $newOperation) {
+                return $newOperation;
+            }
+        }
+
+        if ($operation instanceof DeleteOperationInterface) {
+            $newOperation = $this->setRedirectIfRouteExists($resource, $operation, 'index');
+
+            if (null !== $newOperation) {
+                return $newOperation;
+            }
+        }
+
+        return $operation;
+    }
+
+    private function setRedirectIfRouteExists(ResourceMetadata $resource, HttpOperation $operation, string $shortName): ?Operation
+    {
+        $routeName = $this->operationRouteNameFactory->createRouteName($operation, $shortName);
+
+        if ($resource->hasOperation($routeName)) {
+            return $operation->withRedirectToRoute($routeName);
+        }
+
+        return null;
+    }
+}

--- a/src/Component/Metadata/Show.php
+++ b/src/Component/Metadata/Show.php
@@ -35,6 +35,7 @@ final class Show extends HttpOperation implements ShowOperationInterface
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             methods: $methods ?? ['GET'],
@@ -52,6 +53,7 @@ final class Show extends HttpOperation implements ShowOperationInterface
             write: $write,
             formType: $formType,
             formOptions: $formOptions,
+            redirectToRoute: $redirectToRoute,
         );
     }
 }

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -35,6 +35,7 @@ final class Update extends HttpOperation implements UpdateOperationInterface
         ?bool $write = null,
         ?string $formType = null,
         ?array $formOptions = null,
+        ?string $redirectToRoute = null,
     ) {
         parent::__construct(
             methods: $methods ?? ['GET', 'PUT'],
@@ -52,6 +53,7 @@ final class Update extends HttpOperation implements UpdateOperationInterface
             write: $write,
             formType: $formType,
             formOptions: $formOptions,
+            redirectToRoute: $redirectToRoute,
         );
     }
 }

--- a/src/Component/Reflection/ClassInfoTrait.php
+++ b/src/Component/Reflection/ClassInfoTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Reflection;
+
+/**
+ * Retrieves information about a class.
+ *
+ * @internal
+ */
+trait ClassInfoTrait
+{
+    /**
+     * Get class name of the given object.
+     */
+    private function getObjectClass(object $object): string
+    {
+        return $this->getRealClassName($object::class);
+    }
+
+    /**
+     * Get the real class name of a class name that could be a proxy.
+     */
+    private function getRealClassName(string $className): string
+    {
+        // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
+        // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
+        $positionCg = strrpos($className, '\\__CG__\\');
+        $positionPm = strrpos($className, '\\__PM__\\');
+
+        if (false === $positionCg && false === $positionPm) {
+            return $className;
+        }
+
+        if (false !== $positionCg) {
+            return substr($className, $positionCg + 8);
+        }
+
+        $className = ltrim($className, '\\');
+
+        return substr(
+            $className,
+            8 + $positionPm,
+            strrpos($className, '\\') - ($positionPm + 8),
+        );
+    }
+}

--- a/src/Component/Symfony/EventListener/ValidateListener.php
+++ b/src/Component/Symfony/EventListener/ValidateListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Symfony\EventListener;
+
+use Sylius\Component\Resource\Metadata\CreateOperationInterface;
+use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
+use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+
+final class ValidateListener
+{
+    public function __construct(
+        private HttpOperationInitiator $operationInitiator,
+    ) {
+    }
+
+    public function onKernelView(ViewEvent $event): void
+    {
+        $controllerResult = $event->getControllerResult();
+        $request = $event->getRequest();
+
+        /** @var FormInterface|null $form */
+        $form = $request->attributes->get('form');
+
+        $request = $event->getRequest();
+        $operation = $this->operationInitiator->initializeOperation($request);
+
+        if (
+            $controllerResult instanceof Response ||
+            !($operation instanceof CreateOperationInterface || $operation instanceof UpdateOperationInterface) ||
+            null === $form
+        ) {
+            return;
+        }
+
+        if (
+            !$request->isMethodSafe() &&
+            $form->isSubmitted() &&
+            $form->isValid()
+        ) {
+            $request->attributes->set('is_valid', true);
+            $event->setControllerResult($form->getData());
+
+            return;
+        }
+
+        $request->attributes->set('is_valid', false);
+    }
+}

--- a/src/Component/Symfony/EventListener/WriteListener.php
+++ b/src/Component/Symfony/EventListener/WriteListener.php
@@ -37,7 +37,9 @@ final class WriteListener
 
         if (
             null === $operation ||
-            !($operation->canWrite() ?? true)
+            !($operation->canWrite() ?? true) ||
+            $request->isMethodSafe() ||
+            !$request->attributes->getBoolean('is_valid', true)
         ) {
             return;
         }

--- a/src/Component/Symfony/Request/State/TwigResponder.php
+++ b/src/Component/Symfony/Request/State/TwigResponder.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Symfony\Request\State;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\RequestOption;
+use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
+use Sylius\Component\Resource\Metadata\CreateOperationInterface;
+use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
+use Sylius\Component\Resource\Metadata\HttpOperation;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
+use Sylius\Component\Resource\State\ResponderInterface;
+use Sylius\Component\Resource\Symfony\Routing\RedirectHandler;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+
+final class TwigResponder implements ResponderInterface
+{
+    public function __construct(
+        private RedirectHandler $redirectHandler,
+        private ?Environment $twig,
+    ) {
+    }
+
+    public function respond(mixed $data, Operation $operation, Context $context): ?Response
+    {
+        $request = $context->get(RequestOption::class)?->request();
+
+        if (null === $this->twig) {
+            throw new \LogicException('You can not use the "Twig" if it is not available. Try running "composer require twig".');
+        }
+
+        if (null === $request) {
+            return null;
+        }
+
+        $isValid = $request->attributes->getBoolean('is_valid', true);
+
+        if ($operation instanceof DeleteOperationInterface && $operation instanceof HttpOperation) {
+            return $this->redirectHandler->redirectToResource($data, $operation, $request);
+            //return $this->redirectHandler->redirectToIndex($data, $operation, $request);
+        }
+
+        if (
+            $isValid &&
+            $operation instanceof HttpOperation &&
+            ($operation instanceof UpdateOperationInterface || $operation instanceof CreateOperationInterface)
+        ) {
+            return $this->redirectHandler->redirectToResource($data, $operation, $request);
+        }
+
+        $content = $this->twig->render(
+            $operation->getTemplate() ?? '',
+            $this->getTwigContext($data, $operation, $request),
+        );
+
+        return new Response($content);
+    }
+
+    private function getTwigContext(mixed $data, Operation $operation, Request $request): array
+    {
+        $context = ['operation' => $operation];
+
+        /** @var FormInterface|null $form */
+        $form = $request->attributes->get('form');
+
+        if (null !== $form) {
+            $context['form'] = $form->createView();
+        }
+
+        if ($operation instanceof CollectionOperationInterface) {
+            $context['resources'] = $data;
+            $context[$operation->getResource()?->getPluralName() ?? ''] = $data;
+        } else {
+            $context['resource'] = $data;
+            $context[$operation->getResource()?->getName() ?? ''] = $data;
+        }
+
+        return $context;
+    }
+}

--- a/src/Component/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/Symfony/Routing/RedirectHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Symfony\Routing;
+
+use Sylius\Component\Resource\Metadata\HttpOperation;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Routing\RouterInterface;
+
+final class RedirectHandler
+{
+    public function __construct(private RouterInterface $router)
+    {
+    }
+
+    public function redirectToResource(mixed $data, HttpOperation $operation, Request $request): RedirectResponse
+    {
+        $route = $operation->getRedirectToRoute();
+
+        if (null === $route) {
+            throw new \RuntimeException(sprintf('Operation "%s" has no redirection route, but it should.', $operation->getName() ?? ''));
+        }
+
+        $parameters = $this->parseResourceValues([], $data);
+
+        return $this->redirectToRoute($data, $operation, $route, $parameters);
+    }
+
+    public function redirectToRoute(mixed $data, HttpOperation $operation, string $route, array $parameters = []): RedirectResponse
+    {
+        return new RedirectResponse($this->router->generate($route, $parameters));
+    }
+
+    private function parseResourceValues(array $parameters, mixed $data): array
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        if (empty($parameters)) {
+            if (\is_object($data) && $accessor->isReadable($data, 'id')) {
+                return ['id' => $accessor->getValue($data, 'id')];
+            }
+        }
+
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                $parameters[$key] = $this->parseResourceValues($value, $data);
+            }
+
+            if (is_string($value) && str_starts_with($value, 'resource.')) {
+                $parameters[$key] = $accessor->getValue($data, substr($value, 9));
+            }
+        }
+
+        return $parameters;
+    }
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithName.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithName.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy', name: 'book')]
+#[Create]
+#[Update]
+#[Index]
+#[Show]
+final class DummyResourceWithName
+{
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithPluralName.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithPluralName.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy', pluralName: 'books')]
+#[Create]
+#[Update]
+#[Index]
+#[Show]
+final class DummyResourceWithPluralName
+{
+}

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -37,12 +37,14 @@
         "symfony/http-foundation": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/property-access": "^5.4 || ^6.0",
+        "symfony/routing": "^5.4 || ^6.0",
         "winzou/state-machine": "^0.4"
     },
     "require-dev": {
         "behat/transliterator": "^1.3",
         "phpspec/phpspec": "^7.2",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "twig/twig": "^2.12 || ^3.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -26,6 +26,7 @@ use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Metadata\Update;
 use Sylius\Component\Resource\Symfony\Request\State\Provider;
+use Sylius\Component\Resource\Symfony\Request\State\TwigResponder;
 use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
 use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyOperationsWithoutResource;
@@ -510,5 +511,44 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
 
         $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
         $operation->getProvider()->shouldReturn(Provider::class);
+    }
+
+    function it_creates_resource_metadata_with_default_twig_provider_on_http_operations(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithTemplatesDir::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->getResponder()->shouldReturn(TwigResponder::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->getResponder()->shouldReturn(TwigResponder::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->getResponder()->shouldReturn(TwigResponder::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->getResponder()->shouldReturn(TwigResponder::class);
     }
 }

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -31,7 +31,9 @@ use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyOperationsWithoutResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithFormType;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithName;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithPluralName;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSections;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSectionsAndNestedOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithTemplatesDir;
@@ -391,6 +393,84 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
         $operation->getMethods()->shouldReturn(['GET']);
         $operation->getRepository()->shouldReturn('app.repository.dummy');
         $operation->getTemplate()->shouldReturn('book/show.html.twig');
+    }
+
+    function it_creates_resource_metadata_with_resource_name(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithName::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_book_create')->shouldReturn(true);
+        $operations->has('app_book_update')->shouldReturn(true);
+        $operations->has('app_book_index')->shouldReturn(true);
+        $operations->has('app_book_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_book_create');
+        $operation->getResource()->getName()->shouldReturn('book');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_book_update');
+        $operation->getResource()->getName()->shouldReturn('book');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_book_index');
+        $operation->getResource()->getName()->shouldReturn('book');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_book_show');
+        $operation->getResource()->getName()->shouldReturn('book');
+    }
+
+    function it_creates_resource_metadata_with_resource_plural_name(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithPluralName::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->getResource()->getPluralName()->shouldReturn('books');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->getResource()->getPluralName()->shouldReturn('books');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->getResource()->getPluralName()->shouldReturn('books');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->getResource()->getPluralName()->shouldReturn('books');
     }
 
     function it_creates_resource_metadata_with_default_provider_on_http_operations(RegistryInterface $resourceRegistry): void

--- a/src/Component/spec/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactorySpec.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Metadata\Resource\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Delete;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Operations;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Resource\Factory\RedirectResourceMetadataCollectionFactory;
+use Sylius\Component\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Sylius\Component\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+use Sylius\Component\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+
+final class RedirectResourceMetadataCollectionFactorySpec extends ObjectBehavior
+{
+    function let(ResourceMetadataCollectionFactoryInterface $decorated): void
+    {
+        $this->beConstructedWith(new OperationRouteNameFactory(), $decorated);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RedirectResourceMetadataCollectionFactory::class);
+    }
+
+    function it_redirects_create_to_show_if_route_exists(
+        ResourceMetadataCollectionFactoryInterface $decorated,
+    ): void {
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
+
+        $create = (new Create(name: 'app_book_create'))->withResource($resource);
+        $show = (new Show(name: 'app_book_show'))->withResource($resource);
+
+        $resource = $resource->withOperations(new Operations([
+            $create->getName() => $create,
+            $show->getName() => $show,
+        ]));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $decorated->create('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $this->create('App\Resource');
+
+        $create = $resourceMetadataCollection->getOperation('app.book', 'app_book_create');
+        $create->getRedirectToRoute()->shouldReturn('app_book_show');
+    }
+
+    function it_redirects_create_to_index_if_route_exists(
+        ResourceMetadataCollectionFactoryInterface $decorated,
+    ): void {
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
+
+        $create = (new Create(name: 'app_book_create'))->withResource($resource);
+        $index = (new Create(name: 'app_book_index'))->withResource($resource);
+
+        $resource = $resource->withOperations(new Operations([
+            $create->getName() => $create,
+            $index->getName() => $index,
+        ]));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $decorated->create('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $this->create('App\Resource');
+
+        $create = $resourceMetadataCollection->getOperation('app.book', 'app_book_create');
+        $create->getRedirectToRoute()->shouldReturn('app_book_index');
+    }
+
+    function it_redirects_update_to_show_if_route_exists(
+        ResourceMetadataCollectionFactoryInterface $decorated,
+    ): void {
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
+
+        $update = (new Update(name: 'app_book_update'))->withResource($resource);
+        $show = (new Show(name: 'app_book_show'))->withResource($resource);
+
+        $resource = $resource->withOperations(new Operations([
+            $update->getName() => $update,
+            $show->getName() => $show,
+        ]));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $decorated->create('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $this->create('App\Resource');
+
+        $update = $resourceMetadataCollection->getOperation('app.book', 'app_book_update');
+        $update->getRedirectToRoute()->shouldReturn('app_book_show');
+    }
+
+    function it_redirects_update_to_index_if_route_exists(
+        ResourceMetadataCollectionFactoryInterface $decorated,
+    ): void {
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
+
+        $update = (new Update(name: 'app_book_update'))->withResource($resource);
+        $index = (new Index(name: 'app_book_index'))->withResource($resource);
+
+        $resource = $resource->withOperations(new Operations([
+            $update->getName() => $update,
+            $index->getName() => $index,
+        ]));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $decorated->create('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $this->create('App\Resource');
+
+        $update = $resourceMetadataCollection->getOperation('app.book', 'app_book_update');
+        $update->getRedirectToRoute()->shouldReturn('app_book_index');
+    }
+
+    function it_redirects_delete_to_index_if_route_exists(
+        ResourceMetadataCollectionFactoryInterface $decorated,
+    ): void {
+        $resource = new Resource(alias: 'app.book', name: 'book', applicationName: 'app');
+
+        $delete = (new Delete(name: 'app_book_delete'))->withResource($resource);
+        $index = (new Show(name: 'app_book_index'))->withResource($resource);
+
+        $resource = $resource->withOperations(new Operations([
+            $delete->getName() => $delete,
+            $index->getName() => $index,
+        ]));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $decorated->create('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $this->create('App\Resource');
+
+        $delete = $resourceMetadataCollection->getOperation('app.book', 'app_book_delete');
+        $delete->getRedirectToRoute()->shouldReturn('app_book_index');
+    }
+}

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -121,7 +121,7 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_an_application_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, null, null, 'app');
+        $this->beConstructedWith('app.book', null, null, null, null, null, 'app');
 
         $this->getApplicationName()->shouldReturn('app');
     }
@@ -140,11 +140,18 @@ final class ResourceSpec extends ObjectBehavior
         $this->getTemplatesDir()->shouldReturn('book');
     }
 
+    function it_can_be_constructed_with_a_plural_name(): void
+    {
+        $this->beConstructedWith('app.book', null, null, null, null, 'books');
+
+        $this->getPluralName()->shouldReturn('books');
+    }
+
     function it_can_be_constructed_with_operations(): void
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith('app.book', null, null, null, null, null, $operations);
+        $this->beConstructedWith('app.book', null, null, null, null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }

--- a/src/Component/spec/Symfony/Request/State/TwigResponderSpec.php
+++ b/src/Component/spec/Symfony/Request/State/TwigResponderSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Symfony\Request\State;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\RequestOption;
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Symfony\Request\State\TwigResponder;
+use Sylius\Component\Resource\Symfony\Routing\RedirectHandler;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+
+final class TwigResponderSpec extends ObjectBehavior
+{
+    function let(Environment $twig, RouterInterface $router): void
+    {
+        $this->beConstructedWith(new RedirectHandler($router->getWrappedObject()), $twig);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(TwigResponder::class);
+    }
+
+    function it_returns_a_response_for_resource_show(
+        \stdClass $data,
+        Request $request,
+        ParameterBag $attributes,
+        Environment $twig,
+    ): void {
+        $request->attributes = $attributes;
+
+        $attributes->getBoolean('is_valid', true)->willReturn(true)->shouldBeCalled();
+        $attributes->get('form')->willReturn(null);
+
+        $resource = new Resource(alias: 'app.book', name: 'book');
+        $operation = (new Show(template: 'book/show.html.twig'))->withResource($resource);
+
+        $twig->render('book/show.html.twig', [
+            'operation' => $operation,
+            'resource' => $data->getWrappedObject(),
+            'book' => $data->getWrappedObject(),
+        ])->willReturn('result')->shouldBeCalled();
+
+        $this->respond($data, $operation, new Context(new RequestOption($request->getWrappedObject())));
+    }
+
+    function it_returns_a_response_for_resource_index(
+        \ArrayObject $data,
+        Request $request,
+        ParameterBag $attributes,
+        Environment $twig,
+    ): void {
+        $request->attributes = $attributes;
+
+        $attributes->getBoolean('is_valid', true)->willReturn(true)->shouldBeCalled();
+        $attributes->get('form')->willReturn(null);
+
+        $resource = new Resource(alias: 'app.book', pluralName: 'books');
+        $operation = (new Index(template: 'book/index.html.twig'))->withResource($resource);
+
+        $twig->render('book/index.html.twig', [
+            'operation' => $operation,
+            'resources' => $data->getWrappedObject(),
+            'books' => $data->getWrappedObject(),
+        ])->willReturn('result')->shouldBeCalled();
+
+        $this->respond($data, $operation, new Context(new RequestOption($request->getWrappedObject())));
+    }
+
+    function it_redirect_to_route_after_creation(
+        \ArrayObject $data,
+        Request $request,
+        ParameterBag $attributes,
+        RouterInterface $router,
+    ): void {
+        $request->attributes = $attributes;
+
+        $attributes->getBoolean('is_valid', true)->willReturn(true)->shouldBeCalled();
+
+        $operation = new Create(redirectToRoute: 'app_dummy_index');
+
+        $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
+
+        $response = $this->respond($data, $operation, new Context(new RequestOption($request->getWrappedObject())));
+        $response->shouldHaveType(RedirectResponse::class);
+        $response->getTargetUrl()->shouldReturn('/dummies');
+    }
+}

--- a/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
+++ b/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Symfony\Routing;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Symfony\Routing\RedirectHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+
+final class RedirectHandlerSpec extends ObjectBehavior
+{
+    function let(RouterInterface $router): void
+    {
+        $this->beConstructedWith($router);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RedirectHandler::class);
+    }
+
+    function it_redirects_to_resource(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+    ): void {
+        $operation = new Create(redirectToRoute: 'app_dummy_index');
+
+        $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
+
+        $this->redirectToResource($data, $operation, $request);
+    }
+
+    function it_redirects_to_route(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+    ): void {
+        $operation = new Create();
+
+        $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
+
+        $this->redirectToRoute($data, $operation, 'app_dummy_index');
+    }
+
+    function it_throws_an_exception_when_operation_has_no_route_redirection(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+    ): void {
+        $operation = new Create(name: 'app_dummy_create');
+
+        $router->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $this->shouldThrow(
+            new \RuntimeException('Operation "app_dummy_create" has no redirection route, but it should.'),
+        )->during('redirectToResource', [$data, $operation, $request]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

With the previous PR #583, we can configure a responder on any operations.
With this PR, we configure the Twig responder as default one for Http operations.

```php
#[Resource(
    alias: 'app.book',
    section: 'admin',
    formType: BookType::class,
    templatesDir: 'book',
    operations: [
        new Index(
            // responder: TwigResponder::class,
        )
    ]
),
```