### PR TITLE
Add POST http method on update, delete and bulk delete operation

### DIFF
--- a/src/Component/Metadata/ApplyStateMachineTransition.php
+++ b/src/Component/Metadata/ApplyStateMachineTransition.php
@@ -42,7 +42,7 @@ final class ApplyStateMachineTransition extends HttpOperation implements UpdateO
         private ?string $stateMachineGraph = null,
     ) {
         parent::__construct(
-            methods: $methods ?? ['PUT', 'PATCH'],
+            methods: $methods ?? ['PUT', 'PATCH', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
             template: $template,

--- a/src/Component/Metadata/BulkDelete.php
+++ b/src/Component/Metadata/BulkDelete.php
@@ -42,7 +42,7 @@ final class BulkDelete extends HttpOperation implements DeleteOperationInterface
         ?array $vars = null,
     ) {
         parent::__construct(
-            methods: $methods ?? ['DELETE'],
+            methods: $methods ?? ['DELETE', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
             template: $template,

--- a/src/Component/Metadata/Delete.php
+++ b/src/Component/Metadata/Delete.php
@@ -47,7 +47,7 @@ final class Delete extends HttpOperation implements DeleteOperationInterface
         ?array $vars = null,
     ) {
         parent::__construct(
-            methods: $methods ?? ['DELETE'],
+            methods: $methods ?? ['DELETE', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
             template: $template,

--- a/src/Component/Metadata/Update.php
+++ b/src/Component/Metadata/Update.php
@@ -50,7 +50,7 @@ final class Update extends HttpOperation implements UpdateOperationInterface, St
         private ?string $stateMachineGraph = null,
     ) {
         parent::__construct(
-            methods: $methods ?? ['GET', 'PUT'],
+            methods: $methods ?? ['GET', 'PUT', 'POST'],
             path: $path,
             routePrefix: $routePrefix,
             template: $template,

--- a/src/Component/spec/Metadata/ApplyStateMachineTransitionSpec.php
+++ b/src/Component/spec/Metadata/ApplyStateMachineTransitionSpec.php
@@ -14,16 +14,20 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\ApplyStateMachineTransition;
+use Sylius\Component\Resource\Metadata\BulkDelete;
+use Sylius\Component\Resource\Metadata\BulkOperationInterface;
+use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
 use Sylius\Component\Resource\Metadata\Resource;
-use Sylius\Component\Resource\Metadata\Update;
+use Sylius\Component\Resource\Metadata\StateMachineAwareOperationInterface;
 use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
-final class UpdateSpec extends ObjectBehavior
+final class ApplyStateMachineTransitionSpec extends ObjectBehavior
 {
     function it_is_initializable(): void
     {
-        $this->shouldHaveType(Update::class);
+        $this->shouldHaveType(ApplyStateMachineTransition::class);
     }
 
     function it_is_an_operation(): void
@@ -34,6 +38,11 @@ final class UpdateSpec extends ObjectBehavior
     function it_implements_update_operation_interface(): void
     {
         $this->shouldImplement(UpdateOperationInterface::class);
+    }
+
+    function it_implements_state_machine_aware_operation_interface(): void
+    {
+        $this->shouldImplement(StateMachineAwareOperationInterface::class);
     }
 
     function it_has_no_resource_by_default(): void
@@ -51,13 +60,13 @@ final class UpdateSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_update_name_by_default(): void
+    function it_has_bulk_delete_short_name_by_default(): void
     {
-        $this->getShortName()->shouldReturn('update');
+        $this->getShortName()->shouldReturn('apply_state_machine_transition');
     }
 
-    function it_has_get_and_put_methods_by_default(): void
+    function it_has_delete_methods_by_default(): void
     {
-        $this->getMethods()->shouldReturn(['GET', 'PUT', 'POST']);
+        $this->getMethods()->shouldReturn(['PUT', 'PATCH', 'POST']);
     }
 }

--- a/src/Component/spec/Metadata/ApplyStateMachineTransitionSpec.php
+++ b/src/Component/spec/Metadata/ApplyStateMachineTransitionSpec.php
@@ -15,9 +15,6 @@ namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Metadata\ApplyStateMachineTransition;
-use Sylius\Component\Resource\Metadata\BulkDelete;
-use Sylius\Component\Resource\Metadata\BulkOperationInterface;
-use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
 use Sylius\Component\Resource\Metadata\Resource;
 use Sylius\Component\Resource\Metadata\StateMachineAwareOperationInterface;

--- a/src/Component/spec/Metadata/BulkDeleteSpec.php
+++ b/src/Component/spec/Metadata/BulkDeleteSpec.php
@@ -14,16 +14,17 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Resource\Metadata;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Metadata\BulkDelete;
+use Sylius\Component\Resource\Metadata\BulkOperationInterface;
+use Sylius\Component\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Component\Resource\Metadata\Operation;
 use Sylius\Component\Resource\Metadata\Resource;
-use Sylius\Component\Resource\Metadata\Update;
-use Sylius\Component\Resource\Metadata\UpdateOperationInterface;
 
-final class UpdateSpec extends ObjectBehavior
+final class BulkDeleteSpec extends ObjectBehavior
 {
     function it_is_initializable(): void
     {
-        $this->shouldHaveType(Update::class);
+        $this->shouldHaveType(BulkDelete::class);
     }
 
     function it_is_an_operation(): void
@@ -31,9 +32,14 @@ final class UpdateSpec extends ObjectBehavior
         $this->shouldHaveType(Operation::class);
     }
 
-    function it_implements_update_operation_interface(): void
+    function it_implements_delete_operation_interface(): void
     {
-        $this->shouldImplement(UpdateOperationInterface::class);
+        $this->shouldImplement(DeleteOperationInterface::class);
+    }
+
+    function it_implements_bulk_operation_interface(): void
+    {
+        $this->shouldImplement(BulkOperationInterface::class);
     }
 
     function it_has_no_resource_by_default(): void
@@ -51,13 +57,13 @@ final class UpdateSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_update_name_by_default(): void
+    function it_has_bulk_delete_short_name_by_default(): void
     {
-        $this->getShortName()->shouldReturn('update');
+        $this->getShortName()->shouldReturn('bulk_delete');
     }
 
-    function it_has_get_and_put_methods_by_default(): void
+    function it_has_delete_methods_by_default(): void
     {
-        $this->getMethods()->shouldReturn(['GET', 'PUT', 'POST']);
+        $this->getMethods()->shouldReturn(['DELETE', 'POST']);
     }
 }

--- a/src/Component/spec/Metadata/DeleteSpec.php
+++ b/src/Component/spec/Metadata/DeleteSpec.php
@@ -58,6 +58,6 @@ final class DeleteSpec extends ObjectBehavior
 
     function it_has_delete_methods_by_default(): void
     {
-        $this->getMethods()->shouldReturn(['DELETE']);
+        $this->getMethods()->shouldReturn(['DELETE', 'POST']);
     }
 }

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
@@ -132,7 +132,7 @@ final class OperationRouteFactorySpec extends ObjectBehavior
         );
 
         $route->getPath()->shouldReturn('/dummies/{id}/edit');
-        $route->getMethods()->shouldReturn(['GET', 'PUT']);
+        $route->getMethods()->shouldReturn(['GET', 'PUT', 'POST']);
         $route->getDefaults()->shouldReturn([
             '_controller' => PlaceHolderAction::class,
             '_sylius' => [
@@ -157,7 +157,7 @@ final class OperationRouteFactorySpec extends ObjectBehavior
         );
 
         $route->getPath()->shouldReturn('/dummies/{id}');
-        $route->getMethods()->shouldReturn(['DELETE']);
+        $route->getMethods()->shouldReturn(['DELETE', 'POST']);
         $route->getDefaults()->shouldReturn([
             '_controller' => PlaceHolderAction::class,
             '_sylius' => [
@@ -182,7 +182,7 @@ final class OperationRouteFactorySpec extends ObjectBehavior
         );
 
         $route->getPath()->shouldReturn('/dummies/bulk_delete');
-        $route->getMethods()->shouldReturn(['DELETE']);
+        $route->getMethods()->shouldReturn(['DELETE', 'POST']);
         $route->getDefaults()->shouldReturn([
             '_controller' => PlaceHolderAction::class,
             '_sylius' => [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On new Symfony projects, http method overrides option is disabled by default.
