### PR TITLE
Custom twig context factory

### DIFF
--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -29,6 +29,7 @@ use Sylius\Component\Resource\Reflection\ClassReflection;
 use Sylius\Component\Resource\State\ProcessorInterface;
 use Sylius\Component\Resource\State\ProviderInterface;
 use Sylius\Component\Resource\State\ResponderInterface;
+use Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -83,6 +84,10 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
 
         $container->registerForAutoconfiguration(FactoryInterface::class)
             ->addTag('sylius.resource_factory')
+        ;
+
+        $container->registerForAutoconfiguration(ContextFactoryInterface::class)
+            ->addTag('sylius.twig_context_factory')
         ;
 
         $container->addObjectResource(Metadata::class);

--- a/src/Bundle/Resources/config/services/twig.xml
+++ b/src/Bundle/Resources/config/services/twig.xml
@@ -13,8 +13,14 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.twig.context.factory" class="Sylius\Component\Resource\Twig\Context\Factory\ContextFactory" />
-        <service id="Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface" alias="sylius.twig.context.factory" />
+        <service id="sylius.twig.context.factory" class="Sylius\Component\Resource\Twig\Context\Factory\ContextFactory">
+            <argument type="tagged_locator" tag="sylius.twig_context_factory" />
+        </service>
+
+        <service id="sylius.twig.context.factory.default" class="Sylius\Component\Resource\Twig\Context\Factory\DefaultContextFactory">
+            <tag name="sylius.twig_context_factory" />
+        </service>
+        <service id="Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface" alias="sylius.twig.context.factory.default" />
 
         <service id="sylius.twig.context.factory.request"
                  class="Sylius\Component\Resource\Twig\Context\Factory\RequestContextFactory"

--- a/src/Bundle/test/src/Subscription/Entity/Subscription.php
+++ b/src/Bundle/test/src/Subscription/Entity/Subscription.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Subscription\Entity;
 
 use App\Subscription\Form\Type\SubscriptionType;
+use App\Subscription\Twig\Context\Factory\ShowSubscriptionContextFactory;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Resource\Metadata\Api;
 use Sylius\Component\Resource\Metadata\ApplyStateMachineTransition;
@@ -41,7 +42,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApplyStateMachineTransition(stateMachineTransition: 'accept')]
 #[ApplyStateMachineTransition(stateMachineTransition: 'reject')]
 #[Delete]
-#[Show(template: 'subscription/show.html.twig')]
+#[Show(
+    template: 'subscription/show.html.twig',
+    twigContextFactory: ShowSubscriptionContextFactory::class,
+)]
 
 #[Resource(
     alias: 'app.subscription',

--- a/src/Bundle/test/src/Subscription/Twig/Context/Factory/ShowSubscriptionContextFactory.php
+++ b/src/Bundle/test/src/Subscription/Twig/Context/Factory/ShowSubscriptionContextFactory.php
@@ -17,7 +17,7 @@ use Sylius\Component\Resource\Context\Context;
 use Sylius\Component\Resource\Metadata\Operation;
 use Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface;
 
-class ShowSubscriptionContextFactory implements ContextFactoryInterface
+final class ShowSubscriptionContextFactory implements ContextFactoryInterface
 {
     public function __construct(private ContextFactoryInterface $decorated)
     {

--- a/src/Bundle/test/src/Subscription/Twig/Context/Factory/ShowSubscriptionContextFactory.php
+++ b/src/Bundle/test/src/Subscription/Twig/Context/Factory/ShowSubscriptionContextFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Subscription\Twig\Context\Factory;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Operation;
+use Sylius\Component\Resource\Twig\Context\Factory\ContextFactoryInterface;
+
+class ShowSubscriptionContextFactory implements ContextFactoryInterface
+{
+    public function __construct(private ContextFactoryInterface $decorated)
+    {
+    }
+
+    public function create(mixed $data, Operation $operation, Context $context): array
+    {
+        return array_merge($this->decorated->create($data, $operation, $context), [
+            'foo' => 'bar',
+        ]);
+    }
+}

--- a/src/Bundle/test/src/Tests/Controller/SubscriptionUiTest.php
+++ b/src/Bundle/test/src/Tests/Controller/SubscriptionUiTest.php
@@ -33,6 +33,7 @@ final class SubscriptionUiTest extends ApiTestCase
         $content = $response->getContent();
         $this->assertStringContainsString(sprintf('ID: %s', $subscriptions['subscription_marty']->getId()), $content);
         $this->assertStringContainsString('Email: marty.mcfly@bttf.com', $content);
+        $this->assertStringContainsString('Foo: bar', $content);
     }
 
     /** @test */

--- a/src/Bundle/test/templates/subscription/show.html.twig
+++ b/src/Bundle/test/templates/subscription/show.html.twig
@@ -1,4 +1,8 @@
 <h1>Subscription</h1>
 
 <h3>ID: {{ resource.id }}</h3>
-<span>Email: {{ resource.email }}</span>
+<ul>
+    <li>Email: {{ resource.email }}</li>
+    <li>Foo: {{ foo }}</li>
+</ul>
+

--- a/src/Component/Metadata/Create.php
+++ b/src/Component/Metadata/Create.php
@@ -47,6 +47,7 @@ final class Create extends HttpOperation implements CreateOperationInterface, St
         ?array $formOptions = null,
         ?array $validationContext = null,
         ?string $eventShortName = null,
+        string|callable|null $twigContextFactory = null,
         ?string $redirectToRoute = null,
         ?array $redirectArguments = null,
         private ?string $stateMachineComponent = null,
@@ -75,6 +76,7 @@ final class Create extends HttpOperation implements CreateOperationInterface, St
             formOptions: $formOptions,
             validationContext: $validationContext,
             eventShortName: $eventShortName,
+            twigContextFactory: $twigContextFactory,
             redirectToRoute: $redirectToRoute,
             redirectArguments: $redirectArguments,
         );

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -40,6 +40,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $formOptions = null,
         ?array $validationContext = null,
         ?string $eventShortName = null,
+        string|callable|null $twigContextFactory = null,
         ?string $redirectToRoute = null,
         ?array $redirectArguments = null,
     ) {
@@ -64,6 +65,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
             formOptions: $formOptions,
             validationContext: $validationContext,
             eventShortName: $eventShortName,
+            twigContextFactory: $twigContextFactory,
             redirectToRoute: $redirectToRoute,
             redirectArguments: $redirectArguments,
         );

--- a/src/Component/Metadata/HttpOperation.php
+++ b/src/Component/Metadata/HttpOperation.php
@@ -18,6 +18,9 @@ namespace Sylius\Component\Resource\Metadata;
  */
 class HttpOperation extends Operation
 {
+    /** @var string|callable|null */
+    protected $twigContextFactory;
+
     public function __construct(
         protected ?array $methods = null,
         protected ?string $path = null,
@@ -43,6 +46,7 @@ class HttpOperation extends Operation
         ?array $denormalizationContext = null,
         ?array $validationContext = null,
         ?string $eventShortName = null,
+        string|callable|null $twigContextFactory = null,
         protected ?string $redirectToRoute = null,
         protected ?array $redirectArguments = null,
     ) {
@@ -68,6 +72,8 @@ class HttpOperation extends Operation
             validationContext: $validationContext,
             eventShortName: $eventShortName,
         );
+
+        $this->twigContextFactory = $twigContextFactory;
     }
 
     public function getMethods(): ?array
@@ -118,6 +124,19 @@ class HttpOperation extends Operation
     {
         $self = clone $this;
         $self->routePrefix = $routePrefix;
+
+        return $self;
+    }
+
+    public function getTwigContextFactory(): callable|string|null
+    {
+        return $this->twigContextFactory;
+    }
+
+    public function withTwigContextFactory(callable|string|null $twigContextFactory): self
+    {
+        $self = clone $this;
+        $self->twigContextFactory = $twigContextFactory;
 
         return $self;
     }

--- a/src/Component/Metadata/Index.php
+++ b/src/Component/Metadata/Index.php
@@ -41,6 +41,7 @@ final class Index extends HttpOperation implements CollectionOperationInterface
         ?array $formOptions = null,
         ?string $eventShortName = null,
         ?array $validationContext = null,
+        string|callable|null $twigContextFactory = null,
         ?string $redirectToRoute = null,
     ) {
         parent::__construct(
@@ -65,6 +66,7 @@ final class Index extends HttpOperation implements CollectionOperationInterface
             formOptions: $formOptions,
             validationContext: $validationContext,
             eventShortName: $eventShortName,
+            twigContextFactory: $twigContextFactory,
             redirectToRoute: $redirectToRoute,
         );
     }

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -204,6 +204,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
                 $operation = $operation->withRoutePrefix($resource->getRoutePrefix() ?? null);
             }
 
+            if (null === $operation->getTwigContextFactory()) {
+                $operation = $operation->withTwigContextFactory('sylius.twig.context.factory.default');
+            }
+
             if (null === $routeName = $operation->getRouteName()) {
                 $routeName = $this->operationRouteNameFactory->createRouteName($operation);
                 $operation = $operation->withRouteName($routeName);
@@ -219,10 +223,6 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
 
             if (null === $operation->getResponder()) {
                 $operation = $operation->withResponder(Responder::class);
-            }
-
-            if (null === $operation->getTwigContextFactory()) {
-                $operation = $operation->withTwigContextFactory('sylius.twig.context.factory.default');
             }
 
             $operation = $operation->withName($routeName);

--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -221,6 +221,10 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
                 $operation = $operation->withResponder(Responder::class);
             }
 
+            if (null === $operation->getTwigContextFactory()) {
+                $operation = $operation->withTwigContextFactory('sylius.twig.context.factory.default');
+            }
+
             $operation = $operation->withName($routeName);
         }
 

--- a/src/Component/Metadata/Show.php
+++ b/src/Component/Metadata/Show.php
@@ -41,6 +41,7 @@ final class Show extends HttpOperation implements ShowOperationInterface
         ?array $formOptions = null,
         ?array $validationContext = null,
         ?string $eventShortName = null,
+        string|callable|null $twigContextFactory = null,
         ?string $redirectToRoute = null,
     ) {
         parent::__construct(
@@ -65,6 +66,7 @@ final class Show extends HttpOperation implements ShowOperationInterface
             formOptions: $formOptions,
             validationContext: $validationContext,
             eventShortName: $eventShortName,
+            twigContextFactory: $twigContextFactory,
             redirectToRoute: $redirectToRoute,
         );
     }

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -41,6 +41,7 @@ final class Update extends HttpOperation implements UpdateOperationInterface, St
         ?array $formOptions = null,
         ?array $validationContext = null,
         ?string $eventShortName = null,
+        string|callable|null $twigContextFactory = null,
         ?string $redirectToRoute = null,
         ?array $redirectArguments = null,
         private ?string $stateMachineComponent = null,
@@ -69,6 +70,7 @@ final class Update extends HttpOperation implements UpdateOperationInterface, St
             formOptions: $formOptions,
             validationContext: $validationContext,
             eventShortName: $eventShortName,
+            twigContextFactory: $twigContextFactory,
             redirectToRoute: $redirectToRoute,
             redirectArguments: $redirectArguments,
         );

--- a/src/Component/Twig/Context/Factory/ContextFactory.php
+++ b/src/Component/Twig/Context/Factory/ContextFactory.php
@@ -27,11 +27,12 @@ final class ContextFactory implements ContextFactoryInterface
 
     public function create(mixed $data, Operation $operation, Context $context): array
     {
-        if (!$operation instanceof HttpOperation) {
+        if (
+            !$operation instanceof HttpOperation ||
+            null === $twigContextFactory = $operation->getTwigContextFactory()
+        ) {
             return [];
         }
-
-        $twigContextFactory = $operation->getTwigContextFactory();
 
         if (\is_callable($twigContextFactory)) {
             return $twigContextFactory($data, $operation, $context);

--- a/src/Component/Twig/Context/Factory/ContextFactory.php
+++ b/src/Component/Twig/Context/Factory/ContextFactory.php
@@ -13,32 +13,38 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Twig\Context\Factory;
 
+use Psr\Container\ContainerInterface;
 use Sylius\Component\Resource\Context\Context;
-use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
+use Sylius\Component\Resource\Metadata\HttpOperation;
 use Sylius\Component\Resource\Metadata\Operation;
+use Webmozart\Assert\Assert;
 
 final class ContextFactory implements ContextFactoryInterface
 {
+    public function __construct(private ContainerInterface $locator)
+    {
+    }
+
     public function create(mixed $data, Operation $operation, Context $context): array
     {
-        $twigContext = ['operation' => $operation];
-
-        if ($operation instanceof CollectionOperationInterface) {
-            $twigContext['resources'] = $data;
-            $pluralName = $operation->getResource()?->getPluralName();
-
-            if (null !== $pluralName) {
-                $twigContext[$pluralName] = $data;
-            }
-        } else {
-            $twigContext['resource'] = $data;
-            $name = $operation->getResource()?->getName();
-
-            if (null !== $name) {
-                $twigContext[$name] = $data;
-            }
+        if (!$operation instanceof HttpOperation) {
+            return [];
         }
 
-        return $twigContext;
+        $twigContextFactory = $operation->getTwigContextFactory();
+
+        if (\is_callable($twigContextFactory)) {
+            return $twigContextFactory($data, $operation, $context);
+        }
+
+        if (!$this->locator->has($twigContextFactory)) {
+            throw new \RuntimeException(sprintf('Twig context factory "%s" not found on operation "%s"', $twigContextFactory, $operation->getName() ?? ''));
+        }
+
+        /** @var ContextFactoryInterface $twigContextFactoryInstance */
+        $twigContextFactoryInstance = $this->locator->get($twigContextFactory);
+        Assert::isInstanceOf($twigContextFactoryInstance, ContextFactoryInterface::class);
+
+        return $twigContextFactoryInstance->create($data, $operation, $context);
     }
 }

--- a/src/Component/Twig/Context/Factory/DefaultContextFactory.php
+++ b/src/Component/Twig/Context/Factory/DefaultContextFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Twig\Context\Factory;
+
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\CollectionOperationInterface;
+use Sylius\Component\Resource\Metadata\Operation;
+
+final class DefaultContextFactory implements ContextFactoryInterface
+{
+    public function create(mixed $data, Operation $operation, Context $context): array
+    {
+        $twigContext = ['operation' => $operation];
+
+        if ($operation instanceof CollectionOperationInterface) {
+            $twigContext['resources'] = $data;
+            $pluralName = $operation->getResource()?->getPluralName();
+
+            if (null !== $pluralName) {
+                $twigContext[$pluralName] = $data;
+            }
+        } else {
+            $twigContext['resource'] = $data;
+            $name = $operation->getResource()?->getName();
+
+            if (null !== $name) {
+                $twigContext[$name] = $data;
+            }
+        }
+
+        return $twigContext;
+    }
+}

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -851,4 +851,47 @@ final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavi
         $operation->shouldHaveType(Show::class);
         $operation->getDenormalizationContext()->shouldReturn(['groups' => ['dummy:write']]);
     }
+
+    function it_creates_resource_metadata_with_default_twig_context_factory(RegistryInterface $resourceRegistry): void
+    {
+        $resourceRegistry->get('app.dummy')->willReturn(Metadata::fromAliasAndConfiguration('app.dummy', [
+            'driver' => 'dummy_driver',
+            'classes' => [
+                'model' => 'App\Dummy',
+                'form' => 'App\Form',
+            ],
+        ]));
+
+        $metadataCollection = $this->create(DummyResourceWithOperations::class);
+        $metadataCollection->shouldHaveType(ResourceMetadataCollection::class);
+
+        $resource = $metadataCollection->getIterator()->current();
+        $resource->shouldHaveType(Resource::class);
+        $resource->getAlias()->shouldReturn('app.dummy');
+
+        $operations = $resource->getOperations();
+        $operations->shouldHaveType(Operations::class);
+
+        $operations->count()->shouldReturn(4);
+        $operations->has('app_dummy_create')->shouldReturn(true);
+        $operations->has('app_dummy_update')->shouldReturn(true);
+        $operations->has('app_dummy_index')->shouldReturn(true);
+        $operations->has('app_dummy_show')->shouldReturn(true);
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_create');
+        $operation->shouldHaveType(Create::class);
+        $operation->getTwigContextFactory()->shouldReturn('sylius.twig.context.factory.default');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_update');
+        $operation->shouldHaveType(Update::class);
+        $operation->getTwigContextFactory()->shouldReturn('sylius.twig.context.factory.default');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_index');
+        $operation->shouldHaveType(Index::class);
+        $operation->getTwigContextFactory()->shouldReturn('sylius.twig.context.factory.default');
+
+        $operation = $metadataCollection->getOperation('app.dummy', 'app_dummy_show');
+        $operation->shouldHaveType(Show::class);
+        $operation->getTwigContextFactory()->shouldReturn('sylius.twig.context.factory.default');
+    }
 }

--- a/src/Component/spec/Twig/Context/Factory/DefaultContextFactorySpec.php
+++ b/src/Component/spec/Twig/Context/Factory/DefaultContextFactorySpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Twig\Context\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Context\Context;
+use Sylius\Component\Resource\Metadata\Index;
+use Sylius\Component\Resource\Metadata\Resource;
+use Sylius\Component\Resource\Metadata\Show;
+use Sylius\Component\Resource\Twig\Context\Factory\DefaultContextFactory;
+
+final class DefaultContextFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(DefaultContextFactory::class);
+    }
+
+    function it_creates_twig_context_for_resource(
+        \stdClass $data,
+    ): void {
+        $operation = (new Show())->withResource(new Resource(alias: 'app.dummy', name: 'dummy'));
+
+        $this->create($data, $operation, new Context())->shouldReturn([
+            'operation' => $operation,
+            'resource' => $data,
+            'dummy' => $data,
+        ]);
+    }
+
+    function it_creates_twig_context_for_resource_collection(
+        \stdClass $data,
+    ): void {
+        $operation = (new Index())->withResource(new Resource(alias: 'app.dummy', pluralName: 'dummies'));
+
+        $this->create($data, $operation, new Context())->shouldReturn([
+            'operation' => $operation,
+            'resources' => $data,
+            'dummies' => $data,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

```php
#[Resource]
#[Show(
    template: 'subscription/show.html.twig',
    twigContextFactory: ShowSubscriptionContextFactory::class,
)]
class Subscription implements ResourceInterface
{
}
```

```php
final class ShowSubscriptionContextFactory implements ContextFactoryInterface
{
    public function __construct(private ContextFactoryInterface $decorated)
    {
    }

    public function create(mixed $data, Operation $operation, Context $context): array
    {
        return array_merge($this->decorated->create($data, $operation, $context), [
            'foo' => 'bar',
        ]);
    }
}
```
In your Twig template
![Capture d’écran du 2023-03-28 12-43-30](https://user-images.githubusercontent.com/8329789/228211767-fdb621bf-7f3a-4c87-8a5a-7601f27e0b23.png)

