### PR TITLE
Fix undefined kernel.project_dir for mapping paths

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,19 @@
+## UPGRADE FOR `1.11.x`
+
+### FROM `1.10.x` to `1.11.x`
+
+We remove the default mapping paths which are used to read PHP 8 attributes to build routes.
+
+To configure this default value, please edit your `config/packages/sylius_resource.yaml` file to add your mapping paths manually:
+
+```yaml
+# config/packages/sylius_resource.yaml
+sylius_resource:
+    mapping:
+        paths:
+            - '%kernel.project_dir%/src/Entity'
+```
+
 ## UPGRADE FOR `1.10.x`
 
 ### FROM `1.9.x` to `1.10.x`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,18 @@ return [
 ];
 ```
 
+Configure your mapping paths for your resources
+
+```yaml
+# config/packages/sylius_resource.yaml
+sylius_resource:
+    mapping:
+        paths:
+            - '%kernel.project_dir%/src/Entity'
+```
+
+Configure the routing
+
 ```yaml
 # config/routes.yaml
 

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -40,7 +40,6 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('paths')
-                            ->defaultValue(['%kernel.project_dir%/src/Entity'])
                             ->prototype('scalar')->end()
                         ->end()
                     ->end()

--- a/src/Bundle/Tests/Configuration/ConfigurationTest.php
+++ b/src/Bundle/Tests/Configuration/ConfigurationTest.php
@@ -36,7 +36,7 @@ class ConfigurationTest extends TestCase
     /**
      * @test
      */
-    public function it_has_default_mapping_paths()
+    public function it_has_no_default_mapping_paths()
     {
         $this->assertProcessedConfigurationEquals(
             [
@@ -44,9 +44,7 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'mapping' => [
-                    'paths' => [
-                        '%kernel.project_dir%/src/Entity',
-                    ],
+                    'paths' => [],
                 ],
             ],
             'mapping',

--- a/src/Bundle/Tests/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/src/Bundle/Tests/DependencyInjection/SyliusResourceExtensionTest.php
@@ -30,17 +30,12 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function it_registers_services_and_parameters_for_resources()
+    public function it_registers_services_and_parameters_for_resources(): void
     {
         // TODO: Move Resource-Grid integration to a dedicated compiler pass
         $this->setParameter('kernel.bundles', []);
 
         $this->load([
-            'mapping' => [
-                'paths' => [
-                    __DIR__ . '/Dummy',
-                ],
-            ],
             'resources' => [
                 'app.book' => [
                     'classes' => [
@@ -68,17 +63,12 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function it_aliases_authorization_checker_with_the_one_given_in_configuration()
+    public function it_aliases_authorization_checker_with_the_one_given_in_configuration(): void
     {
         // TODO: Move Resource-Grid integration to a dedicated compiler pass
         $this->setParameter('kernel.bundles', []);
 
         $this->load([
-            'mapping' => [
-                'paths' => [
-                    __DIR__ . '/Dummy',
-                ],
-            ],
             'authorization_checker' => 'custom_service',
         ]);
 
@@ -88,17 +78,12 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function it_registers_default_translation_parameters()
+    public function it_registers_default_translation_parameters(): void
     {
         // TODO: Move ResourceGrid integration to a dedicated compiler pass
         $this->setParameter('kernel.bundles', []);
 
         $this->load([
-            'mapping' => [
-                'paths' => [
-                    __DIR__ . '/Dummy',
-                ],
-            ],
              'translation' => [
                  'locale_provider' => 'test.custom_locale_provider',
              ],
@@ -115,11 +100,6 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
         // TODO: Move Resource-Grid integration to a dedicated compiler pass
         $this->setParameter('kernel.bundles', []);
         $this->load([
-            'mapping' => [
-                'paths' => [
-                    __DIR__ . '/Dummy',
-                ],
-            ],
             'resources' => [
                 'app.book' => [
                     'classes' => [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The issue appeared since we added auto registering resources feature cause we retrieve the mapping path into SyliusResourceExtension. Kernel parameters are not available on Extensions.

## My proposal

We configure it into our project. So we can add this configuration via Flex (EDIT: already merged in https://github.com/symfony/recipes-contrib/pull/1499, so it seems to be the best choice now).
I've added a note to the UPGRADE.md cause it will breaks routes using SyliusCrudRoutes and SyliusRoute attributes.

## Alternative solution (but not great at all):

Add this configuration on prepend config.

This works if we preprend the configuration like this:

```php
$container->prependExtensionConfig('sylius_resource', [
    'mapping' => [
        'paths' => ['%kernel.project_dir%/src/Entity'],
    ],
]);
```

[⚠️](https://emojipedia.org/warning/) But we cannot drop this config easily, if we configure it into the yaml configuration, it will append the new directory or the same directory twice if we add this configuration via Flex.
And there is no Entity directory in the project, it will break. Silent the not found path could be a solution.
