### PR TITLE
Fix state machine tag

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -120,6 +120,13 @@
             </errorLevel>
         </MethodSignatureMismatch>
 
+        <MissingClassConstType>
+            <errorLevel type="suppress">
+                <directory name="src/Bundle" />
+                <directory name="src/Component" />
+            </errorLevel>
+        </MissingClassConstType>
+
         <MissingParamType>
             <errorLevel type="suppress">
                 <file name="src/Bundle/Routing/ResourceLoader.php" />

--- a/src/Bundle/Resources/config/services/state_machine.xml
+++ b/src/Bundle/Resources/config/services/state_machine.xml
@@ -14,7 +14,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.state_machine.operation" class="Sylius\Resource\StateMachine\OperationStateMachine">
-            <argument type="tagged_locator" tag="sylius.state_machine" index-by="key" />
+            <argument type="tagged_locator" tag="sylius_resource.state_machine" index-by="key" />
         </service>
         <service id="Sylius\Resource\StateMachine\OperationStateMachineInterface" alias="sylius.state_machine.operation" />
 
@@ -22,12 +22,12 @@
 
         <service id="sylius.state_machine.operation.symfony" class="Sylius\Resource\Symfony\Workflow\OperationStateMachine">
             <argument type="service" id="workflow.registry" on-invalid="null" />
-            <tag name="sylius.state_machine" key="symfony" />
+            <tag name="sylius_resource.state_machine" key="symfony" />
         </service>
 
         <service id="sylius.state_machine.operation.winzou" class="Sylius\Resource\Winzou\StateMachine\OperationStateMachine">
             <argument type="service" id="sm.factory" on-invalid="null" />
-            <tag name="sylius.state_machine" key="winzou" />
+            <tag name="sylius_resource.state_machine" key="winzou" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

👋 As Sylius introduced the state machine layer abstraction with its own `sylius.state_machine` service tag, we have a little conflict of configuration, which prevents using SyliusResourceBundle with Sylius 1.13 for now :dancer: (see [this issue](https://github.com/Sylius/Sylius/issues/16231))

For now, I propose we change the tag in this repository to `sylius_resource.state_machine` (which is also semantically more correct), but we should probably think if there is any thing we need to do on this repo according to this state machine abstraction 🖖 