### PR TITLE
Fix form parameter bags accesing in request handler

### DIFF
--- a/src/Bundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Bundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -60,7 +60,7 @@ final class HttpFoundationRequestHandler implements RequestHandlerInterface
                     return;
                 }
 
-                $data = $request->query->all($name);
+                $data = $request->query->all()[$name];
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -93,12 +93,7 @@ final class HttpFoundationRequestHandler implements RequestHandlerInterface
                 /** @psalm-var array|null $default */
                 $default = $form->getConfig()->getCompound() ? [] : null;
 
-                if ($request->request->has($name)) {
-                    $params = $request->request->all($name);
-                } else {
-                    $params = $default;
-                }
-
+                $params = $request->request->all()[$name] ?? $default;
                 $files = $request->files->get($name, $default);
             } else {
                 // Don't submit the form if it is not present in the request


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #876, followup of #507
| License         | MIT

Keeping the way we access the parameters bag the same way it's done in the base class.
Refs:
- https://github.com/symfony/form/blob/5.4/Extension/HttpFoundation/HttpFoundationRequestHandler.php
- https://github.com/symfony/form/blob/6.4/Extension/HttpFoundation/HttpFoundationRequestHandler.php