### PR TITLE
Missed typehint for `TranslatableFactoryInterface`

### DIFF
--- a/src/Bundle/Controller/RequestConfigurationFactory.php
+++ b/src/Bundle/Controller/RequestConfigurationFactory.php
@@ -30,7 +30,6 @@ final class RequestConfigurationFactory implements RequestConfigurationFactoryIn
 
     /**
      * @var string
-     *
      * @psalm-var class-string<RequestConfiguration>
      */
     private $configurationClass;

--- a/src/Component/Factory/Factory.php
+++ b/src/Component/Factory/Factory.php
@@ -20,7 +20,6 @@ final class Factory implements FactoryInterface
 {
     /**
      * @var string
-     *
      * @psalm-var class-string
      */
     private $className;

--- a/src/Component/Factory/TranslatableFactoryInterface.php
+++ b/src/Component/Factory/TranslatableFactoryInterface.php
@@ -18,4 +18,8 @@ namespace Sylius\Component\Resource\Factory;
  */
 interface TranslatableFactoryInterface extends FactoryInterface
 {
+    /**
+     * @return T
+     */
+    public function createNew();
 }

--- a/src/Component/Factory/TranslatableFactoryInterface.php
+++ b/src/Component/Factory/TranslatableFactoryInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Resource\Factory;
 
+/**
+ * @template T of object
+ */
 interface TranslatableFactoryInterface extends FactoryInterface
 {
 }

--- a/src/Component/Model/TranslatableInterface.php
+++ b/src/Component/Model/TranslatableInterface.php
@@ -19,7 +19,6 @@ interface TranslatableInterface
 {
     /**
      * @return Collection|TranslationInterface[]
-     *
      * @psalm-return Collection<array-key, TranslationInterface>
      */
     public function getTranslations(): Collection;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

There is a problem with a type hint of:
https://github.com/Sylius/Sylius/blob/1.13/src/Sylius/Component/Product/Factory/ProductFactoryInterface.php
in the end application because the implemented interface is missing annotations

https://github.com/Sylius/SyliusResourceBundle/blob/1.10/src/Component/Factory/FactoryInterface.php