### PR TITLE
[Maintenance] Add an exception for unavailable storages

### DIFF
--- a/src/Bundle/Storage/SessionStorage.php
+++ b/src/Bundle/Storage/SessionStorage.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Storage;
 
-use Sylius\Component\Resource\Exception\StorageUnavailableException;
+use Sylius\Resource\Exception\StorageUnavailableException;
 use Sylius\Resource\Storage\StorageInterface;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Bundle/spec/Storage/SessionStorageSpec.php
+++ b/src/Bundle/spec/Storage/SessionStorageSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ResourceBundle\Storage;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Resource\Exception\StorageUnavailableException;
+use Sylius\Resource\Exception\StorageUnavailableException;
 use Sylius\Resource\Storage\StorageInterface;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Bundle/spec/Storage/SessionStorageSpec.php
+++ b/src/Bundle/spec/Storage/SessionStorageSpec.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ResourceBundle\Storage;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Exception\StorageUnavailableException;
 use Sylius\Resource\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -36,6 +38,18 @@ final class SessionStorageSpec extends ObjectBehavior
     function it_is_a_storage(): void
     {
         $this->shouldImplement(StorageInterface::class);
+    }
+
+    function it_throws_storage_unavailable_exception_when_there_is_no_session(RequestStack $requestStack): void
+    {
+        $requestStack->getSession()->willThrow(SessionNotFoundException::class);
+
+        $call = $this->shouldThrow(StorageUnavailableException::class);
+        $call->during('has', ['name']);
+        $call->during('get', ['name']);
+        $call->during('set', ['name', 'value']);
+        $call->during('remove', ['name']);
+        $call->during('all');
     }
 
     function it_does_not_have_a_named_value_if_it_was_not_set_previously(): void

--- a/src/Component/legacy/src/Exception/StorageUnavailableException.php
+++ b/src/Component/legacy/src/Exception/StorageUnavailableException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Exception;
+
+class StorageUnavailableException extends \RuntimeException
+{
+    public function __construct(string $message = '', \Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Component/src/Exception/StorageUnavailableException.php
+++ b/src/Component/src/Exception/StorageUnavailableException.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\Exception;
+namespace Sylius\Resource\Exception;
 
-class StorageUnavailableException extends \RuntimeException
+class StorageUnavailableException extends RuntimeException
 {
     public function __construct(string $message = '', \Exception $previous = null)
     {

--- a/src/Component/src/Storage/StorageInterface.php
+++ b/src/Component/src/Storage/StorageInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Storage;
 
-use Sylius\Component\Resource\Exception\StorageUnavailableException;
+use Sylius\Resource\Exception\StorageUnavailableException;
 
 interface StorageInterface
 {

--- a/src/Component/src/Storage/StorageInterface.php
+++ b/src/Component/src/Storage/StorageInterface.php
@@ -13,24 +13,39 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Storage;
 
+use Sylius\Component\Resource\Exception\StorageUnavailableException;
+
 interface StorageInterface
 {
+    /**
+     * @throws StorageUnavailableException
+     */
     public function has(string $name): bool;
 
     /**
      * @param mixed $default
      *
      * @return mixed
+     *
+     * @throws StorageUnavailableException
      */
     public function get(string $name, $default = null);
 
     /**
      * @param mixed $value
+     *
+     * @throws StorageUnavailableException
      */
     public function set(string $name, $value): void;
 
+    /**
+     * @throws StorageUnavailableException
+     */
     public function remove(string $name): void;
 
+    /**
+     * @throws StorageUnavailableException
+     */
     public function all(): array;
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | kinda
| New feature?    | yes?
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

There's a bunch of issues open Sylius regarding cli/stateless actions resulting in fatals since session is not available when resolving something within a context.
Would be nice to have a unified way of knowing whether the storage medium can be accessed at all.