### PR TITLE
Remove cache on metadata when debug is enabled

### DIFF
--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -27,7 +27,7 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterStateMachi
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\TwigPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\WinzouStateMachinePass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\PagerfantaExtension;
-use Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
+use Sylius\Resource\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -27,6 +27,7 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterStateMachi
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\TwigPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\WinzouStateMachinePass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\PagerfantaExtension;
+use Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -46,6 +47,7 @@ final class SyliusResourceBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new CsrfTokenManagerPass());
+        $container->addCompilerPass(new DisableMetadataCachePass());
         $container->addCompilerPass(new DoctrineContainerRepositoryFactoryPass());
         $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(new TargetEntitiesResolver()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RegisterFormBuilderPass());

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -49,6 +49,7 @@
     "require-dev": {
         "behat/transliterator": "^1.3",
         "doctrine/orm": "^2.5",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.2.1",
         "phpspec/phpspec": "^7.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",

--- a/src/Component/src/State/Processor/WriteProcessor.php
+++ b/src/Component/src/State/Processor/WriteProcessor.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\src\State\Processor;
+namespace Sylius\Resource\State\Processor;
 
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Operation;

--- a/src/Component/src/Symfony/DependencyIjection/Compiler/DisableMetadataCachePass.php
+++ b/src/Component/src/Symfony/DependencyIjection/Compiler/DisableMetadataCachePass.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler;
+namespace Sylius\Resource\Symfony\DependencyIjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Component/src/Symfony/DependencyIjection/Compiler/DisableMetadataCachePass.php
+++ b/src/Component/src/Symfony/DependencyIjection/Compiler/DisableMetadataCachePass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class DisableMetadataCachePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (
+            !$container->hasParameter('kernel.debug') ||
+            !$container->getParameter('kernel.debug')
+        ) {
+            return;
+        }
+
+        $container->removeDefinition('sylius.resource_metadata_collection.factory.cached');
+    }
+}

--- a/src/Component/src/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessor.php
+++ b/src/Component/src/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessor.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\src\Symfony\EventDispatcher\State;
+namespace Sylius\Resource\Symfony\EventDispatcher\State;
 
 use Sylius\Component\Resource\ResourceActions;
 use Sylius\Resource\Context\Context;

--- a/src/Component/tests/State/Processor/WriteProcessorTest.php
+++ b/src/Component/tests/State/Processor/WriteProcessorTest.php
@@ -17,9 +17,9 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sylius\Component\Resource\src\State\Processor\WriteProcessor;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Create;
+use Sylius\Resource\State\Processor\WriteProcessor;
 use Sylius\Resource\State\ProcessorInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
+++ b/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\tests\Symfony\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class DisableMetadataCachePassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_disables_cache_when_debug_is_enabled(): void
+    {
+        $this->setDefinition('sylius.resource_metadata_collection.factory.cached', new Definition());
+        $this->setParameter('kernel.debug', true);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sylius.resource_metadata_collection.factory.cached');
+    }
+
+    /** @test */
+    public function it_does_not_disable_cache_when_debug_is_disabled(): void
+    {
+        $this->setDefinition('sylius.resource_metadata_collection.factory.cached', new Definition());
+        $this->setParameter('kernel.debug', false);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius.resource_metadata_collection.factory.cached');
+    }
+
+    /** @test */
+    public function it_does_not_disable_cache_when_debug_parameter_does_not_exist(): void
+    {
+        $this->setDefinition('sylius.resource_metadata_collection.factory.cached', new Definition());
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius.resource_metadata_collection.factory.cached');
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new DisableMetadataCachePass());
+    }
+}

--- a/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
+++ b/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Resource\tests\Symfony\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Sylius\Component\Resource\src\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
+use Sylius\Resource\Symfony\DependencyIjection\Compiler\DisableMetadataCachePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 

--- a/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
+++ b/src/Component/tests/Symfony/EventDispatcher/State/DispatchPreWriteEventProcessorTest.php
@@ -16,13 +16,13 @@ namespace spec\Sylius\Resource\Symfony\EventDispatcher\State;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sylius\Component\Resource\src\Symfony\EventDispatcher\State\DispatchPreWriteEventProcessor;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\State\ProcessorInterface;
 use Sylius\Resource\Symfony\EventDispatcher\OperationEvent;
 use Sylius\Resource\Symfony\EventDispatcher\OperationEventDispatcherInterface;
 use Sylius\Resource\Symfony\EventDispatcher\OperationEventHandlerInterface;
+use Sylius\Resource\Symfony\EventDispatcher\State\DispatchPreWriteEventProcessor;
 use Symfony\Component\HttpFoundation\Response;
 
 final class DispatchPreWriteEventProcessorTest extends TestCase


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On dev, when updating metadata, the metadata (and so the routing) was in cache due to this service. But on dev/test environment, we don't need that cache, we need to update the routing while configuring the attributes on our Sylius resources.