### PR TITLE
Add local constraints

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,10 @@ These following services are now Doctrine listeners instead of Doctrine subscrib
 * Sylius\Bundle\ResourceBundle\EventListener\ORMRepositoryClassSubscriber
 * Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber
 
+Applied the `UniqueEntity` constraint for `locale` and `translatable` fields, and added `NotBlank` & `Locale` constraints for the `locale` property in classes extending `Sylius\Resource\Model\AbstractTranslation`.
+
+Applied the `Valid` constraint for the `getTranslations` method for objects implementing `Sylius\Resource\Model\TranslatableInterface`.
+
 
 ## UPGRADE FOR `1.10.x`
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/form": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/http-foundation": "^5.4 || ^6.0",
+        "symfony/intl": "^5.4 || ^6.0",
         "symfony/security-core": "^5.4 || ^6.0",
         "symfony/security-csrf": "^5.4 || ^6.0",
         "symfony/routing": "^5.4 || ^6.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -83,12 +83,6 @@
             </errorLevel>
         </InvalidArgument>
 
-        <InvalidDocblock>
-            <errorLevel type="suppress">
-                <file name="vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php" />
-            </errorLevel>
-        </InvalidDocblock>
-
         <InvalidReturnStatement>
             <errorLevel type="suppress">
                 <file name="src/Component/src/Doctrine/Persistence/InMemoryRepository.php" />
@@ -170,7 +164,7 @@
                 <file name="src/Bundle/Routing/Configuration.php" />
             </errorLevel>
         </PossiblyNullReference>
-        
+
         <PossiblyUndefinedArrayOffset>
             <errorLevel type="suppress">
                 <file name="src/Bundle/Controller/ParametersParser.php" />
@@ -204,7 +198,7 @@
                 <file name="src/Bundle/Form/DataTransformer/CollectionToStringTransformer.php" />
             </errorLevel>
         </RedundantConditionGivenDocblockType>
-        
+
         <RiskyTruthyFalsyComparison>
             <errorLevel type="suppress">
                 <directory name="src" />

--- a/src/Bundle/Resources/config/validation/AbstractTranslation.xml
+++ b/src/Bundle/Resources/config/validation/AbstractTranslation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+    <class name="Sylius\Resource\Model\AbstractTranslation">
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">
+                <value>locale</value>
+                <value>translatable</value>
+            </option>
+            <option name="groups">sylius</option>
+            <option name="message">sylius.resource.translation.locale.unique</option>
+        </constraint>
+        <property name="locale">
+            <constraint name="NotBlank">
+                <option name="groups">sylius</option>
+                <option name="message">sylius.resource.translation.locale.not_blank</option>
+            </constraint>
+            <constraint name="Locale">
+                <option name="groups">sylius</option>
+                <option name="message">sylius.resource.translation.locale.invalid</option>
+            </constraint>
+        </property>
+    </class>
+</constraint-mapping>

--- a/src/Bundle/Resources/config/validation/TranslatableInterface.xml
+++ b/src/Bundle/Resources/config/validation/TranslatableInterface.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+    <class name="Sylius\Resource\Model\TranslatableInterface">
+        <getter property="translations">
+            <constraint name="Valid" />
+        </getter>
+    </class>
+</constraint-mapping>

--- a/src/Bundle/Resources/translations/validators.en.yml
+++ b/src/Bundle/Resources/translations/validators.en.yml
@@ -2,3 +2,8 @@ sylius:
     resource:
         not_enabled: "Given resource is disabled"
         not_disabled: "Given resource is enabled"
+        translation:
+            locale:
+                not_blank: Please enter the locale.
+                invalid: This value is not a valid locale.
+                unique: A translation for the {{ value }} locale code already exists.

--- a/tests/Application/src/Tests/DataFixtures/ORM/books.yml
+++ b/tests/Application/src/Tests/DataFixtures/ORM/books.yml
@@ -9,3 +9,9 @@ App\Entity\Book:
         currentLocale: en_US
         title: "Game of Thrones"
         author: "George R. R. Martin"
+
+App\Entity\BookTranslation:
+    book1_pl_PL:
+        title: "Władca Pierścieni"
+        locale: "pl_PL"
+        translatable: "@book1"

--- a/tests/Application/src/Tests/Validator/TranslatableValidatorTest.php
+++ b/tests/Application/src/Tests/Validator/TranslatableValidatorTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final class TranslatableValidatorTest extends JsonApiTestCase
 {
     /** @test */
-    public function it_fails_validation_with_empty_locale()
+    public function it_fails_validation_with_empty_locale(): void
     {
         $this->loadFixturesFromFile('books.yml');
         $book = $this->getBookBy();
@@ -32,7 +32,7 @@ final class TranslatableValidatorTest extends JsonApiTestCase
     }
 
     /** @test */
-    public function it_fails_validation_with_invalid_locale()
+    public function it_fails_validation_with_invalid_locale(): void
     {
         $this->loadFixturesFromFile('books.yml');
         $book = $this->getBookBy();
@@ -44,7 +44,7 @@ final class TranslatableValidatorTest extends JsonApiTestCase
     }
 
     /** @test */
-    public function it_fails_validation_with_not_unique_locale()
+    public function it_fails_validation_with_not_unique_locale(): void
     {
         $this->loadFixturesFromFile('books.yml');
         $book = $this->getBookBy();

--- a/tests/Application/src/Tests/Validator/TranslatableValidatorTest.php
+++ b/tests/Application/src/Tests/Validator/TranslatableValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Validator;
+
+use ApiTestCase\JsonApiTestCase;
+use App\Entity\Book;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class TranslatableValidatorTest extends JsonApiTestCase
+{
+    /** @test */
+    public function it_fails_validation_with_empty_locale()
+    {
+        $this->loadFixturesFromFile('books.yml');
+        $book = $this->getBookBy();
+        $book->getTranslation('pl_PL')->setLocale('');
+
+        $errors = $this->getValidator()->validate($book, null, ['sylius']);
+        $this->assertCount(1, $errors);
+        $this->assertSame('sylius.resource.translation.locale.not_blank', $errors->get(0)->getMessageTemplate());
+    }
+
+    /** @test */
+    public function it_fails_validation_with_invalid_locale()
+    {
+        $this->loadFixturesFromFile('books.yml');
+        $book = $this->getBookBy();
+        $book->getTranslation('pl_PL')->setLocale('invalid');
+
+        $errors = $this->getValidator()->validate($book, null, ['sylius']);
+        $this->assertCount(1, $errors);
+        $this->assertSame('sylius.resource.translation.locale.invalid', $errors->get(0)->getMessageTemplate());
+    }
+
+    /** @test */
+    public function it_fails_validation_with_not_unique_locale()
+    {
+        $this->loadFixturesFromFile('books.yml');
+        $book = $this->getBookBy();
+        $book->getTranslation('pl_PL')->setLocale('en_US');
+
+        $errors = $this->getValidator()->validate($book, null, ['sylius']);
+        $this->assertCount(1, $errors);
+        $this->assertSame('sylius.resource.translation.locale.unique', $errors->get(0)->getMessageTemplate());
+    }
+
+    private function getValidator(): ValidatorInterface
+    {
+        return self::getContainer()->get('validator');
+    }
+
+    private function getBookBy(array $criteria = ['author' => 'J.R.R. Tolkien']): ?Book
+    {
+        return self::getContainer()->get('app.repository.book')->findOneBy($criteria);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

I have added Symfony constraints that correspond to database constraints, including the `Locale` constraint for enhanced validation, even though it doesn't directly match a database constraint.