### PR TITLE
Allow doctrine/collections ^2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     tests:
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, Persistence: ${{ matrix.persistence }}"
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, Persistence: ${{ matrix.persistence }}, Collections: ${{ matrix.collections }}"
         strategy:
             fail-fast: false
             matrix:
@@ -22,17 +22,24 @@ jobs:
                 symfony: ["^5.4", "~6.0.0", "~6.1.0", "~6.2.0"]
                 twig: ["^2.12", "^3.0"]
                 persistence: ["^2.0", "^3.0"]
+                collections: ["^1.8", "^2.0"]
                 include:
                     - php: "8.0"
                       pagerfanta: "^3.7"
                       symfony: "^5.4"
                 exclude:
-                    -
-                        php: "8.0"
-                        symfony: "~6.1.0"
-                    -
-                        php: "8.0"
-                        symfony: "~6.2.0"
+                    - php: "8.0"
+                      symfony: "~6.1.0"
+                    - php: "8.0"
+                      symfony: "~6.2.0"
+                    - php: "8.0"
+                      collections: "^2.0"
+                    - php: "8.1"
+                      collections: "^2.0"
+                      persistence: "^2.0"
+                    - php: "8.2"
+                      collections: "^2.0"
+                      persistence: "^2.0"
 
         steps:
             -
@@ -71,6 +78,11 @@ jobs:
                 name: Restrict doctrine/persistence version
                 if: matrix.persistence != ''
                 run: composer require "doctrine/persistence:${{ matrix.persistence }}" --no-update --no-scripts
+
+            -
+                name: Restrict doctrine/collections version
+                if: matrix.collections != ''
+                run: composer require "doctrine/collections:${{ matrix.collections }}" --no-update --no-scripts
 
             -
                 name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^8.0",
         "babdev/pagerfanta-bundle": "^3.7 || ^4.0",
-        "doctrine/collections": "^1.6",
+        "doctrine/collections": "^1.8 || ^2.0",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4 || ^2.0",

--- a/src/Bundle/Form/DataTransformer/RecursiveTransformer.php
+++ b/src/Bundle/Form/DataTransformer/RecursiveTransformer.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ResourceBundle\Form\DataTransformer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ReadableCollection;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
@@ -28,7 +29,7 @@ final class RecursiveTransformer implements DataTransformerInterface
     }
 
     /** @param Collection|null $value */
-    public function transform($value): Collection
+    public function transform($value): ReadableCollection
     {
         if (null === $value) {
             return new ArrayCollection();
@@ -49,7 +50,7 @@ final class RecursiveTransformer implements DataTransformerInterface
     }
 
     /** @param Collection|null $value */
-    public function reverseTransform($value): Collection
+    public function reverseTransform($value): ReadableCollection
     {
         if (null === $value) {
             return new ArrayCollection();

--- a/src/Bundle/Form/DataTransformer/ResourceToIdentifierTransformer.php
+++ b/src/Bundle/Form/DataTransformer/ResourceToIdentifierTransformer.php
@@ -36,6 +36,8 @@ final class ResourceToIdentifierTransformer implements DataTransformerInterface
      * @psalm-suppress MissingParamType
      *
      * @param object|null $value
+     *
+     * @return mixed
      */
     public function transform($value)
     {

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/collections": "^1.6",
+        "doctrine/collections": "^1.8 || ^2.0",
         "doctrine/inflector": "^1.4 || ^2.0",
         "gedmo/doctrine-extensions": "^2.4.12 || ^3.0",
         "pagerfanta/core": "^3.7 || ^4.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #494 
| License         | MIT

Not sure if this is right way to fix the CI

When installing doctrine/collections ^2.0 doctrine/persistence ^3.0 and PHP 8.1 should be used.
doctrine/collections ^2.0 should not be installed on PHP 8.0

What to do with the psalm errors?