### PR TITLE
Fix grid limits on request grid provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "twig/twig": "^2.12 || ^3.0",
         "vimeo/psalm": "^5.20",
         "rector/rector": "^0.18.2",
+        "symfony/css-selector": "^5.4 || ^6.4",
         "symfony/messenger": "^5.4 || ^6.4",
         "symfony/serializer": "^5.4 || ^6.4",
         "symfony/security-bundle": "^5.4 || ^6.4"

--- a/src/Component/spec/Grid/State/RequestGridProviderSpec.php
+++ b/src/Component/spec/Grid/State/RequestGridProviderSpec.php
@@ -80,12 +80,101 @@ final class RequestGridProviderSpec extends ObjectBehavior
         $request->query = new InputBag(['page' => 42]);
 
         $gridProvider->get('app_book')->willReturn($gridDefinition);
+        $gridDefinition->getLimits()->willReturn([]);
         $gridDefinition->getDriverConfiguration()->willReturn([]);
 
         $gridViewFactory->create($gridDefinition, $context, new Parameters(['page' => 42]), [])->willReturn($gridView);
 
         $gridView->getData()->willReturn($pagerfanta);
         $pagerfanta->setCurrentPage(42)->willReturn($pagerfanta)->shouldBeCalled();
+        $pagerfanta->setMaxPerPage(10)->willReturn($pagerfanta)->shouldBeCalled();
+
+        $this->provide($operation, $context)
+            ->shouldReturn($gridView)
+        ;
+    }
+
+    function it_sets_max_per_page_from_request(
+        Request $request,
+        GridViewFactoryInterface $gridViewFactory,
+        GridProviderInterface $gridProvider,
+        Grid $gridDefinition,
+        GridView $gridView,
+        Pagerfanta $pagerfanta,
+    ): void {
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $operation = new Index(grid: 'app_book');
+
+        $request->query = new InputBag(['limit' => 25]);
+
+        $gridProvider->get('app_book')->willReturn($gridDefinition);
+        $gridDefinition->getDriverConfiguration()->willReturn([]);
+        $gridDefinition->getLimits()->willReturn([10, 25]);
+
+        $gridViewFactory->create($gridDefinition, $context, new Parameters(['limit' => 25]), [])->willReturn($gridView);
+
+        $gridView->getData()->willReturn($pagerfanta);
+        $pagerfanta->setCurrentPage(1)->willReturn($pagerfanta)->shouldBeCalled();
+        $pagerfanta->setMaxPerPage(25)->willReturn($pagerfanta)->shouldBeCalled();
+
+        $this->provide($operation, $context)
+            ->shouldReturn($gridView)
+        ;
+    }
+
+    function it_sets_max_per_page_from_grid_configuration(
+        Request $request,
+        GridViewFactoryInterface $gridViewFactory,
+        GridProviderInterface $gridProvider,
+        Grid $gridDefinition,
+        GridView $gridView,
+        Pagerfanta $pagerfanta,
+    ): void {
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $operation = new Index(grid: 'app_book');
+
+        $request->query = new InputBag();
+
+        $gridProvider->get('app_book')->willReturn($gridDefinition);
+        $gridDefinition->getDriverConfiguration()->willReturn([]);
+        $gridDefinition->getLimits()->willReturn([15, 30]);
+
+        $gridViewFactory->create($gridDefinition, $context, new Parameters([]), [])->willReturn($gridView);
+
+        $gridView->getData()->willReturn($pagerfanta);
+        $pagerfanta->setCurrentPage(1)->willReturn($pagerfanta)->shouldBeCalled();
+        $pagerfanta->setMaxPerPage(15)->willReturn($pagerfanta)->shouldBeCalled();
+
+        $this->provide($operation, $context)
+            ->shouldReturn($gridView)
+        ;
+    }
+
+    function it_limits_max_per_page_with_max_grid_configuration_limit(
+        Request $request,
+        GridViewFactoryInterface $gridViewFactory,
+        GridProviderInterface $gridProvider,
+        Grid $gridDefinition,
+        GridView $gridView,
+        Pagerfanta $pagerfanta,
+    ): void {
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $operation = new Index(grid: 'app_book');
+
+        $request->query = new InputBag(['limit' => 40]);
+
+        $gridProvider->get('app_book')->willReturn($gridDefinition);
+        $gridDefinition->getDriverConfiguration()->willReturn([]);
+        $gridDefinition->getLimits()->willReturn([15, 30]);
+
+        $gridViewFactory->create($gridDefinition, $context, new Parameters(['limit' => 40]), [])->willReturn($gridView);
+
+        $gridView->getData()->willReturn($pagerfanta);
+        $pagerfanta->setCurrentPage(1)->willReturn($pagerfanta)->shouldBeCalled();
+        $pagerfanta->setMaxPerPage(30)->willReturn($pagerfanta)->shouldBeCalled();
 
         $this->provide($operation, $context)
             ->shouldReturn($gridView)

--- a/src/Component/src/Grid/State/RequestGridProvider.php
+++ b/src/Component/src/Grid/State/RequestGridProvider.php
@@ -25,6 +25,8 @@ use Sylius\Resource\State\ProviderInterface;
 
 final class RequestGridProvider implements ProviderInterface
 {
+    private const DEFAULT_MAX_PER_PAGE = 10;
+
     public function __construct(
         private ?GridViewFactoryInterface $gridViewFactory = null,
         private ?GridProviderInterface $gridProvider = null,
@@ -80,7 +82,7 @@ final class RequestGridProvider implements ProviderInterface
         if (null === $requestLimit) {
             $firstGridLimit = reset($gridLimits);
 
-            return false === $firstGridLimit ? 10 : $firstGridLimit;
+            return false === $firstGridLimit ? self::DEFAULT_MAX_PER_PAGE : $firstGridLimit;
         }
 
         if (!empty($gridLimits)) {

--- a/src/Component/src/Grid/State/RequestGridProvider.php
+++ b/src/Component/src/Grid/State/RequestGridProvider.php
@@ -64,8 +64,32 @@ final class RequestGridProvider implements ProviderInterface
         if ($data instanceof Pagerfanta) {
             $currentPage = $request->query->getInt('page', 1);
             $data->setCurrentPage($currentPage);
+
+            $maxPerPage = $this->resolveMaxPerPage(
+                $request->query->has('limit') ? $request->query->getInt('limit') : null,
+                $gridDefinition->getLimits(),
+            );
+            $data->setMaxPerPage($maxPerPage);
         }
 
         return $gridView;
+    }
+
+    private function resolveMaxPerPage(?int $requestLimit, array $gridLimits = []): int
+    {
+        if (null === $requestLimit) {
+            $firstGridLimit = reset($gridLimits);
+
+            return false === $firstGridLimit ? 10 : $firstGridLimit;
+        }
+
+        if (!empty($gridLimits)) {
+            $maxGridLimit = max($gridLimits);
+
+            // Cannot retrieve more items than configured in the grid
+            return min($requestLimit, $maxGridLimit);
+        }
+
+        return $requestLimit;
     }
 }

--- a/tests/Application/src/Subscription/Grid/SubscriptionGrid.php
+++ b/tests/Application/src/Subscription/Grid/SubscriptionGrid.php
@@ -38,6 +38,7 @@ final class SubscriptionGrid extends AbstractGrid implements ResourceAwareGridIn
     {
         $gridBuilder
             ->orderBy('email', 'asc')
+            ->setLimits([5, 3, 10])
             ->addField(
                 StringField::create('email')
                     ->setLabel('Email')

--- a/tests/Application/src/Tests/Controller/SubscriptionUiTest.php
+++ b/tests/Application/src/Tests/Controller/SubscriptionUiTest.php
@@ -47,10 +47,8 @@ final class SubscriptionUiTest extends ApiTestCase
         $this->assertResponseCode($response, Response::HTTP_OK);
         $content = $response->getContent();
 
-        $this->assertStringContainsString('<td>marty.mcfly@bttf.com</td>', $content);
-        $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s">Show</a>', $subscriptions['subscription_marty']->getId()), $content);
-        $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s/edit">Edit</a>', $subscriptions['subscription_marty']->getId()), $content);
-        $this->assertStringContainsString(sprintf('<form action="/admin/subscriptions/%s/delete" method="post">', $subscriptions['subscription_marty']->getId()), $content);
+        // only 5 subscriptions
+        $this->assertSelectorCount(5, 'tbody tr');
 
         $this->assertStringContainsString('<td>doc.brown@bttf.com</td>', $content);
         $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s">Show</a>', $subscriptions['subscription_doc']->getId()), $content);
@@ -61,6 +59,34 @@ final class SubscriptionUiTest extends ApiTestCase
         $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s">Show</a>', $subscriptions['subscription_biff']->getId()), $content);
         $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s/edit">Edit</a>', $subscriptions['subscription_biff']->getId()), $content);
         $this->assertStringContainsString(sprintf('<form action="/admin/subscriptions/%s/delete" method="post">', $subscriptions['subscription_biff']->getId()), $content);
+    }
+
+    /** @test */
+    public function it_allows_browsing_subscriptions_with_page_limit(): void
+    {
+        $this->loadFixturesFromFile('subscriptions.yml');
+
+        $this->client->request('GET', '/admin/subscriptions?limit=3');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseCode($response, Response::HTTP_OK);
+
+        // only 2 subscriptions
+        $this->assertSelectorCount(3, 'tbody tr');
+    }
+
+    /** @test */
+    public function it_allows_browsing_subscriptions_with_grid_limits(): void
+    {
+        $this->loadFixturesFromFile('subscriptions.yml');
+
+        $this->client->request('GET', '/admin/subscriptions');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseCode($response, Response::HTTP_OK);
+
+        // only 5 subscriptions
+        $this->assertSelectorCount(5, 'tbody tr');
     }
 
     /** @test */
@@ -154,7 +180,7 @@ final class SubscriptionUiTest extends ApiTestCase
     {
         $this->loadFixturesFromFile('subscriptions.yml');
 
-        $this->client->request('GET', '/admin/subscriptions');
+        $this->client->request('GET', '/admin/subscriptions?limit=10');
         $this->client->submitForm('Bulk delete');
 
         $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);
@@ -187,7 +213,7 @@ final class SubscriptionUiTest extends ApiTestCase
     {
         $this->loadFixturesFromFile('subscriptions.yml');
 
-        $this->client->request('GET', '/admin/subscriptions');
+        $this->client->request('GET', '/admin/subscriptions?limit=10');
         $this->client->submitForm('Bulk accept');
 
         $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);

--- a/tests/Application/src/Tests/Controller/SubscriptionUiTest.php
+++ b/tests/Application/src/Tests/Controller/SubscriptionUiTest.php
@@ -48,7 +48,9 @@ final class SubscriptionUiTest extends ApiTestCase
         $content = $response->getContent();
 
         // only 5 subscriptions
-        $this->assertSelectorCount(5, 'tbody tr');
+        if (method_exists($this, 'assertSelectorCount')) {
+            $this->assertSelectorCount(5, 'tbody tr');
+        }
 
         $this->assertStringContainsString('<td>doc.brown@bttf.com</td>', $content);
         $this->assertStringContainsString(sprintf('<a href="/admin/subscriptions/%s">Show</a>', $subscriptions['subscription_doc']->getId()), $content);
@@ -72,7 +74,9 @@ final class SubscriptionUiTest extends ApiTestCase
         $this->assertResponseCode($response, Response::HTTP_OK);
 
         // only 2 subscriptions
-        $this->assertSelectorCount(3, 'tbody tr');
+        if (method_exists($this, 'assertSelectorCount')) {
+            $this->assertSelectorCount(3, 'tbody tr');
+        }
     }
 
     /** @test */
@@ -86,7 +90,9 @@ final class SubscriptionUiTest extends ApiTestCase
         $this->assertResponseCode($response, Response::HTTP_OK);
 
         // only 5 subscriptions
-        $this->assertSelectorCount(5, 'tbody tr');
+        if (method_exists($this, 'assertSelectorCount')) {
+            $this->assertSelectorCount(5, 'tbody tr');
+        }
     }
 
     /** @test */

--- a/tests/Application/src/Tests/DataFixtures/ORM/subscriptions.yml
+++ b/tests/Application/src/Tests/DataFixtures/ORM/subscriptions.yml
@@ -6,3 +6,9 @@ App\Subscription\Entity\Subscription:
     subscription_biff:
         email: 'biff.tannen@bttf.com'
         state: accepted
+    subscription_lorraine:
+        email: 'lorraine.baines@bttf.com'
+    subscription_george:
+        email: 'george.mcfly@bttf.com'
+    subscription_jennifer:
+        email: 'jennifer.parker@bttf.com'

--- a/tests/Application/src/Tests/Responses/subscriptions/index_response.json
+++ b/tests/Application/src/Tests/Responses/subscriptions/index_response.json
@@ -11,6 +11,18 @@
         {
             "state": "accepted",
             "email": "biff.tannen@bttf.com"
+        },
+        {
+            "state": "new",
+            "email": "lorraine.baines@bttf.com"
+        },
+        {
+            "state": "new",
+            "email": "george.mcfly@bttf.com"
+        },
+        {
+            "state": "new",
+            "email": "jennifer.parker@bttf.com"
         }
     ],
     "pagination": {
@@ -18,7 +30,7 @@
         "has_previous_page": false,
         "has_next_page": false,
         "per_page": 10,
-        "total_items": 3,
+        "total_items": 6,
         "total_pages": 1
     }
 }

--- a/tests/Application/src/Tests/Responses/subscriptions/index_response.xml
+++ b/tests/Application/src/Tests/Responses/subscriptions/index_response.xml
@@ -1,23 +1,35 @@
 <?xml version="1.0"?>
 <response>
-    <items>
-        <state>new</state>
-        <email>marty.mcfly@bttf.com</email>
-    </items>
-    <items>
-        <state>new</state>
-        <email>doc.brown@bttf.com</email>
-    </items>
-    <items>
-        <state>accepted</state>
-        <email>biff.tannen@bttf.com</email>
-    </items>
-    <pagination>
-        <current_page>1</current_page>
-        <has_previous_page>0</has_previous_page>
-        <has_next_page>0</has_next_page>
-        <per_page>10</per_page>
-        <total_items>3</total_items>
-        <total_pages>1</total_pages>
-    </pagination>
+  <items>
+    <state>new</state>
+    <email>marty.mcfly@bttf.com</email>
+  </items>
+  <items>
+    <state>new</state>
+    <email>doc.brown@bttf.com</email>
+  </items>
+  <items>
+    <state>accepted</state>
+    <email>biff.tannen@bttf.com</email>
+  </items>
+  <items>
+    <state>new</state>
+    <email>lorraine.baines@bttf.com</email>
+  </items>
+  <items>
+    <state>new</state>
+    <email>george.mcfly@bttf.com</email>
+  </items>
+  <items>
+    <state>new</state>
+    <email>jennifer.parker@bttf.com</email>
+  </items>
+<pagination>
+    <current_page>1</current_page>
+    <has_previous_page>0</has_previous_page>
+    <has_next_page>0</has_next_page>
+    <per_page>10</per_page>
+    <total_items>6</total_items>
+    <total_pages>1</total_pages>
+</pagination>
 </response>

--- a/tests/Application/src/Tests/Responses/subscriptions/index_response.xml
+++ b/tests/Application/src/Tests/Responses/subscriptions/index_response.xml
@@ -24,12 +24,12 @@
     <state>new</state>
     <email>jennifer.parker@bttf.com</email>
   </items>
-<pagination>
+  <pagination>
     <current_page>1</current_page>
     <has_previous_page>0</has_previous_page>
     <has_next_page>0</has_next_page>
     <per_page>10</per_page>
     <total_items>6</total_items>
     <total_pages>1</total_pages>
-</pagination>
+  </pagination>
 </response>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Missing this part from https://github.com/Sylius/SyliusResourceBundle/blob/1.12/src/Bundle/Controller/ResourcesCollectionProvider.php#L76

We do not have "limit" or "paginate" attribute on operation for now, only paginated resources is used with grids for now. 