### PR TITLE
Add on-invalid null for missing security.token_storage service

### DIFF
--- a/src/Bundle/Resources/config/services/expression_language.xml
+++ b/src/Bundle/Resources/config/services/expression_language.xml
@@ -18,7 +18,7 @@
         <service id="sylius.routing.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
 
         <service id="sylius.expression_language.variables.token" class="Sylius\Component\Resource\Symfony\ExpressionLanguage\TokenVariables">
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.token_storage" on-invalid="null" />
             <tag name="sylius.resource_factory_variables" />
             <tag name="sylius.repository_variables" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
