### PR TITLE
Debug resource with FQCN

### DIFF
--- a/src/Bundle/Command/DebugResourceCommand.php
+++ b/src/Bundle/Command/DebugResourceCommand.php
@@ -63,7 +63,11 @@ EOT
             return 0;
         }
 
-        $metadata = $this->registry->get($resource);
+        if (str_contains($resource, '.')) {
+            $metadata = $this->registry->get($resource);
+        } else {
+            $metadata = $this->registry->getByClass($resource);
+        }
 
         $this->debugResource($metadata, $output);
 

--- a/src/Bundle/Tests/Command/DebugResourceCommandTest.php
+++ b/src/Bundle/Tests/Command/DebugResourceCommandTest.php
@@ -85,6 +85,32 @@ EOT
             , $display);
     }
 
+    /**
+     * @test
+     */
+    public function it_displays_the_metadata_for_given_resource_as_fully_qualified_class_name(): void
+    {
+        $this->registry->getByClass('App\Resource')->willReturn($this->createMetadata('one'));
+        $this->tester->execute([
+            'resource' => 'App\Resource',
+        ]);
+
+        $display = $this->tester->getDisplay();
+
+        $this->assertEquals(<<<'EOT'
++------------------------------+-----------------+
+| name                         | one             |
+| application                  | sylius          |
+| driver                       | doctrine/foobar |
+| classes.foo                  | bar             |
+| classes.bar                  | foo             |
+| whatever.something.elephants | camels          |
++------------------------------+-----------------+
+
+EOT
+            , $display);
+    }
+
     private function createMetadata(string $suffix): MetadataInterface
     {
         $metadata = Metadata::fromAliasAndConfiguration(sprintf('sylius.%s', $suffix), [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

@lchrusciel I've added this on our new board, cause I already add this on the new documentation part. 
It's not directly related to our new architecture, but it's more important now that we configure an alias by default.
