### PR TITLE
Configure specific state machine component for a resource

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterResourceStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterResourceStateMachinePass.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterResourceStateMachinePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('sylius.resources')) {
+            return;
+        }
+
+        /** @var array $resources */
+        $resources = $container->getParameter('sylius.resources');
+
+        foreach ($resources as $alias => $configuration) {
+            [$applicationName, $resourceName] = explode('.', $alias, 2);
+            $stateMachineId = sprintf('%s.state_machine.%s', $applicationName, $resourceName);
+
+            $stateMachineComponent = $configuration['state_machine_component'] ?? null;
+
+            if (null === $stateMachineComponent) {
+                $container->setAlias($stateMachineId, 'sylius.resource_controller.state_machine');
+
+                continue;
+            }
+
+            $specificStateMachineId = sprintf('sylius.resource_controller.state_machine.%s', $stateMachineComponent);
+
+            if (!$container->hasDefinition($specificStateMachineId)) {
+                throw new \LogicException(sprintf('State machine "%s" is not available.', $stateMachineComponent));
+            }
+
+            $container->setAlias($stateMachineId, $specificStateMachineId);
+        }
+    }
+}

--- a/src/Bundle/DependencyInjection/Compiler/RegisterResourceStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterResourceStateMachinePass.php
@@ -29,7 +29,7 @@ final class RegisterResourceStateMachinePass implements CompilerPassInterface
 
         foreach ($resources as $alias => $configuration) {
             [$applicationName, $resourceName] = explode('.', $alias, 2);
-            $stateMachineId = sprintf('%s.state_machine.%s', $applicationName, $resourceName);
+            $stateMachineId = sprintf('%s.controller_state_machine.%s', $applicationName, $resourceName);
 
             $stateMachineComponent = $configuration['state_machine_component'] ?? null;
 

--- a/src/Bundle/DependencyInjection/Compiler/RegisterStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterStateMachinePass.php
@@ -33,6 +33,9 @@ final class RegisterStateMachinePass implements CompilerPassInterface
         $settings = $container->getParameter('sylius.resource.settings');
         $stateMachine = $settings['state_machine_component'];
 
+        $this->registerWinzouStateMachine($container);
+        $this->registerSymfonyWorkflowStateMachine($container);
+
         if (null !== $stateMachine) {
             $this->setStateMachine($container, $stateMachine);
 
@@ -80,6 +83,28 @@ final class RegisterStateMachinePass implements CompilerPassInterface
         $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine', StateMachine::class);
         $stateMachineDefinition->setPublic(false);
         $stateMachineDefinition->addArgument(new Reference('sm.factory'));
+    }
+
+    private function registerWinzouStateMachine(ContainerBuilder $container): void
+    {
+        if (!$this->isWinzouStateMachineEnabled($container)) {
+            return;
+        }
+
+        $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine.winzou', StateMachine::class);
+        $stateMachineDefinition->setPublic(false);
+        $stateMachineDefinition->addArgument(new Reference('sm.factory'));
+    }
+
+    private function registerSymfonyWorkflowStateMachine(ContainerBuilder $container): void
+    {
+        if (!$this->isSymfonyWorkflowEnabled($container)) {
+            return;
+        }
+
+        $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine.symfony', Workflow::class);
+        $stateMachineDefinition->setPublic(false);
+        $stateMachineDefinition->addArgument(new Reference('workflow.registry'));
     }
 
     private function setSymfonyWorkflowAsStateMachine(ContainerBuilder $container): void

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -66,6 +66,7 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
                             ->variableNode('options')->end()
                             ->scalarNode('templates')->cannotBeEmpty()->end()
+                            ->scalarNode('state_machine_component')->defaultNull()->end()
                             ->arrayNode('classes')
                                 ->isRequired()
                                 ->addDefaultsIfNotSet()

--- a/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
@@ -76,7 +76,7 @@ abstract class AbstractDriver implements DriverInterface
                 new Reference('sylius.resource_controller.flash_helper'),
                 new Reference('sylius.resource_controller.authorization_checker'),
                 new Reference('sylius.resource_controller.event_dispatcher'),
-                new Reference('sylius.resource_controller.state_machine', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                new Reference($metadata->getServiceId('state_machine'), ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sylius.resource_controller.resource_update_handler'),
                 new Reference('sylius.resource_controller.resource_delete_handler'),
             ])

--- a/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Bundle/DependencyInjection/Driver/AbstractDriver.php
@@ -76,7 +76,7 @@ abstract class AbstractDriver implements DriverInterface
                 new Reference('sylius.resource_controller.flash_helper'),
                 new Reference('sylius.resource_controller.authorization_checker'),
                 new Reference('sylius.resource_controller.event_dispatcher'),
-                new Reference($metadata->getServiceId('state_machine'), ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                new Reference($metadata->getServiceId('controller_state_machine'), ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sylius.resource_controller.resource_update_handler'),
                 new Reference('sylius.resource_controller.resource_delete_handler'),
             ])

--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -22,6 +22,7 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterFormBuilde
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterFqcnControllersPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourceRepositoryPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourcesPass;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourceStateMachinePass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterStateMachinePass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\TwigPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\WinzouStateMachinePass;
@@ -50,6 +51,7 @@ final class SyliusResourceBundle extends Bundle
         $container->addCompilerPass(new RegisterResourceRepositoryPass());
         $container->addCompilerPass(new RegisterResourcesPass());
         $container->addCompilerPass(new RegisterStateMachinePass());
+        $container->addCompilerPass(new RegisterResourceStateMachinePass());
         $container->addCompilerPass(new TwigPass());
         $container->addCompilerPass(new WinzouStateMachinePass());
 

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceStateMachinePassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceStateMachinePassTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\ResourceBundle\Controller\StateMachine;
+use Sylius\Bundle\ResourceBundle\Controller\Workflow;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourceStateMachinePass;
+use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Compiler\AuthorClass;
+use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Compiler\BookClass;
+use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Compiler\PullRequestClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class RegisterResourceStateMachinePassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_registers_state_machine_components_for_resources(): void
+    {
+        $this->registerService('sylius.resource_controller.state_machine', StateMachine::class);
+        $this->makeSymfonyWorkflowAvailable();
+        $this->makeWinzouStateMachineAvailable();
+
+        $this->setDefinition('sylius.resource_registry', new Definition());
+
+        $this->setParameter(
+            'sylius.resources',
+            [
+                'app.book' => ['state_machine_component' => 'symfony', 'classes' => ['model' => BookClass::class]],
+                'app.author' => ['state_machine_component' => 'winzou', 'classes' => ['model' => AuthorClass::class]],
+                'app.pull_request' => ['classes' => ['model' => PullRequestClass::class]],
+            ],
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('app.state_machine.book', 'sylius.resource_controller.state_machine.symfony');
+        $this->assertContainerBuilderHasAlias('app.state_machine.author', 'sylius.resource_controller.state_machine.winzou');
+        $this->assertContainerBuilderHasAlias('app.state_machine.pull_request', 'sylius.resource_controller.state_machine');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_specific_symfony_state_machine_component_is_not_available(): void
+    {
+        $this->registerService('sylius.resource_controller.state_machine', StateMachine::class);
+        $this->makeWinzouStateMachineAvailable();
+
+        $this->setDefinition('sylius.resource_registry', new Definition());
+
+        $this->setParameter(
+            'sylius.resources',
+            [
+                'app.book' => ['state_machine_component' => 'symfony', 'classes' => ['model' => BookClass::class]],
+                'app.author' => ['state_machine_component' => 'winzou', 'classes' => ['model' => AuthorClass::class]],
+                'app.pull_request' => ['classes' => ['model' => PullRequestClass::class]],
+            ],
+        );
+
+        $error = false;
+
+        try {
+            $this->compile();
+        } catch (\LogicException $exception) {
+            $error = true;
+            $message = $exception->getMessage();
+        }
+
+        $this->assertTrue($error, 'Should not compile');
+        $this->assertEquals('State machine "symfony" is not available.', $message);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_specific_winzou_state_machine_component_is_not_available(): void
+    {
+        $this->registerService('sylius.resource_controller.state_machine', Workflow::class);
+        $this->makeSymfonyWorkflowAvailable();
+
+        $this->setDefinition('sylius.resource_registry', new Definition());
+
+        $this->setParameter(
+            'sylius.resources',
+            [
+                'app.book' => ['state_machine_component' => 'symfony', 'classes' => ['model' => BookClass::class]],
+                'app.author' => ['state_machine_component' => 'winzou', 'classes' => ['model' => AuthorClass::class]],
+                'app.pull_request' => ['classes' => ['model' => PullRequestClass::class]],
+            ],
+        );
+
+        $error = false;
+
+        try {
+            $this->compile();
+        } catch (\LogicException $exception) {
+            $error = true;
+            $message = $exception->getMessage();
+        }
+
+        $this->assertTrue($error, 'Should not compile');
+        $this->assertEquals('State machine "winzou" is not available.', $message);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RegisterResourceStateMachinePass());
+    }
+
+    private function makeWinzouStateMachineAvailable(): void
+    {
+        $this->registerService('sylius.resource_controller.state_machine.winzou', StateMachine::class);
+    }
+
+    private function makeSymfonyWorkflowAvailable(): void
+    {
+        $this->registerService('sylius.resource_controller.state_machine.symfony', Workflow::class);
+    }
+}

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceStateMachinePassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourceStateMachinePassTest.php
@@ -45,9 +45,9 @@ final class RegisterResourceStateMachinePassTest extends AbstractCompilerPassTes
 
         $this->compile();
 
-        $this->assertContainerBuilderHasAlias('app.state_machine.book', 'sylius.resource_controller.state_machine.symfony');
-        $this->assertContainerBuilderHasAlias('app.state_machine.author', 'sylius.resource_controller.state_machine.winzou');
-        $this->assertContainerBuilderHasAlias('app.state_machine.pull_request', 'sylius.resource_controller.state_machine');
+        $this->assertContainerBuilderHasAlias('app.controller_state_machine.book', 'sylius.resource_controller.state_machine.symfony');
+        $this->assertContainerBuilderHasAlias('app.controller_state_machine.author', 'sylius.resource_controller.state_machine.winzou');
+        $this->assertContainerBuilderHasAlias('app.controller_state_machine.pull_request', 'sylius.resource_controller.state_machine');
     }
 
     /** @test */

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourcesPassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterResourcesPassTest.php
@@ -70,3 +70,7 @@ class BookClass extends AbstractResource
 class AuthorClass extends AbstractResource
 {
 }
+
+class PullRequestClass extends AbstractResource
+{
+}

--- a/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStateMachinePassTest.php
+++ b/src/Bundle/Tests/DependencyInjection/Compiler/RegisterStateMachinePassTest.php
@@ -26,13 +26,15 @@ use winzou\Bundle\StateMachineBundle\winzouStateMachineBundle;
 final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
 {
     /** @test */
-    public function it_does_nothing_when_no_state_machine_are_available_and_no_state_machine_is_configured(): void
+    public function it_does_nothing_when_no_state_machine_are_available(): void
     {
         $this->setParameter('sylius.resource.settings', ['state_machine_component' => null]);
 
         $this->compile();
 
         $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine');
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.symfony');
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.winzou');
     }
 
     /** @test */
@@ -44,6 +46,8 @@ final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine', Workflow::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.symfony', Workflow::class);
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.winzou');
     }
 
     /** @test */
@@ -55,6 +59,8 @@ final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine', StateMachine::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.winzou', StateMachine::class);
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.symfony');
     }
 
     /** @test */
@@ -66,6 +72,8 @@ final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine', Workflow::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.symfony', Workflow::class);
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.winzou');
     }
 
     /** @test */
@@ -77,6 +85,8 @@ final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine', StateMachine::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.winzou', StateMachine::class);
+        $this->assertContainerBuilderNotHasService('sylius.resource_controller.state_machine.symfony');
     }
 
     /** @test */
@@ -89,6 +99,8 @@ final class RegisterStateMachinePassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine', StateMachine::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.winzou', StateMachine::class);
+        $this->assertContainerBuilderHasService('sylius.resource_controller.state_machine.symfony', Workflow::class);
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

```yaml
sylius_resource:
    resources:
        app.pull_request:
            state_machine_component: symfony #or winzou
            classes:
                model: App\Entity\PullRequest
                form: App\Form\Type\PullRequestType
```

```bash
bin/console debug:container app.controller_state_machine.pull_request
```

```bash
 // This service is a private alias for the service                                                                     
 // sylius.resource_controller.state_machine.symfony  

Information for Service "sylius.resource_controller.state_machine.symfony"
==========================================================================

 ---------------- -------------------------------------------------- 
  Option           Value                                             
 ---------------- -------------------------------------------------- 
  Service ID       sylius.resource_controller.state_machine.symfony  
  Class            Sylius\Bundle\ResourceBundle\Controller\Workflow  
  Tags             -                                                 
  Public           no                                                
  Synthetic        no                                                
  Lazy             no                                                
  Shared           yes                                               
  Abstract         no                                                
  Autowired        no                                                
  Autoconfigured   no                                                
 ---------------- --------------------------------------------------
```