### PR TITLE
Twig context factory

### DIFF
--- a/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
+++ b/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Context\Initiator;
+
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfigurationFactoryInterface;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LegacyRequestContextInitiator implements RequestContextInitiatorInterface
+{
+    public function __construct(
+        private RegistryInterface $resourceRegistry,
+        private RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        private RequestContextInitiatorInterface $decorated,
+    ) {
+    }
+
+    public function initializeContext(Request $request): Context
+    {
+        $context = $this->decorated->initializeContext($request);
+
+        if ([] === $attributes = $request->attributes->all('_sylius')) {
+            return $context;
+        }
+
+        if (null === ($resource = $attributes['resource'] ?? null)) {
+            return $context;
+        }
+
+        if (str_contains($resource, '.')) {
+            $metadata = $this->resourceRegistry->get($resource);
+        } else {
+            $metadata = $this->resourceRegistry->getByClass($resource);
+        }
+
+        $configuration = $this->requestConfigurationFactory->create($metadata, $request);
+
+        return $context->with(new MetadataOption($metadata), new RequestConfigurationOption($configuration));
+    }
+}

--- a/src/Bundle/Context/Option/RequestConfigurationOption.php
+++ b/src/Bundle/Context/Option/RequestConfigurationOption.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Context\Option;
+
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+
+final class RequestConfigurationOption
+{
+    public function __construct(private RequestConfiguration $requestConfiguration)
+    {
+    }
+
+    public function requestConfiguration(): RequestConfiguration
+    {
+        return $this->requestConfiguration;
+    }
+}

--- a/src/Bundle/Grid/View/LegacyGridViewFactory.php
+++ b/src/Bundle/Grid/View/LegacyGridViewFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Grid\View;
+
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Grid\View\GridView;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Grid\View\Factory\GridViewFactoryInterface;
+
+final class LegacyGridViewFactory implements GridViewFactoryInterface
+{
+    public function __construct(
+        private ResourceGridViewFactoryInterface $resourceGridViewFactory,
+        private GridViewFactoryInterface $decorated,
+    ) {
+    }
+
+    public function create(
+        Grid $grid,
+        Context $context,
+        Parameters $parameters,
+        array $driverConfiguration,
+    ): ResourceGridView|GridView {
+        $requestConfiguration = $context->get(RequestConfigurationOption::class)?->requestConfiguration();
+        $metadata = $context->get(MetadataOption::class)?->metadata();
+
+        if (null === $requestConfiguration || null === $metadata) {
+            return $this->decorated->create($grid, $context, $parameters, $driverConfiguration);
+        }
+
+        return $this->resourceGridViewFactory->create($grid, $parameters, $metadata, $requestConfiguration);
+    }
+}

--- a/src/Bundle/Twig/Context/LegacyContextFactory.php
+++ b/src/Bundle/Twig/Context/LegacyContextFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Twig\Context;
+
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface;
+
+final class LegacyContextFactory implements ContextFactoryInterface
+{
+    public function __construct(private ContextFactoryInterface $decorated)
+    {
+    }
+
+    public function create(mixed $data, Operation $operation, Context $context): array
+    {
+        $twigContext = $this->decorated->create($data, $operation, $context);
+
+        $requestConfiguration = $context->get(RequestConfigurationOption::class)?->requestConfiguration();
+        $metadata = $context->get(MetadataOption::class)?->metadata();
+
+        if (null !== $requestConfiguration) {
+            $twigContext['configuration'] = $requestConfiguration;
+        }
+
+        if (null !== $metadata) {
+            $twigContext['metadata'] = $metadata;
+        }
+
+        return $twigContext;
+    }
+}

--- a/src/Bundle/spec/Context/Initiator/LegacyRequestContextInitiatorSpec.php
+++ b/src/Bundle/spec/Context/Initiator/LegacyRequestContextInitiatorSpec.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ResourceBundle\Context\Initiator;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\Context\Initiator\LegacyRequestContextInitiator;
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfigurationFactoryInterface;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LegacyRequestContextInitiatorSpec extends ObjectBehavior
+{
+    function let(
+        RegistryInterface $resourceRegistry,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestContextInitiatorInterface $decorated,
+    ): void {
+        $this->beConstructedWith($resourceRegistry, $requestConfigurationFactory, $decorated);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(LegacyRequestContextInitiator::class);
+    }
+
+    function it_adds_metadata_and_request_configuration_to_the_context(
+        Request $request,
+        RequestContextInitiatorInterface $decorated,
+        RegistryInterface $resourceRegistry,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        MetadataInterface $metadata,
+        RequestConfiguration $requestConfiguration,
+    ): void {
+        $request->attributes = new ParameterBag(['_sylius' => ['resource' => 'app.dummy']]);
+
+        $decorated->initializeContext($request)->willReturn(new Context());
+
+        $resourceRegistry->get('app.dummy')->willReturn($metadata)->shouldBeCalled();
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($requestConfiguration)->shouldBeCalled();
+
+        $result = $this->initializeContext($request);
+        $result->shouldHaveType(Context::class);
+
+        $result->get(MetadataOption::class)?->metadata()->shouldReturn($metadata);
+        $result->get(RequestConfigurationOption::class)?->requestConfiguration()->shouldReturn($requestConfiguration);
+    }
+
+    function it_directly_returns_the_context_when_request_has_no_sylius_attributes(
+        Request $request,
+        RequestContextInitiatorInterface $decorated,
+        RegistryInterface $resourceRegistry,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        MetadataInterface $metadata,
+        RequestConfiguration $requestConfiguration,
+    ): void {
+        $request->attributes = new ParameterBag();
+
+        $decorated->initializeContext($request)->willReturn(new Context());
+
+        $resourceRegistry->get('app.dummy')->willReturn($metadata)->shouldNotBeCalled();
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($requestConfiguration)->shouldNotBeCalled();
+
+        $result = $this->initializeContext($request);
+        $result->shouldHaveType(Context::class);
+
+        $result->get(MetadataOption::class)->shouldReturn(null);
+        $result->get(RequestConfigurationOption::class)->shouldReturn(null);
+    }
+
+    function it_directly_returns_the_context_when_request_has_no_resource_on_attributes(
+        Request $request,
+        RequestContextInitiatorInterface $decorated,
+        RegistryInterface $resourceRegistry,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        MetadataInterface $metadata,
+        RequestConfiguration $requestConfiguration,
+    ): void {
+        $request->attributes = new ParameterBag(['_sylius' => ['section' => 'admin']]);
+
+        $decorated->initializeContext($request)->willReturn(new Context());
+
+        $resourceRegistry->get('app.dummy')->willReturn($metadata)->shouldNotBeCalled();
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($requestConfiguration)->shouldNotBeCalled();
+
+        $result = $this->initializeContext($request);
+        $result->shouldHaveType(Context::class);
+
+        $result->get(MetadataOption::class)->shouldReturn(null);
+        $result->get(RequestConfigurationOption::class)->shouldReturn(null);
+    }
+}

--- a/src/Bundle/spec/Context/Option/RequestConfigurationOptionSpec.php
+++ b/src/Bundle/spec/Context/Option/RequestConfigurationOptionSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ResourceBundle\Context\Option;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+
+final class RequestConfigurationOptionSpec extends ObjectBehavior
+{
+    function let(RequestConfiguration $requestConfiguration): void
+    {
+        $this->beConstructedWith($requestConfiguration);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RequestConfigurationOption::class);
+    }
+
+    function it_returns_request_configuration(RequestConfiguration $requestConfiguration): void
+    {
+        $this->requestConfiguration()->shouldReturn($requestConfiguration);
+    }
+}

--- a/src/Bundle/spec/Grid/View/LegacyGridViewFactorySpec.php
+++ b/src/Bundle/spec/Grid/View/LegacyGridViewFactorySpec.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ResourceBundle\Grid\View;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Grid\View\LegacyGridViewFactory;
+use Sylius\Bundle\ResourceBundle\Grid\View\ResourceGridView;
+use Sylius\Bundle\ResourceBundle\Grid\View\ResourceGridViewFactoryInterface;
+use Sylius\Component\Grid\Definition\Grid;
+use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Grid\View\GridView;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Grid\View\Factory\GridViewFactoryInterface;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+
+final class LegacyGridViewFactorySpec extends ObjectBehavior
+{
+    function let(
+        ResourceGridViewFactoryInterface $resourceGridViewFactory,
+        GridViewFactoryInterface $decorated,
+    ): void {
+        $this->beConstructedWith($resourceGridViewFactory, $decorated);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(LegacyGridViewFactory::class);
+    }
+
+    function it_creates_a_legacy_resource_grid_view(
+        Grid $grid,
+        RequestConfiguration $requestConfiguration,
+        MetadataInterface $metadata,
+        ResourceGridViewFactoryInterface $resourceGridViewFactory,
+        ResourceGridView $resourceGridView,
+    ): void {
+        $context = new Context(
+            new RequestConfigurationOption($requestConfiguration->getWrappedObject()),
+            new MetadataOption($metadata->getWrappedObject()),
+        );
+
+        $parameters = new Parameters();
+
+        $resourceGridViewFactory->create(
+            $grid,
+            $parameters,
+            $metadata,
+            $requestConfiguration,
+        )->willReturn($resourceGridView)->shouldBeCalled();
+
+        $this->create($grid, $context, $parameters, [])->shouldReturn($resourceGridView);
+    }
+
+    function it_creates_a_grid_view_when_context_has_no_request_configuration(
+        Grid $grid,
+        GridViewFactoryInterface $decorated,
+        MetadataInterface $metadata,
+        GridView $gridView,
+    ): void {
+        $context = new Context(
+            new MetadataOption($metadata->getWrappedObject()),
+        );
+
+        $parameters = new Parameters();
+
+        $decorated->create($grid, $context, $parameters, [])->willReturn($gridView)->shouldBeCalled();
+
+        $this->create($grid, $context, $parameters, [])->shouldReturn($gridView);
+    }
+}

--- a/src/Bundle/spec/Twig/Context/LegacyContextFactorySpec.php
+++ b/src/Bundle/spec/Twig/Context/LegacyContextFactorySpec.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ResourceBundle\Twig\Context;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\Context\Option\RequestConfigurationOption;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Twig\Context\LegacyContextFactory;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface;
+
+final class LegacyContextFactorySpec extends ObjectBehavior
+{
+    function let(ContextFactoryInterface $decorated): void
+    {
+        $this->beConstructedWith($decorated);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(LegacyContextFactory::class);
+    }
+
+    function it_adds_twig_vars(
+        ContextFactoryInterface $decorated,
+        \stdClass $data,
+        Operation $operation,
+        RequestConfiguration $requestConfiguration,
+        MetadataInterface $metadata,
+    ): void {
+        $context = new Context(
+            new RequestConfigurationOption($requestConfiguration->getWrappedObject()),
+            new MetadataOption($metadata->getWrappedObject()),
+        );
+
+        $decorated->create($data, $operation, $context)->willReturn(['resource' => $data]);
+
+        $this->create($data, $operation, $context)->shouldReturn([
+            'resource' => $data,
+            'configuration' => $requestConfiguration,
+            'metadata' => $metadata,
+        ]);
+    }
+
+    function it_does_not_add_twig_vars_if_is_not_necessary(
+        ContextFactoryInterface $decorated,
+        \stdClass $data,
+        Operation $operation,
+        RequestConfiguration $requestConfiguration,
+        MetadataInterface $metadata,
+    ): void {
+        $context = new Context();
+
+        $decorated->create($data, $operation, $context)->willReturn(['resource' => $data]);
+
+        $this->create($data, $operation, $context)->shouldReturn([
+            'resource' => $data,
+        ]);
+    }
+}

--- a/src/Component/Context/Initiator/RequestContextInitiatorInterface.php
+++ b/src/Component/Context/Initiator/RequestContextInitiatorInterface.php
@@ -14,13 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Component\Resource\Context\Initiator;
 
 use Sylius\Component\Resource\Context\Context;
-use Sylius\Component\Resource\Context\Option\RequestOption;
 use Symfony\Component\HttpFoundation\Request;
 
-final class RequestContextInitiator implements RequestContextInitiatorInterface
+interface RequestContextInitiatorInterface
 {
-    public function initializeContext(Request $request): Context
-    {
-        return new Context(new RequestOption($request));
-    }
+    public function initializeContext(Request $request): Context;
 }

--- a/src/Component/Context/Option/MetadataOption.php
+++ b/src/Component/Context/Option/MetadataOption.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Context\Option;
+
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+
+final class MetadataOption
+{
+    public function __construct(private MetadataInterface $metadata)
+    {
+    }
+
+    public function metadata(): MetadataInterface
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Component/Grid/State/RequestGridProvider.php
+++ b/src/Component/Grid/State/RequestGridProvider.php
@@ -47,7 +47,7 @@ final class RequestGridProvider implements ProviderInterface
         $gridDefinition = $this->gridProvider->get($grid);
         $gridConfiguration = $gridDefinition->getDriverConfiguration();
 
-        $gridView = $this->gridViewFactory->create($gridDefinition, new Parameters(), $gridConfiguration);
+        $gridView = $this->gridViewFactory->create($gridDefinition, $context, new Parameters(), $gridConfiguration);
 
         $data = $gridView->getData();
 

--- a/src/Component/Grid/View/Factory/GridViewFactory.php
+++ b/src/Component/Grid/View/Factory/GridViewFactory.php
@@ -17,6 +17,7 @@ use Sylius\Component\Grid\Data\DataProviderInterface;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Parameters;
 use Sylius\Component\Grid\View\GridView;
+use Sylius\Component\Resource\Context\Context;
 
 final class GridViewFactory implements GridViewFactoryInterface
 {
@@ -25,7 +26,7 @@ final class GridViewFactory implements GridViewFactoryInterface
     ) {
     }
 
-    public function create(Grid $grid, Parameters $parameters, array $driverConfiguration): GridView
+    public function create(Grid $grid, Context $context, Parameters $parameters, array $driverConfiguration): GridView
     {
         return new GridView($this->dataProvider->getData($grid, $parameters), $grid, $parameters);
     }

--- a/src/Component/Grid/View/Factory/GridViewFactoryInterface.php
+++ b/src/Component/Grid/View/Factory/GridViewFactoryInterface.php
@@ -16,8 +16,9 @@ namespace Sylius\Component\Resource\Grid\View\Factory;
 use Sylius\Component\Grid\Definition\Grid;
 use Sylius\Component\Grid\Parameters;
 use Sylius\Component\Grid\View\GridView;
+use Sylius\Component\Resource\Context\Context;
 
 interface GridViewFactoryInterface
 {
-    public function create(Grid $grid, Parameters $parameters, array $driverConfiguration): GridView;
+    public function create(Grid $grid, Context $context, Parameters $parameters, array $driverConfiguration): GridView;
 }

--- a/src/Component/Symfony/EventListener/FormListener.php
+++ b/src/Component/Symfony/EventListener/FormListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
-use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
@@ -25,7 +25,7 @@ final class FormListener
 {
     public function __construct(
         private HttpOperationInitiator $operationInitiator,
-        private RequestContextInitiator $contextInitiator,
+        private RequestContextInitiatorInterface $contextInitiator,
         private FormFactoryInterface $formFactory,
     ) {
     }

--- a/src/Component/Symfony/EventListener/ReadListener.php
+++ b/src/Component/Symfony/EventListener/ReadListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
-use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
 use Sylius\Component\Resource\Metadata\CreateOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
 use Sylius\Component\Resource\State\ProviderInterface;
@@ -24,7 +24,7 @@ final class ReadListener
 {
     public function __construct(
         private HttpOperationInitiator $operationInitiator,
-        private RequestContextInitiator $contextInitiator,
+        private RequestContextInitiatorInterface $contextInitiator,
         private ProviderInterface $provider,
     ) {
     }

--- a/src/Component/Symfony/EventListener/RespondListener.php
+++ b/src/Component/Symfony/EventListener/RespondListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
-use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
 use Sylius\Component\Resource\State\ResponderInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,7 +24,7 @@ final class RespondListener
 {
     public function __construct(
         private HttpOperationInitiator $operationInitiator,
-        private RequestContextInitiator $contextInitiator,
+        private RequestContextInitiatorInterface $contextInitiator,
         private ResponderInterface $responder,
     ) {
     }

--- a/src/Component/Symfony/EventListener/WriteListener.php
+++ b/src/Component/Symfony/EventListener/WriteListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Symfony\EventListener;
 
-use Sylius\Component\Resource\Context\Initiator\RequestContextInitiator;
+use Sylius\Component\Resource\Context\Initiator\RequestContextInitiatorInterface;
 use Sylius\Component\Resource\Metadata\Operation\HttpOperationInitiator;
 use Sylius\Component\Resource\State\ProcessorInterface;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -22,7 +22,7 @@ final class WriteListener
 {
     public function __construct(
         private HttpOperationInitiator $operationInitiator,
-        private RequestContextInitiator $contextInitiator,
+        private RequestContextInitiatorInterface $contextInitiator,
         private ProcessorInterface $processor,
     ) {
     }

--- a/src/Component/Twig/Context/Factory/ContextFactory.php
+++ b/src/Component/Twig/Context/Factory/ContextFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Twig\Context\Factory;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
+use Sylius\Component\Resource\Metadata\Operation;
+
+final class ContextFactory implements ContextFactoryInterface
+{
+    public function create(mixed $data, Operation $operation, Context $context): array
+    {
+        $twigContext = ['operation' => $operation];
+
+        if ($operation instanceof CollectionOperationInterface) {
+            $twigContext['resources'] = $data;
+            $pluralName = $operation->getResource()?->getPluralName();
+
+            if (null !== $pluralName) {
+                $twigContext[$pluralName] = $data;
+            }
+        } else {
+            $twigContext['resource'] = $data;
+            $name = $operation->getResource()?->getName();
+
+            if (null !== $name) {
+                $twigContext[$name] = $data;
+            }
+        }
+
+        return $twigContext;
+    }
+}

--- a/src/Component/Twig/Context/Factory/ContextFactoryInterface.php
+++ b/src/Component/Twig/Context/Factory/ContextFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Twig\Context\Factory;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Operation;
+
+interface ContextFactoryInterface
+{
+    public function create(mixed $data, Operation $operation, Context $context): array;
+}

--- a/src/Component/Twig/Context/Factory/RequestContextFactory.php
+++ b/src/Component/Twig/Context/Factory/RequestContextFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Twig\Context\Factory;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Context\Option\RequestOption;
+use Sylius\Component\Resource\Metadata\Operation;
+use Symfony\Component\Form\FormInterface;
+
+final class RequestContextFactory implements ContextFactoryInterface
+{
+    public function __construct(private ContextFactoryInterface $decorated)
+    {
+    }
+
+    public function create(mixed $data, Operation $operation, Context $context): array
+    {
+        $twigContext = $this->decorated->create($data, $operation, $context);
+
+        $request = $context->get(RequestOption::class)?->request();
+
+        if (null === $request) {
+            return $twigContext;
+        }
+
+        /** @var FormInterface|null $form */
+        $form = $request->attributes->get('form');
+
+        if (null === $form) {
+            return $twigContext;
+        }
+
+        return array_merge($twigContext, ['form' => $form->createView()]);
+    }
+}

--- a/src/Component/spec/Context/Option/MetadataOptionSpec.php
+++ b/src/Component/spec/Context/Option/MetadataOptionSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Context\Option;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Context\Option\MetadataOption;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+
+final class MetadataOptionSpec extends ObjectBehavior
+{
+    function let(MetadataInterface $metadata): void
+    {
+        $this->beConstructedWith($metadata);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(MetadataOption::class);
+    }
+
+    function it_returns_request_configuration(MetadataInterface $metadata): void
+    {
+        $this->metadata()->shouldReturn($metadata);
+    }
+}

--- a/src/Component/spec/Grid/State/RequestGridProviderSpec.php
+++ b/src/Component/spec/Grid/State/RequestGridProviderSpec.php
@@ -48,14 +48,18 @@ final class RequestGridProviderSpec extends ObjectBehavior
         Grid $gridDefinition,
         GridView $gridView,
     ): void {
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
         $operation = new Index(grid: 'app_book');
+
+        $request->query = new InputBag();
 
         $gridProvider->get('app_book')->willReturn($gridDefinition);
         $gridDefinition->getDriverConfiguration()->willReturn([]);
 
-        $gridViewFactory->create($gridDefinition, new Parameters(), [])->willReturn($gridView);
+        $gridViewFactory->create($gridDefinition, $context, new Parameters(), [])->willReturn($gridView);
 
-        $this->provide($operation, new Context(new RequestOption($request->getWrappedObject())))
+        $this->provide($operation, $context)
             ->shouldReturn($gridView)
         ;
     }
@@ -68,6 +72,8 @@ final class RequestGridProviderSpec extends ObjectBehavior
         GridView $gridView,
         Pagerfanta $pagerfanta,
     ): void {
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
         $operation = new Index(grid: 'app_book');
 
         $request->query = new InputBag(['page' => 42]);
@@ -75,12 +81,12 @@ final class RequestGridProviderSpec extends ObjectBehavior
         $gridProvider->get('app_book')->willReturn($gridDefinition);
         $gridDefinition->getDriverConfiguration()->willReturn([]);
 
-        $gridViewFactory->create($gridDefinition, new Parameters(), [])->willReturn($gridView);
+        $gridViewFactory->create($gridDefinition, $context, new Parameters(), [])->willReturn($gridView);
 
         $gridView->getData()->willReturn($pagerfanta);
         $pagerfanta->setCurrentPage(42)->willReturn($pagerfanta)->shouldBeCalled();
 
-        $this->provide($operation, new Context(new RequestOption($request->getWrappedObject())))
+        $this->provide($operation, $context)
             ->shouldReturn($gridView)
         ;
     }

--- a/src/Component/spec/Twig/Context/Factory/ContextFactorySpec.php
+++ b/src/Component/spec/Twig/Context/Factory/ContextFactorySpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\Show;
 use Sylius\Component\Resource\Twig\Context\Factory\ContextFactory;
 
-class ContextFactorySpec extends ObjectBehavior
+final class ContextFactorySpec extends ObjectBehavior
 {
     function it_is_initializable(): void
     {

--- a/src/Component/spec/Twig/Context/Factory/ContextFactorySpec.php
+++ b/src/Component/spec/Twig/Context/Factory/ContextFactorySpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Twig\Context\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Twig\Context\Factory\ContextFactory;
+
+class ContextFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ContextFactory::class);
+    }
+
+    function it_creates_twig_context_for_resource(
+        \stdClass $data,
+    ): void {
+        $operation = (new Show())->withResource(new Resource(alias: 'app.dummy', name: 'dummy'));
+
+        $this->create($data, $operation, new Context())->shouldReturn([
+            'operation' => $operation,
+            'resource' => $data,
+            'dummy' => $data,
+        ]);
+    }
+
+    function it_creates_twig_context_for_resource_collection(
+        \stdClass $data,
+    ): void {
+        $operation = (new Index())->withResource(new Resource(alias: 'app.dummy', pluralName: 'dummies'));
+
+        $this->create($data, $operation, new Context())->shouldReturn([
+            'operation' => $operation,
+            'resources' => $data,
+            'dummies' => $data,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

To bring a bc-layer for current AdminBundle CRUD templates (or Monofony ones) without any changes, we have to add RequestConfiguration and Metadata on Twig.

```php
        if ($configuration->isHtmlRequest()) {
            return $this->render($configuration->getTemplate(ResourceActions::SHOW . '.html'), [
                'configuration' => $configuration,
                'metadata' => $this->metadata,
                'resource' => $resource,
                $this->metadata->getName() => $resource,
            ]);
        }
```