### PR TITLE
Allow Pagerfanta 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,14 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.0", "8.1", "8.2"]
+                pagerfanta: [""]
                 symfony: ["^5.4", "~6.0.0", "~6.1.0", "~6.2.0"]
                 twig: ["^2.12", "^3.0"]
                 persistence: ["^2.0", "^3.0"]
+                include:
+                    - php: "8.0"
+                      pagerfanta: "^3.7"
+                      symfony: "^5.4"
                 exclude:
                     -
                         php: "8.0"
@@ -48,6 +53,14 @@ jobs:
                     composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
                     (cd src/Component && composer config extra.symfony.require "${{ matrix.symfony }}")
+
+            -
+                name: Restrict Pagerfanta version
+                if: matrix.pagerfanta != ''
+                run: |
+                    composer require "babdev/pagerfanta-bundle:${{ matrix.pagerfanta }}" --no-update --no-scripts
+                    composer require "pagerfanta/pagerfanta:${{ matrix.pagerfanta }}" --dev --no-update --no-scripts
+                    (cd src/Component && composer require "pagerfanta/core:${{ matrix.pagerfanta }}" --no-update --no-scripts)
 
             -
                 name: Restrict twig/twig version

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "babdev/pagerfanta-bundle": "^3.0",
+        "babdev/pagerfanta-bundle": "^3.7 || ^4.0",
         "doctrine/collections": "^1.6",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/event-manager": "^1.1",
@@ -61,7 +61,7 @@
         "doctrine/orm": "^2.5",
         "lchrusciel/api-test-case": "^5.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2.1",
-        "pagerfanta/pagerfanta": "^3.0",
+        "pagerfanta/pagerfanta": "^3.7 || ^4.0",
         "pamil/phpspec-skip-example-extension": "^4.2",
         "phpspec/phpspec": "^7.3",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -31,7 +31,7 @@
         "doctrine/collections": "^1.6",
         "doctrine/inflector": "^1.4 || ^2.0",
         "gedmo/doctrine-extensions": "^2.4.12 || ^3.0",
-        "pagerfanta/core": "^3.0",
+        "pagerfanta/core": "^3.7 || ^4.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
         "symfony/http-foundation": "^5.4 || ^6.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

I tagged Pagerfanta 4.0.  It's pretty much B/C with 3.x minus a bit of internal cleanup.  For now, both the latest 3.x and 4.0 are allowed to make it possible for the upgrade to start trickling out.