### PR TITLE
Move some routing factories into 2 sub-directories

### DIFF
--- a/src/Bundle/Resources/config/services/routing.xml
+++ b/src/Bundle/Resources/config/services/routing.xml
@@ -39,16 +39,16 @@
         </service>
         <service id="Sylius\Bundle\ResourceBundle\Routing\RoutesAttributesLoader" alias="sylius.routing.loader.routes_attributes" public="false" />
 
-        <service id="sylius.routing.factory.operation_route_name_factory" class="Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory" public="false" />
-        <service id="Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactoryInterface" alias="sylius.routing.factory.operation_route_name_factory" />
+        <service id="sylius.routing.factory.operation_route_name_factory" class="Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory" public="false" />
+        <service id="Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactoryInterface" alias="sylius.routing.factory.operation_route_name_factory" />
 
-        <service id="sylius.routing.factory.operation_route_path_factory.default" class="Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactory" public="false" />
+        <service id="sylius.routing.factory.operation_route_path_factory.default" class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactory" public="false" />
 
         <service id="sylius.routing.factory.operation_route_path_factory" alias="sylius.routing.factory.operation_route_path_factory.default" />
-        <service id="Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface" alias="sylius.routing.factory.operation_route_path_factory" />
+        <service id="Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface" alias="sylius.routing.factory.operation_route_path_factory" />
 
         <service id="sylius.routing.factory.operation_route_path_factory.collection"
-                 class="Sylius\Resource\Symfony\Routing\Factory\CollectionOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\CollectionOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="60"
         >
@@ -56,7 +56,7 @@
         </service>
 
         <service id="sylius.routing.factory.operation_route_path_factory.create"
-                 class="Sylius\Resource\Symfony\Routing\Factory\CreateOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\CreateOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="-50"
         >
@@ -64,7 +64,7 @@
         </service>
 
         <service id="sylius.routing.factory.operation_route_path_factory.bulk_operation"
-                 class="Sylius\Resource\Symfony\Routing\Factory\BulkOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\BulkOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="-40"
         >
@@ -72,7 +72,7 @@
         </service>
 
         <service id="sylius.routing.factory.operation_route_path_factory.update"
-                 class="Sylius\Resource\Symfony\Routing\Factory\UpdateOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\UpdateOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="-30"
         >
@@ -80,7 +80,7 @@
         </service>
 
         <service id="sylius.routing.factory.operation_route_path_factory.delete"
-                 class="Sylius\Resource\Symfony\Routing\Factory\DeleteOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\DeleteOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="-20"
         >
@@ -88,7 +88,7 @@
         </service>
 
         <service id="sylius.routing.factory.operation_route_path_factory.show"
-                 class="Sylius\Resource\Symfony\Routing\Factory\ShowOperationRoutePathFactory"
+                 class="Sylius\Resource\Symfony\Routing\Factory\RoutePath\ShowOperationRoutePathFactory"
                  decorates="sylius.routing.factory.operation_route_path_factory.default"
                  decoration-priority="-10"
         >

--- a/src/Bundle/spec/Routing/AttributesOperationRouteFactorySpec.php
+++ b/src/Bundle/spec/Routing/AttributesOperationRouteFactorySpec.php
@@ -25,8 +25,8 @@ use Sylius\Resource\Metadata\Resource\Factory\AttributesResourceMetadataCollecti
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 use Sylius\Resource\Symfony\Routing\Factory\OperationRouteFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Webmozart\Assert\Assert;
 

--- a/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactorySpec.php
@@ -41,7 +41,7 @@ use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 use Sylius\Resource\Symfony\Request\State\Responder;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 
 final class AttributesResourceMetadataCollectionFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactorySpec.php
+++ b/src/Component/spec/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactorySpec.php
@@ -24,7 +24,7 @@ use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 
 final class RedirectResourceMetadataCollectionFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
@@ -26,7 +26,7 @@ use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
 use Sylius\Resource\Symfony\Routing\Factory\OperationRouteFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
 final class OperationRouteFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RouteName/OperationRouteNameFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RouteName/OperationRouteNameFactorySpec.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RouteName;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\ResourceMetadata;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 
 final class OperationRouteNameFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactorySpec.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\BulkDelete;
 use Sylius\Resource\Metadata\BulkUpdate;
-use Sylius\Resource\Symfony\Routing\Factory\BulkOperationRoutePathFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\BulkOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
 final class BulkOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactorySpec.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Index;
-use Sylius\Resource\Symfony\Routing\Factory\CollectionOperationRoutePathFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\CollectionOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
 final class CollectionOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactorySpec.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Create;
-use Sylius\Resource\Symfony\Routing\Factory\CreateOperationRoutePathFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\CreateOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
 final class CreateOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactorySpec.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Metadata\ResourceMetadata;
-use Sylius\Resource\Symfony\Routing\Factory\DeleteOperationRoutePathFactory;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\DeleteOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
 final class DeleteOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactorySpec.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
-use Sylius\Resource\Symfony\Routing\Factory\ShowOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\ShowOperationRoutePathFactory;
 
 final class ShowOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactorySpec.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Resource\Symfony\Routing\Factory;
+namespace spec\Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Update;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRoutePathFactoryInterface;
-use Sylius\Resource\Symfony\Routing\Factory\UpdateOperationRoutePathFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\UpdateOperationRoutePathFactory;
 
 final class UpdateOperationRoutePathFactorySpec extends ObjectBehavior
 {

--- a/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
+++ b/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
@@ -20,7 +20,7 @@ use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactoryInterface;
 use Sylius\Resource\Symfony\Routing\RedirectHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/Component/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -23,7 +23,7 @@ use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Reflection\ClassReflection;
 use Sylius\Resource\Symfony\Request\State\Responder;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 
 final class AttributesResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {

--- a/src/Component/src/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/RedirectResourceMetadataCollectionFactory.php
@@ -22,7 +22,7 @@ use Sylius\Resource\Metadata\Operations;
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\UpdateOperationInterface;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactory;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 
 final class RedirectResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {

--- a/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
@@ -17,6 +17,7 @@ use Gedmo\Sluggable\Util\Urlizer;
 use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\Route;
 
 final class OperationRouteFactory implements OperationRouteFactoryInterface

--- a/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactory.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RouteName;
 
 use Sylius\Resource\Metadata\Operation;
 

--- a/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactoryInterface.php
+++ b/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactoryInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RouteName;
 
 use Sylius\Resource\Metadata\Operation;
 

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactory.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
-use Sylius\Resource\Metadata\CollectionOperationInterface;
+use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
 
-final class CollectionOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class BulkOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -24,15 +24,10 @@ final class CollectionOperationRoutePathFactory implements OperationRoutePathFac
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
     {
-        $shortName = $operation->getShortName();
+        $shortName = $operation->getShortName() ?? '';
 
-        if ($operation instanceof CollectionOperationInterface) {
-            $path = match ($shortName) {
-                'index', 'get_collection' => '',
-                default => '/' . $shortName,
-            };
-
-            return sprintf('%s%s', $rootPath, $path);
+        if ($operation instanceof BulkOperationInterface) {
+            return sprintf('%s/%s', $rootPath, $shortName);
         }
 
         return $this->decorated->createRoutePath($operation, $rootPath);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactory.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
+use Sylius\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\UpdateOperationInterface;
 
-final class UpdateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class CollectionOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -25,16 +25,14 @@ final class UpdateOperationRoutePathFactory implements OperationRoutePathFactory
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
     {
         $shortName = $operation->getShortName();
-        $identifier = $operation->getResource()?->getIdentifier() ?? 'id';
 
-        if ($operation instanceof UpdateOperationInterface) {
+        if ($operation instanceof CollectionOperationInterface) {
             $path = match ($shortName) {
-                'update' => '/edit',
-                'put', 'patch' => '',
+                'index', 'get_collection' => '',
                 default => '/' . $shortName,
             };
 
-            return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);
+            return sprintf('%s%s', $rootPath, $path);
         }
 
         return $this->decorated->createRoutePath($operation, $rootPath);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactory.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
-use Sylius\Resource\Metadata\BulkOperationInterface;
+use Sylius\Resource\Metadata\CreateOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
 
-final class BulkOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class CreateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -24,10 +24,16 @@ final class BulkOperationRoutePathFactory implements OperationRoutePathFactoryIn
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
     {
-        $shortName = $operation->getShortName() ?? '';
+        $shortName = $operation->getShortName();
 
-        if ($operation instanceof BulkOperationInterface) {
-            return sprintf('%s/%s', $rootPath, $shortName);
+        if ($operation instanceof CreateOperationInterface) {
+            $path = match ($shortName) {
+                'create' => '/new',
+                'post' => '',
+                default => '/' . $shortName,
+            };
+
+            return sprintf('%s%s', $rootPath, $path);
         }
 
         return $this->decorated->createRoutePath($operation, $rootPath);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactory.php
@@ -11,12 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
-use Sylius\Resource\Metadata\CreateOperationInterface;
+use Sylius\Resource\Metadata\Api\ApiOperationInterface;
+use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
 
-final class CreateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class DeleteOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -25,15 +26,12 @@ final class CreateOperationRoutePathFactory implements OperationRoutePathFactory
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
     {
         $shortName = $operation->getShortName();
+        $identifier = $operation->getResource()?->getIdentifier() ?? 'id';
 
-        if ($operation instanceof CreateOperationInterface) {
-            $path = match ($shortName) {
-                'create' => '/new',
-                'post' => '',
-                default => '/' . $shortName,
-            };
+        if ($operation instanceof DeleteOperationInterface) {
+            $path = $operation instanceof ApiOperationInterface && 'delete' === $shortName ? '' : '/' . $shortName;
 
-            return sprintf('%s%s', $rootPath, $path);
+            return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);
         }
 
         return $this->decorated->createRoutePath($operation, $rootPath);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/OperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/OperationRoutePathFactory.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\Operation;
 

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/OperationRoutePathFactoryInterface.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/OperationRoutePathFactoryInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\HttpOperation;
 

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactory.php
@@ -11,13 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
-use Sylius\Resource\Metadata\Api\ApiOperationInterface;
-use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\ShowOperationInterface;
 
-final class DeleteOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class ShowOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -28,8 +27,11 @@ final class DeleteOperationRoutePathFactory implements OperationRoutePathFactory
         $shortName = $operation->getShortName();
         $identifier = $operation->getResource()?->getIdentifier() ?? 'id';
 
-        if ($operation instanceof DeleteOperationInterface) {
-            $path = $operation instanceof ApiOperationInterface && 'delete' === $shortName ? '' : '/' . $shortName;
+        if ($operation instanceof ShowOperationInterface) {
+            $path = match ($shortName) {
+                'show', 'get' => '',
+                default => '/' . $shortName,
+            };
 
             return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);
         }

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactory.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Resource\Symfony\Routing\Factory;
+namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\ShowOperationInterface;
+use Sylius\Resource\Metadata\UpdateOperationInterface;
 
-final class ShowOperationRoutePathFactory implements OperationRoutePathFactoryInterface
+final class UpdateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
     public function __construct(private OperationRoutePathFactoryInterface $decorated)
     {
@@ -27,9 +27,10 @@ final class ShowOperationRoutePathFactory implements OperationRoutePathFactoryIn
         $shortName = $operation->getShortName();
         $identifier = $operation->getResource()?->getIdentifier() ?? 'id';
 
-        if ($operation instanceof ShowOperationInterface) {
+        if ($operation instanceof UpdateOperationInterface) {
             $path = match ($shortName) {
-                'show', 'get' => '',
+                'update' => '/edit',
+                'put', 'patch' => '',
                 default => '/' . $shortName,
             };
 

--- a/src/Component/src/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/src/Symfony/Routing/RedirectHandler.php
@@ -18,7 +18,7 @@ use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
-use Sylius\Resource\Symfony\Routing\Factory\OperationRouteNameFactoryInterface;
+use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no (it has been added to 1.11 only)
| Deprecations?   | no
| Related tickets | 
| License         | MIT

To improve quality and future maintenance, I split the routing factories into 2 sub-directories.