### PR TITLE
Add route prefix for all operation on a resource

### DIFF
--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -19,6 +19,9 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrinePHP
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\DriverProvider;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Resource\Metadata\Metadata;
+use Sylius\Component\Resource\State\ProcessorInterface;
+use Sylius\Component\Resource\State\ProviderInterface;
+use Sylius\Component\Resource\State\ResponderInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -32,6 +35,7 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
     public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration($this->getConfiguration([], $container), $configs);
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $loader->load('services.xml');
@@ -54,6 +58,18 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
 
         $this->loadPersistence($config['drivers'], $config['resources'], $loader);
         $this->loadResources($config['resources'], $container);
+
+        $container->registerForAutoconfiguration(ProviderInterface::class)
+            ->addTag('sylius.state_provider')
+        ;
+
+        $container->registerForAutoconfiguration(ProcessorInterface::class)
+            ->addTag('sylius.state_processor')
+        ;
+
+        $container->registerForAutoconfiguration(ResponderInterface::class)
+            ->addTag('sylius.state_responder')
+        ;
 
         $container->addObjectResource(Metadata::class);
         $container->addObjectResource(DriverProvider::class);

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -99,7 +99,7 @@ class HttpOperation extends Operation
         return $this->routePrefix;
     }
 
-    public function withRoutePrefix(string $routePrefix): self
+    public function withRoutePrefix(?string $routePrefix): self
     {
         $self = clone $this;
         $self->routePrefix = $routePrefix;

--- a/src/Component/Metadata/Resource.php
+++ b/src/Component/Metadata/Resource.php
@@ -23,6 +23,7 @@ final class Resource
         private ?string $section = null,
         private ?string $formType = null,
         private ?string $templatesDir = null,
+        private ?string $routePrefix = null,
         private ?string $name = null,
         private ?string $pluralName = null,
         private ?string $applicationName = null,
@@ -70,19 +71,6 @@ final class Resource
         return $self;
     }
 
-    public function getTemplatesDir(): ?string
-    {
-        return $this->templatesDir;
-    }
-
-    public function withTemplatesDir(string $templatesDir): self
-    {
-        $self = clone $this;
-        $self->templatesDir = $templatesDir;
-
-        return $self;
-    }
-
     public function getName(): ?string
     {
         return $this->name;
@@ -118,6 +106,32 @@ final class Resource
     {
         $self = clone $this;
         $self->applicationName = $applicationName;
+
+        return $self;
+    }
+
+    public function getTemplatesDir(): ?string
+    {
+        return $this->templatesDir;
+    }
+
+    public function withTemplatesDir(string $templatesDir): self
+    {
+        $self = clone $this;
+        $self->templatesDir = $templatesDir;
+
+        return $self;
+    }
+
+    public function getRoutePrefix(): ?string
+    {
+        return $this->routePrefix;
+    }
+
+    public function withRoutePrefix(string $routePrefix): self
+    {
+        $self = clone $this;
+        $self->routePrefix = $routePrefix;
 
         return $self;
     }

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -165,6 +165,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         }
 
         if ($operation instanceof HttpOperation) {
+            if (null === $operation->getRoutePrefix()) {
+                $operation = $operation->withRoutePrefix($resource->getRoutePrefix() ?? null);
+            }
+
             if (null === $routeName = $operation->getRouteName()) {
                 $routeName = $this->operationRouteNameFactory->createRouteName($operation);
                 $operation = $operation->withRouteName($routeName);

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Metadata\Resource\Factory;
 
+use Sylius\Component\Resource\Grid\State\RequestGridProvider;
 use Sylius\Component\Resource\Metadata\HttpOperation;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Metadata\Operation;
@@ -167,6 +168,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             if (null === $routeName = $operation->getRouteName()) {
                 $routeName = $this->operationRouteNameFactory->createRouteName($operation);
                 $operation = $operation->withRouteName($routeName);
+            }
+
+            if (null === $operation->getProvider() && null !== $operation->getGrid()) {
+                $operation = $operation->withProvider(RequestGridProvider::class);
             }
 
             if (null === $operation->getProvider()) {

--- a/src/Component/Tests/Dummy/DummyResourceWithGrid.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithGrid.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy')]
+#[Create]
+#[Update]
+#[Index(grid: 'app_dummy')]
+#[Show]
+final class DummyResourceWithGrid
+{
+}

--- a/src/Component/Tests/Dummy/DummyResourceWithRoutePrefix.php
+++ b/src/Component/Tests/Dummy/DummyResourceWithRoutePrefix.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+use Sylius\Component\Resource\Metadata\Create;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Metadata\Update;
+
+#[Resource(alias: 'app.dummy', routePrefix: '/admin')]
+#[Create]
+#[Update]
+#[Index]
+#[Show]
+final class DummyResourceWithRoutePrefix
+{
+}

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Resource\Metadata\Resource\Factory;
 
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Grid\State\RequestGridProvider;
 use Sylius\Component\Resource\Metadata\Create;
 use Sylius\Component\Resource\Metadata\Index;
 use Sylius\Component\Resource\Metadata\Metadata;
@@ -32,6 +33,7 @@ use Sylius\Component\Resource\Tests\Dummy\DummyMultiResourcesWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyOperationsWithoutResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResource;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithFormType;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithGrid;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithName;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithPluralName;
@@ -508,6 +510,45 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
 
         $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
         $operation->getProvider()->shouldReturn(Provider::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->getProvider()->shouldReturn(Provider::class);
+    }
+
+    function it_creates_resource_metadata_with_default_grid_provider_on_http_operations(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithGrid::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->getProvider()->shouldReturn(Provider::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->getProvider()->shouldReturn(Provider::class);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->getProvider()->shouldReturn(RequestGridProvider::class);
 
         $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
         $operation->getProvider()->shouldReturn(Provider::class);

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -37,6 +37,7 @@ use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithGrid;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithName;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithPluralName;
+use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithRoutePrefix;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSections;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithSectionsAndNestedOperations;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithTemplatesDir;
@@ -591,5 +592,48 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
 
         $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
         $operation->getResponder()->shouldReturn(TwigResponder::class);
+    }
+
+    function it_creates_resource_metadata_with_route_prefix(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithRoutePrefix::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->shouldHaveType(Create::class);
+        $operation->getRoutePrefix()->shouldReturn('/admin');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->shouldHaveType(Update::class);
+        $operation->getRoutePrefix()->shouldReturn('/admin');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getRoutePrefix()->shouldReturn('/admin');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getRoutePrefix()->shouldReturn('/admin');
     }
 }

--- a/src/Component/spec/Metadata/ResourceSpec.php
+++ b/src/Component/spec/Metadata/ResourceSpec.php
@@ -114,14 +114,14 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, null, 'book');
+        $this->beConstructedWith('app.book', null, null, null, null, 'book');
 
         $this->getName()->shouldReturn('book');
     }
 
     function it_can_be_constructed_with_an_application_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, null, null, null, 'app');
+        $this->beConstructedWith('app.book', null, null, null, null, null, null, 'app');
 
         $this->getApplicationName()->shouldReturn('app');
     }
@@ -142,16 +142,23 @@ final class ResourceSpec extends ObjectBehavior
 
     function it_can_be_constructed_with_a_plural_name(): void
     {
-        $this->beConstructedWith('app.book', null, null, null, null, 'books');
+        $this->beConstructedWith('app.book', null, null, null, null, null, 'books');
 
         $this->getPluralName()->shouldReturn('books');
+    }
+
+    function it_can_be_constructed_with_a_route_prefix(): void
+    {
+        $this->beConstructedWith('app.book', null, null, null, '/admin');
+
+        $this->getRoutePrefix()->shouldReturn('/admin');
     }
 
     function it_can_be_constructed_with_operations(): void
     {
         $operations = [new Create(), new Update()];
 
-        $this->beConstructedWith('app.book', null, null, null, null, null, null, $operations);
+        $this->beConstructedWith('app.book', null, null, null, null, null, null, null, $operations);
 
         $this->getOperations()->shouldHaveCount(2);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT


Before 

```php
#[Resource(
    alias: 'app.book',
    section: 'admin',
    formType: BookType::class,
    templatesDir: '@SyliusAdminUi/crud',
    operations: [
        new Index(routePrefix: '/admin', grid: 'app_book'),
        new Create(routePrefix: '/admin'),
        new Update(routePrefix: '/admin'),
        new Delete(routePrefix: 'admin'),
        new Show(routePrefix: '/admin', template: 'book/show.html.twig'),
    ],
)]
```

After

```php
#[Resource(
    alias: 'app.book',
    section: 'admin',
    formType: BookType::class,
    templatesDir: '@SyliusAdminUi/crud', 
    routePrefix: '/admin',
    operations: [
        new Index(grid: 'app_book'),
        new Create(),
        new Update(),
        new Delete(),
        new Show(template: 'book/show.html.twig'),
    ],
)]
```
