### PR TITLE
Fix - Use operation name by default for the route name

### DIFF
--- a/src/Component/spec/Symfony/Routing/Factory/RouteName/OperationRouteNameFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/RouteName/OperationRouteNameFactorySpec.php
@@ -25,7 +25,7 @@ final class OperationRouteNameFactorySpec extends ObjectBehavior
         $this->shouldHaveType(OperationRouteNameFactory::class);
     }
 
-    function it_create_a_route_name(): void
+    function it_creates_a_route_name(): void
     {
         $resource = new ResourceMetadata(alias: 'app.book', name: 'book', applicationName: 'app');
         $operation = (new Create())->withResource($resource);
@@ -33,12 +33,28 @@ final class OperationRouteNameFactorySpec extends ObjectBehavior
         $this->createRouteName($operation)->shouldReturn('app_book_create');
     }
 
-    function it_create_a_route_name_with_a_section(): void
+    function it_uses_the_operation_name_when_specified(): void
+    {
+        $resource = new ResourceMetadata(alias: 'app.book', name: 'book', applicationName: 'app');
+        $operation = (new Create(name: 'app_book_new'))->withResource($resource);
+
+        $this->createRouteName($operation)->shouldReturn('app_book_new');
+    }
+
+    function it_creates_a_route_name_with_a_section(): void
     {
         $resource = new ResourceMetadata(alias: 'app.book', section: 'admin', name: 'book', applicationName: 'app');
         $operation = (new Create())->withResource($resource);
 
         $this->createRouteName($operation)->shouldReturn('app_admin_book_create');
+    }
+
+    function it_creates_a_route_name_from_another_operation(): void
+    {
+        $resource = new ResourceMetadata(alias: 'app.book', name: 'book', applicationName: 'app');
+        $operation = (new Create())->withResource($resource);
+
+        $this->createRouteName($operation, 'index')->shouldReturn('app_book_index');
     }
 
     function it_throws_an_exception_when_operation_has_no_resource(): void

--- a/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RouteName/OperationRouteNameFactory.php
@@ -28,6 +28,12 @@ final class OperationRouteNameFactory implements OperationRouteNameFactoryInterf
             throw new \RuntimeException(sprintf('No resource was found on the operation "%s"', $operation->getShortName() ?? ''));
         }
 
+        $operationName = $operation->getName();
+
+        if (null === $shortName && null !== $operationName) {
+            return $operationName;
+        }
+
         $section = $resource->getSection();
         $sectionPrefix = $section ? $section . '_' : '';
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

When using an HttpOperation, the name of the operation is used to store the route name. (a CLI operation which does not exist yet could use the name for the command name, that's why the "name" is kind generic).

On OperationRouteNameFactory, it builds the route name based on other properties even if the name is already defined.

We need that fix here
https://github.com/Sylius/Sylius/pull/17695/files#r1971186393 for this route https://github.com/Sylius/Sylius/blob/2.1/src/Sylius/Bundle/AdminBundle/Resources/config/routing/inventory.yml

- [x] Fix it
- [ ] Document it (needs a separated PR on Sylius stack)

:warning:  There's also a route name property, I need to investigate.