### PR TITLE
Alias the workflow registry

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/RegisterStateMachinePass.php
+++ b/src/Bundle/DependencyInjection/Compiler/RegisterStateMachinePass.php
@@ -106,9 +106,26 @@ final class RegisterStateMachinePass implements CompilerPassInterface
             return;
         }
 
+        $this->defineSyliusWorkflowRegistry($container);
+
         $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine.symfony', Workflow::class);
         $stateMachineDefinition->setPublic(false);
-        $stateMachineDefinition->addArgument(new Reference('workflow.registry'));
+        $stateMachineDefinition->addArgument(new Reference('sylius.workflow.registry'));
+    }
+
+    private function defineSyliusWorkflowRegistry(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('.workflow.registry')) {
+            $container->setAlias('sylius.workflow.registry', '.workflow.registry');
+
+            return;
+        }
+
+        if ($container->hasDefinition('workflow.registry')) {
+            $container->setAlias('sylius.workflow.registry', 'workflow.registry');
+
+            return;
+        }
     }
 
     private function setSymfonyWorkflowAsStateMachine(ContainerBuilder $container): void
@@ -124,14 +141,14 @@ final class RegisterStateMachinePass implements CompilerPassInterface
         $container->setParameter('sylius.state_machine_component.default', 'symfony');
         $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine', Workflow::class);
         $stateMachineDefinition->setPublic(false);
-        $stateMachineDefinition->addArgument(new Reference('workflow.registry'));
+        $stateMachineDefinition->addArgument(new Reference('sylius.workflow.registry'));
 
         $container->setAlias('sylius.state_machine.operation.default', 'sylius.state_machine.operation.symfony');
     }
 
     private function isSymfonyWorkflowEnabled(ContainerBuilder $container): bool
     {
-        return $container->hasDefinition('workflow.registry');
+        return $container->hasDefinition('workflow.registry') || $container->hasDefinition('.workflow.registry');
     }
 
     private function isWinzouStateMachineEnabled(ContainerBuilder $container): bool

--- a/src/Bundle/Resources/config/services/state_machine.xml
+++ b/src/Bundle/Resources/config/services/state_machine.xml
@@ -21,7 +21,7 @@
         <service id="sylius.state_machine.operation.default" alias="sylius.state_machine.operation.winzou" />
 
         <service id="sylius.state_machine.operation.symfony" class="Sylius\Component\Resource\Symfony\Workflow\OperationStateMachine">
-            <argument type="service" id="workflow.registry" on-invalid="null" />
+            <argument type="service" id="sylius.workflow.registry" on-invalid="null" />
             <tag name="sylius.state_machine" key="symfony" />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (will be)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

See these different versions
[5.4](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php)
[6.1](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php)
[6.2](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php)

On 6.2, the 'workflow.registry' is an alias of '.workflow.registry' instead of being the id itself.