### PR TITLE
Move some namespaces on State machines

### DIFF
--- a/src/Bundle/Resources/config/services/state.xml
+++ b/src/Bundle/Resources/config/services/state.xml
@@ -54,7 +54,7 @@
             <tag name="sylius.state_processor" />
         </service>
 
-        <service id="Sylius\Component\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor">
+        <service id="Sylius\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor">
             <argument type="service" id="sylius.state_machine.operation" />
             <argument type="service" id="Sylius\Resource\Doctrine\Common\State\PersistProcessor" />
             <tag name="sylius.state_processor" />

--- a/src/Bundle/Resources/config/services/state_machine.xml
+++ b/src/Bundle/Resources/config/services/state_machine.xml
@@ -13,10 +13,10 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.state_machine.operation" class="Sylius\Component\Resource\StateMachine\OperationStateMachine">
+        <service id="sylius.state_machine.operation" class="Sylius\Resource\StateMachine\OperationStateMachine">
             <argument type="tagged_locator" tag="sylius.state_machine" index-by="key" />
         </service>
-        <service id="Sylius\Component\Resource\StateMachine\OperationStateMachineInterface" alias="sylius.state_machine.operation" />
+        <service id="Sylius\Resource\StateMachine\OperationStateMachineInterface" alias="sylius.state_machine.operation" />
 
         <service id="sylius.state_machine.operation.default" alias="sylius.state_machine.operation.winzou" />
 

--- a/src/Component/legacy/src/Winzou/StateMachine/OperationStateMachine.php
+++ b/src/Component/legacy/src/Winzou/StateMachine/OperationStateMachine.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Component\Resource\Winzou\StateMachine;
 
 use SM\Factory\Factory;
-use Sylius\Component\Resource\StateMachine\OperationStateMachineInterface;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\StateMachineAwareOperationInterface;
+use Sylius\Resource\StateMachine\OperationStateMachineInterface;
 use Webmozart\Assert\Assert;
 
 final class OperationStateMachine implements OperationStateMachineInterface

--- a/src/Component/spec/Metadata/Resource/Factory/StateMachineResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/StateMachineResourceMetadataCollectionFactorySpec.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Resource\Metadata\Resource\Factory;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operations;
@@ -23,6 +22,7 @@ use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryI
 use Sylius\Resource\Metadata\Resource\Factory\StateMachineResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 
 final class StateMachineResourceMetadataCollectionFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/StateMachine/OperationStateMachineSpec.php
+++ b/src/Component/spec/StateMachine/OperationStateMachineSpec.php
@@ -11,16 +11,16 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Resource\StateMachine;
+namespace spec\Sylius\Resource\StateMachine;
 
 use PhpSpec\ObjectBehavior;
 use Psr\Container\ContainerInterface;
-use Sylius\Component\Resource\StateMachine\OperationStateMachine;
-use Sylius\Component\Resource\StateMachine\OperationStateMachineInterface;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\StateMachineAwareOperationInterface;
+use Sylius\Resource\StateMachine\OperationStateMachine;
+use Sylius\Resource\StateMachine\OperationStateMachineInterface;
 
 final class OperationStateMachineSpec extends ObjectBehavior
 {

--- a/src/Component/spec/StateMachine/State/ApplyStateMachineTransitionProcessorSpec.php
+++ b/src/Component/spec/StateMachine/State/ApplyStateMachineTransitionProcessorSpec.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Resource\StateMachine\State;
+namespace spec\Sylius\Resource\StateMachine\State;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Resource\StateMachine\OperationStateMachineInterface;
-use Sylius\Component\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\State\ProcessorInterface;
+use Sylius\Resource\StateMachine\OperationStateMachineInterface;
+use Sylius\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 
 final class ApplyStateMachineTransitionProcessorSpec extends ObjectBehavior
 {

--- a/src/Component/src/Metadata/Resource/Factory/StateMachineResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/StateMachineResourceMetadataCollectionFactory.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Metadata\Resource\Factory;
 
-use Sylius\Component\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\Operations;
@@ -21,6 +20,7 @@ use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\StateMachineAwareOperationInterface;
+use Sylius\Resource\StateMachine\State\ApplyStateMachineTransitionProcessor;
 
 final class StateMachineResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {

--- a/src/Component/src/StateMachine/OperationStateMachine.php
+++ b/src/Component/src/StateMachine/OperationStateMachine.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\StateMachine;
+namespace Sylius\Resource\StateMachine;
 
 use Psr\Container\ContainerInterface;
 use Sylius\Resource\Context\Context;

--- a/src/Component/src/StateMachine/OperationStateMachineInterface.php
+++ b/src/Component/src/StateMachine/OperationStateMachineInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\StateMachine;
+namespace Sylius\Resource\StateMachine;
 
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Operation;

--- a/src/Component/src/StateMachine/State/ApplyStateMachineTransitionProcessor.php
+++ b/src/Component/src/StateMachine/State/ApplyStateMachineTransitionProcessor.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\StateMachine\State;
+namespace Sylius\Resource\StateMachine\State;
 
-use Sylius\Component\Resource\StateMachine\OperationStateMachineInterface;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\State\ProcessorInterface;
+use Sylius\Resource\StateMachine\OperationStateMachineInterface;
 
 final class ApplyStateMachineTransitionProcessor implements ProcessorInterface
 {

--- a/src/Component/src/Symfony/Workflow/OperationStateMachine.php
+++ b/src/Component/src/Symfony/Workflow/OperationStateMachine.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Symfony\Workflow;
 
-use Sylius\Component\Resource\StateMachine\OperationStateMachineInterface;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\StateMachineAwareOperationInterface;
+use Sylius\Resource\StateMachine\OperationStateMachineInterface;
 use Symfony\Component\Workflow\Registry;
 use Webmozart\Assert\Assert;
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no (it was introduced in 1.11)
| Deprecations?   | no
| Related tickets |
| License         | MIT

I will move the `Sylius\Component\Resource\StateMachine\StateMachineInterface` with bc-layer in another PR.
