### PR TITLE
Dispatch pre write event processor

### DIFF
--- a/src/Component/src/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessor.php
+++ b/src/Component/src/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessor.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\src\Symfony\EventDispatcher\State;
+
+use Sylius\Component\Resource\ResourceActions;
+use Sylius\Resource\Context\Context;
+use Sylius\Resource\Metadata\CreateOperationInterface;
+use Sylius\Resource\Metadata\Operation;
+use Sylius\Resource\State\ProcessorInterface;
+use Sylius\Resource\Symfony\EventDispatcher\OperationEventDispatcherInterface;
+use Sylius\Resource\Symfony\EventDispatcher\OperationEventHandlerInterface;
+
+/**
+ * @experimental
+ */
+final class DispatchPreWriteEventProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ProcessorInterface $processor,
+        private OperationEventDispatcherInterface $operationEventDispatcher,
+        private OperationEventHandlerInterface $eventHandler,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(mixed $data, Operation $operation, Context $context): mixed
+    {
+        $operationEvent = $this->operationEventDispatcher->dispatchPreEvent($data, $operation, $context);
+
+        $eventResponse = $this->eventHandler->handlePreProcessEvent(
+            $operationEvent,
+            $context,
+            $operation instanceof CreateOperationInterface ? ResourceActions::INDEX : null,
+        );
+
+        if (null !== $eventResponse) {
+            return $eventResponse;
+        }
+
+        return $this->processor->process($data, $operation, $context);
+    }
+}

--- a/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
+++ b/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Resource\Symfony\EventDispatcher\State;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sylius\Component\Resource\src\Symfony\EventDispatcher\State\DispatchPreWriteEventProcessor;
+use Sylius\Resource\Context\Context;
+use Sylius\Resource\Metadata\Create;
+use Sylius\Resource\State\ProcessorInterface;
+use Sylius\Resource\Symfony\EventDispatcher\OperationEvent;
+use Sylius\Resource\Symfony\EventDispatcher\OperationEventDispatcherInterface;
+use Sylius\Resource\Symfony\EventDispatcher\OperationEventHandlerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DispatchPreWriteEventProcessorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy|ProcessorInterface $processor;
+
+    private ObjectProphecy|OperationEventDispatcherInterface $operationEventDispatcher;
+
+    private ObjectProphecy|OperationEventHandlerInterface $eventHandler;
+
+    private DispatchPreWriteEventProcessor $dispatchPreWriteEventProcessor;
+
+    protected function setUp(): void
+    {
+        $this->processor = $this->prophesize(ProcessorInterface::class);
+        $this->operationEventDispatcher = $this->prophesize(OperationEventDispatcherInterface::class);
+        $this->eventHandler = $this->prophesize(OperationEventHandlerInterface::class);
+
+        $this->dispatchPreWriteEventProcessor = new DispatchPreWriteEventProcessor(
+            $this->processor->reveal(),
+            $this->operationEventDispatcher->reveal(),
+            $this->eventHandler->reveal(),
+        );
+    }
+
+    /** @test */
+    public function it_dispatches_pre_events_with_operation_as_string(): void
+    {
+        $data = new \stdClass();
+
+        $operation = new Create(processor: '\App\Processor');
+        $context = new Context();
+
+        $this->processor->process($data, $operation, $context)->willReturn($data)->shouldBeCalled();
+
+        $preEvent = new OperationEvent();
+
+        $this->operationEventDispatcher->dispatchPreEvent($data, $operation, $context)->willReturn($preEvent)->shouldBeCalled();
+
+        $this->eventHandler->handlePreProcessEvent($preEvent, $context, 'index')->willReturn(null)->shouldBeCalled();
+
+        $result = $this->dispatchPreWriteEventProcessor->process($data, $operation, $context);
+        $this->assertEquals($data, $result);
+    }
+
+    /** @test */
+    public function it_does_not_call_processor_if_pre_event_returns_a_response(): void
+    {
+        $data = new \stdClass();
+        $response = new Response();
+
+        $operation = new Create(processor: '\App\Processor');
+        $context = new Context();
+
+        $this->processor->process($data, $operation, $context)->willReturn($data)->shouldNotBeCalled();
+
+        $preEvent = new OperationEvent();
+
+        $this->operationEventDispatcher->dispatchPreEvent($data, $operation, $context)->willReturn($preEvent)->shouldBeCalled();
+
+        $this->eventHandler->handlePreProcessEvent($preEvent, $context, 'index')->willReturn($response)->shouldBeCalled();
+
+        $result = $this->dispatchPreWriteEventProcessor->process($data, $operation, $context);
+        $this->assertEquals($response, $result);
+    }
+}

--- a/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
+++ b/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
@@ -51,7 +51,7 @@ final class DispatchPreWriteEventProcessorTest extends TestCase
     }
 
     /** @test */
-    public function it_dispatches_pre_events_with_operation_as_string(): void
+    public function it_dispatches_pre_events(): void
     {
         $data = new \stdClass();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Extracted from https://github.com/Sylius/SyliusResourceBundle/pull/817
It was PreEventDispatcherProcessor but I think it's a better name now.

I've decided to split https://github.com/Sylius/SyliusResourceBundle/blob/1.11/src/Component/src/State/Processor/EventDispatcherProcessor.php into two processors, so this one is the first part of the split.

This processor allows user switching from resource controller to this new system easily.
But we will be able to deprecate this event in the future.
