### PR TITLE
Fix provider type hints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,6 @@ jobs:
 
             -
                 name: Run Phpspec tests
-                if: ${{ true != contains( matrix.php, '8.2' ) }}
                 run: |
                     vendor/bin/phpspec run --ansi --no-interaction
                     (cd src/Component && vendor/bin/phpspec run --no-interaction)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -91,7 +91,7 @@ final class BoardGameItemProvider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         $request = $context->get(RequestOption::class)?->request();
         Assert::notNull($request);

--- a/src/Component/Symfony/Request/State/Provider.php
+++ b/src/Component/Symfony/Request/State/Provider.php
@@ -34,7 +34,7 @@ final class Provider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         $request = $context->get(RequestOption::class)?->request();
         $repository = $operation->getRepository();

--- a/src/Component/spec/Symfony/Request/State/TwigResponderSpec.php
+++ b/src/Component/spec/Symfony/Request/State/TwigResponderSpec.php
@@ -107,7 +107,7 @@ final class TwigResponderSpec extends ObjectBehavior
         RedirectHandlerInterface $redirectHandler,
         RedirectResponse $response,
     ): void {
-        $data->id = 'xyz';
+        $data->offsetSet('id', 'xyz');
         $request->attributes = $attributes;
 
         $attributes->getBoolean('is_valid', true)->willReturn(true)->shouldBeCalled();
@@ -128,7 +128,7 @@ final class TwigResponderSpec extends ObjectBehavior
     ): void {
         $context = new Context(new RequestOption($request->getWrappedObject()));
 
-        $data->id = 'xyz';
+        $data->offsetSet('id', 'xyz');
         $request->attributes = $attributes;
 
         $request->isMethodSafe()->willReturn(false)->shouldBeCalled();

--- a/src/Component/src/Grid/State/RequestGridProvider.php
+++ b/src/Component/src/Grid/State/RequestGridProvider.php
@@ -31,7 +31,7 @@ final class RequestGridProvider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         if (null === $this->gridViewFactory || null === $this->gridProvider) {
             throw new \LogicException('You can not use a grid if Sylius Grid Bundle is not available. Try running "composer require sylius/grid-bundle".');

--- a/src/Component/src/State/Provider.php
+++ b/src/Component/src/State/Provider.php
@@ -28,7 +28,7 @@ final class Provider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         $provider = $operation->getProvider();
 

--- a/src/Component/src/State/Provider/EventDispatcherProvider.php
+++ b/src/Component/src/State/Provider/EventDispatcherProvider.php
@@ -31,7 +31,7 @@ final class EventDispatcherProvider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         if (
             $operation instanceof CollectionOperationInterface ||

--- a/src/Component/src/State/ProviderInterface.php
+++ b/src/Component/src/State/ProviderInterface.php
@@ -23,5 +23,5 @@ use Sylius\Resource\Metadata\Operation;
  */
 interface ProviderInterface
 {
-    public function provide(Operation $operation, Context $context): object|iterable|null;
+    public function provide(Operation $operation, Context $context): object|array|null;
 }

--- a/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/State/Http/Provider/BoardGameCollectionProvider.php
+++ b/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/State/Http/Provider/BoardGameCollectionProvider.php
@@ -24,7 +24,7 @@ final class BoardGameCollectionProvider implements ProviderInterface
     {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         return $this->requestGridProvider->provide($operation, $context);
     }

--- a/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/State/Http/Provider/BoardGameItemProvider.php
+++ b/tests/Application/src/BoardGameBlog/Infrastructure/Sylius/State/Http/Provider/BoardGameItemProvider.php
@@ -31,7 +31,7 @@ final class BoardGameItemProvider implements ProviderInterface
     ) {
     }
 
-    public function provide(Operation $operation, Context $context): object|iterable|null
+    public function provide(Operation $operation, Context $context): object|array|null
     {
         $request = $context->get(RequestOption::class)?->request();
         Assert::notNull($request);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (kind of)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

see https://github.com/php/php-src/issues/9556
So I think it will be safer to use `object|array` instead of `object|iterable`

It has been introduced in 1.11 so we don't need any bc-layer