### PR TITLE
Add resource name collection

### DIFF
--- a/src/Component/src/Metadata/Resource/ResourceNameCollection.php
+++ b/src/Component/src/Metadata/Resource/ResourceNameCollection.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Resource;
+
+/**
+ * A collection of resource names.
+ *
+ * @experimental
+ */
+final class ResourceNameCollection implements \IteratorAggregate, \Countable
+{
+    /**
+     * @param string[] $names
+     */
+    public function __construct(private readonly array $names = [])
+    {
+    }
+
+    /**
+     * @return \Traversable<string>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->names);
+    }
+
+    public function count(): int
+    {
+        return \count($this->names);
+    }
+}

--- a/src/Component/tests/Metadata/Resource/ResourceNameCollectionTest.php
+++ b/src/Component/tests/Metadata/Resource/ResourceNameCollectionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Metadata\Resource;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Resource\ResourceNameCollection;
+
+final class ResourceNameCollectionTest extends TestCase
+{
+    public function testItIsAnIteratorAggregate(): void
+    {
+        $collection = new ResourceNameCollection();
+
+        $this->assertInstanceOf(\IteratorAggregate::class, $collection);
+    }
+
+    public function testItIsCountable(): void
+    {
+        $collection = new ResourceNameCollection();
+
+        $this->assertInstanceOf(\Countable::class, $collection);
+    }
+
+    public function testItIsACollectionOfResourceNames(): void
+    {
+        $collection = new ResourceNameCollection(['first_resource', 'second_resource']);
+
+        $this->assertCount(2, $collection);
+        $this->assertEquals('first_resource', $collection->getIterator()[0]);
+        $this->assertEquals('second_resource', $collection->getIterator()[1]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The idea of this collection is to have a collection of resource names (that will be class names inside, but I want it to be more generic if needed later).

It will be used in a new resource loader (for Routing) which will be used instead of this [too much specific one](https://github.com/Sylius/SyliusResourceBundle/blob/1.13/src/Bundle/Routing/RoutesAttributesLoader.php).

It will allow to create route collection for all resources that have new resource metadata.

```php
# config/sylius/resources/speaker.php

use App\Conference\Entity\Speaker;
use Sylius\Resource\Metadata\Create;
use Sylius\Resource\Metadata\Index;
use Sylius\Resource\Metadata\Operations;
use Sylius\Resource\Metadata\ResourceMetadata;

return (new ResourceMetadata())
    ->withRoutePrefix('/admin')
    ->withClass(Speaker::class)
    ->withSection('admin')
    ->withTemplatesDir('crud')
    ->withOperations(new Operations([
        new Create(),
        new Index(),
    ]))
;
```

I've created a specific new-resource-loader branch to allow us to merge it quicky in a WIP mode.