### PR TITLE
[Debug] Show legacy resource metadata on debug command when specified

### DIFF
--- a/tests/Bundle/Command/DebugResourceCommandTest.php
+++ b/tests/Bundle/Command/DebugResourceCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\Command;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -118,31 +119,8 @@ final class DebugResourceCommandTest extends TestCase
         $this->assertEquals(
             <<<TXT
             
-            Configuration
-            -------------
-            
-             ----------------------- ----------------------------- 
-              Option                  Value                        
-             ----------------------- ----------------------------- 
-              name                    "one"                        
-              applicationName         "sylius"                     
-              driver                  "doctrine/foobar"            
-              stateMachineComponent   null                         
-              templatesNamespace      null                         
-              classes                 [                            
-                                        "model" => "App\One",      
-                                        "foo" => "bar",            
-                                        "bar" => "foo"             
-                                      ]                            
-              whatever                [                            
-                                        "something" => [           
-                                          "elephants" => "camels"  
-                                        ]                          
-                                      ]                            
-             ----------------------- ----------------------------- 
-            
-            New Resource Metadata
-            ---------------------
+            Resource Metadata
+            -----------------
             
              ------------------------ ------- 
               Option                   Value  
@@ -164,8 +142,8 @@ final class DebugResourceCommandTest extends TestCase
               vars                     null   
              ------------------------ ------- 
             
-            New operations
-            --------------
+            Operations
+            ----------
             
              ---------------- --------------------------------------------------------------- 
               Name             Details                                                        
@@ -206,31 +184,8 @@ final class DebugResourceCommandTest extends TestCase
         $this->assertEquals(
             <<<TXT
             
-            Configuration
-            -------------
-            
-             ----------------------- ----------------------------- 
-              Option                  Value                        
-             ----------------------- ----------------------------- 
-              name                    "one"                        
-              applicationName         "sylius"                     
-              driver                  "doctrine/foobar"            
-              stateMachineComponent   null                         
-              templatesNamespace      null                         
-              classes                 [                            
-                                        "model" => "App\One",      
-                                        "foo" => "bar",            
-                                        "bar" => "foo"             
-                                      ]                            
-              whatever                [                            
-                                        "something" => [           
-                                          "elephants" => "camels"  
-                                        ]                          
-                                      ]                            
-             ----------------------- ----------------------------- 
-            
-            New Resource Metadata
-            ---------------------
+            Resource Metadata
+            -----------------
             
              ------------------------ -------------- 
               Option                   Value         
@@ -252,8 +207,8 @@ final class DebugResourceCommandTest extends TestCase
               vars                     null          
              ------------------------ -------------- 
             
-            New operations
-            --------------
+            Operations
+            ----------
             
              ---------------- --------------------------------------------------------------- 
               Name             Details                                                        
@@ -354,6 +309,57 @@ final class DebugResourceCommandTest extends TestCase
               validationContext        null                      
               eventShortName           "register"                
              ------------------------ -------------------------- 
+            
+            
+            TXT
+            ,
+            $display,
+        );
+    }
+
+    #[Test]
+    public function it_displays_the_legacy_resource_metadata_for_given_resource_alias(): void
+    {
+        $this->registry->get('metadata.one')->willReturn($this->createMetadata('one'));
+
+        $resourceMetadata = (new ResourceMetadata(alias: 'sylius.one'));
+
+        $resourceMetadataCollection = new ResourceMetadataCollection([$resourceMetadata]);
+
+        $this->resourceCollectionMetadataFactory->create('App\One')->willReturn($resourceMetadataCollection);
+
+        $this->tester->execute([
+            'resource' => 'metadata.one',
+            '--legacy' => true,
+        ]);
+
+        $display = $this->tester->getDisplay();
+
+        $this->assertEquals(
+            <<<TXT
+            
+            Configuration
+            -------------
+            
+             ----------------------- ----------------------------- 
+              Option                  Value                        
+             ----------------------- ----------------------------- 
+              name                    "one"                        
+              applicationName         "sylius"                     
+              driver                  "doctrine/foobar"            
+              stateMachineComponent   null                         
+              templatesNamespace      null                         
+              classes                 [                            
+                                        "model" => "App\One",      
+                                        "foo" => "bar",            
+                                        "bar" => "foo"             
+                                      ]                            
+              whatever                [                            
+                                        "something" => [           
+                                          "elephants" => "camels"  
+                                        ]                          
+                                      ]                            
+             ----------------------- ----------------------------- 
             
             
             TXT


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It improves the readability between the new resource metadata and the legacy ones.
The legacy ones are used for the ResourceController and the new ones are used for Resource Operations.

**Without passing legacy option**
![image](https://github.com/user-attachments/assets/e73383c3-553e-47e7-adb1-ded02b25965c)

**Passing legacy option**
![image](https://github.com/user-attachments/assets/bf998a58-dec4-4e56-8cf2-66230def9f38)
