### PR TITLE
Drivers can now be configured

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -150,9 +150,11 @@
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::arrayNode" />
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::scalarNode" />
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::variableNode" />
+                <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::prototype" />
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeParentInterface::end" />
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\VariableNodeDefinition::scalarNode" />
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\VariableNodeDefinition::variableNode" />
+                <referencedMethod name="Symfony\Component\Config\Definition\Builder\VariableNodeDefinition::prototype" />
             </errorLevel>
         </PossiblyUndefinedMethod>
 

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -164,7 +164,8 @@ final class Configuration implements ConfigurationInterface
                                 if (isset($value['class'])) {
                                     continue;
                                 }
-                                // retro-compatibility
+
+                                // bc-layer
                                 if (in_array($value, SyliusResourceBundle::getAvailableDrivers(), true)) {
                                     $values[$value] = ['class' => match ($value) {
                                         SyliusResourceBundle::DRIVER_DOCTRINE_ORM => DoctrineORMDriver::class,

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -159,28 +159,28 @@ final class Configuration implements ConfigurationInterface
                     ])
                     ->beforeNormalization()
                         ->ifArray()
-                        ->then(static function (array $v) {
-                            foreach ($v as $driver => $value) {
+                        ->then(static function (array $values) {
+                            foreach ($values as $driver => $value) {
                                 if (isset($value['class'])) {
                                     continue;
                                 }
                                 // retro-compatibility
                                 if (in_array($value, SyliusResourceBundle::getAvailableDrivers(), true)) {
-                                    $v[$value] = ['class' => match ($value) {
+                                    $values[$value] = ['class' => match ($value) {
                                         SyliusResourceBundle::DRIVER_DOCTRINE_ORM => DoctrineORMDriver::class,
                                         SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM => DoctrineODMDriver::class,
                                         SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM => DoctrinePHPCRDriver::class,
                                     }];
 
-                                    unset($v[$driver]);
+                                    unset($values[$driver]);
 
                                     continue;
                                 }
 
-                                $v[$driver] = ['class' => $value];
+                                $values[$driver] = ['class' => $value];
                             }
 
-                            return $v;
+                            return $values;
                         })
                     ->end()
                     ->validate()

--- a/src/Bundle/DependencyInjection/Driver/DriverProvider.php
+++ b/src/Bundle/DependencyInjection/Driver/DriverProvider.php
@@ -36,9 +36,10 @@ final class DriverProvider
 
         /** @var class-string|null $class */
         $class = self::$drivers[$type]['class'] ?? null;
+
         if (null !== $class) {
+            /** @var DriverInterface $driver */
             $driver = new $class();
-            Assert::isInstanceOf($driver, DriverInterface::class);
 
             return $driver;
         }

--- a/src/Bundle/DependencyInjection/Driver/DriverProvider.php
+++ b/src/Bundle/DependencyInjection/Driver/DriverProvider.php
@@ -13,18 +13,19 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Driver;
 
-use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineODMDriver;
-use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineORMDriver;
-use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrinePHPCRDriver;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Exception\UnknownDriverException;
-use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Webmozart\Assert\Assert;
 
 final class DriverProvider
 {
-    /** @var DriverInterface[] */
+    /** @var array<string, array<string, string>> */
     private static array $drivers = [];
+
+    public static function build(array $drivers): void
+    {
+        self::$drivers = $drivers;
+    }
 
     /**
      * @throws UnknownDriverException
@@ -33,20 +34,16 @@ final class DriverProvider
     {
         $type = $metadata->getDriver();
 
-        if (isset(self::$drivers[$type])) {
-            return self::$drivers[$type];
+        /** @var class-string|null $class */
+        $class = self::$drivers[$type]['class'] ?? null;
+        if (null !== $class) {
+            $driver = new $class();
+            Assert::isInstanceOf($driver, DriverInterface::class);
+
+            return $driver;
         }
 
         Assert::notFalse($type, sprintf('No driver was configured on the resource "%s".', $metadata->getAlias()));
-
-        switch ($type) {
-            case SyliusResourceBundle::DRIVER_DOCTRINE_ORM:
-                return self::$drivers[$type] = new DoctrineORMDriver();
-            case SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM:
-                return self::$drivers[$type] = new DoctrineODMDriver();
-            case SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM:
-                return self::$drivers[$type] = new DoctrinePHPCRDriver();
-        }
 
         throw new UnknownDriverException($type);
     }

--- a/src/Bundle/Tests/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/src/Bundle/Tests/DependencyInjection/SyliusResourceExtensionTest.php
@@ -19,6 +19,7 @@ use App\Entity\ComicBook;
 use App\Factory\BookFactory;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineORMDriver;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 use Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\BookWithAliasResource;
@@ -177,6 +178,76 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
                 'driver' => 'doctrine/orm',
             ],
         ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_registering_custom_driver(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->load([
+            'drivers' => [
+                'custom' => [
+                    'class' => DoctrineORMDriver::class,
+                ],
+            ],
+        ]);
+
+        // services/integrations/doctrine.xml not loaded
+        $this->assertContainerBuilderNotHasService('sylius_resource.doctrine.mapping_driver_chain');
+        // services/integrations/doctrine/orm.xml not loaded
+        $this->assertContainerBuilderNotHasService('sylius.event_subscriber.orm_mapped_super_class');
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_registering_custom_driver_with_simple_array_values(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->load([
+            'drivers' => [
+                'custom' => DoctrineORMDriver::class,
+            ],
+        ]);
+
+        // services/integrations/doctrine.xml not loaded
+        $this->assertContainerBuilderNotHasService('sylius_resource.doctrine.mapping_driver_chain');
+        // services/integrations/doctrine/orm.xml not loaded
+        $this->assertContainerBuilderNotHasService('sylius.event_subscriber.orm_mapped_super_class');
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_registering_drivers_with_the_legacy_string_array(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->load([
+            'drivers' => [
+                'doctrine/orm',
+            ],
+        ]);
+
+        // services/integrations/doctrine.xml is loaded
+        $this->assertContainerBuilderHasService('sylius_resource.doctrine.mapping_driver_chain');
+        // services/integrations/doctrine/orm.xml is loaded
+        $this->assertContainerBuilderHasService('sylius.event_subscriber.orm_mapped_super_class');
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_registering_drivers_with_defaults_values(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->load();
+
+        // services/integrations/doctrine.xml is loaded
+        $this->assertContainerBuilderHasService('sylius_resource.doctrine.mapping_driver_chain');
+        // services/integrations/doctrine/orm.xml is loaded
+        $this->assertContainerBuilderHasService('sylius.event_subscriber.orm_mapped_super_class');
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This PR allows to configure any drivers you want or even change the default one.

Here is the previous default configuration :

```yaml
sylius_resource:
    drivers:
        - 'doctrine/orm'
```

Now you can setup a little bit more info :

```yaml
sylius_resource:
    drivers:
        doctrine/orm:
            class: 'Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineORMDriver'
```

To keep backward compatibility, you still can set the config with a simple string array when you are using one the 3 available drivers : `doctrine/*`

Right now this PR is using only the `class` config member, but we can have other things added here in the futur.

## Custom driver example

You are creating your own driver and wanted to register it in the list of available drivers, here is how to proceed :

```yaml
# config/packages/sylius_resource.yaml
sylius_resource:
    drivers:
        0: doctrine/orm # Add default value
        custom_driver:
            class: 'MyBundleOrApp\SyliusResource\Driver\MyCustomDriver'
```

```php
<?php

declare(strict_types=1);

namespace MyBundleOrApp\SyliusResource\Driver;

use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\DriverInterface;
use Sylius\Component\Resource\Metadata\MetadataInterface;
use Symfony\Component\DependencyInjection\ContainerBuilder;

final class MyCustomDriver implement DriverInterface {

    public function getType(): string
    {
        return 'custom_driver';
    }

    public function load(ContainerBuilder $container, MetadataInterface $metadata): void
    {
        ...
    }
}
```
