### PR TITLE
Fix default templates dir

### DIFF
--- a/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -158,12 +158,6 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             $operation = $operation->withResource($resource);
         }
 
-        if (null === $operation->getTemplate()) {
-            $templateDir = $resource->getTemplatesDir() ?? '';
-            $template = sprintf('%s/%s.html.twig', $templateDir, $operation->getShortName() ?? '');
-            $operation = $operation->withTemplate($template);
-        }
-
         if (null === $operation->getNormalizationContext()) {
             $operation = $operation->withNormalizationContext($resource->getNormalizationContext());
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I forgot to remove this code. It was originally there and the behaviour has been improved (with default templates dir)  and moved into `TemplatesDirResourceMetadataCollectionFactory`