### PR TITLE
Use plural name from new resource metadata

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -87,6 +87,7 @@ parameters:
         - '/Parameter \#2 \$callback of function preg_replace_callback expects callable\(array\<int\|string\, string\>\): string, Closure\(array\)\: mixed given\./'
         - '/Parameter \#1 \$objectOrArray of method Symfony\\Component\\PropertyAccess\\PropertyAccessorInterface\:\:getValue\(\) expects array\|object, array\|object\|null given\./'
         - '/Parameter \#1 \$min \(0\) of function random_int expects lower number than parameter \#2 \$max \(int\<\-1, max\>\)\./'
+        - '/Property Sylius\\Resource\\Symfony\\Routing\\Factory\\AttributesOperationRouteFactory\:\:\$resourceRegistry is never read, only written\./'
         - '/Method Sylius\\Resource\\Model\\ResourceInterface\:\:getId\(\) has no return type specified\./'
         - '/Method Sylius\\Resource\\Model\\TimestampableInterface\:\:setCreatedAt\(\) has no return type specified\./'
         - '/Method Sylius\\Resource\\Model\\TimestampableInterface\:\:setUpdatedAt\(\) has no return type specified\./'

--- a/src/Bundle/Resources/config/services/routing/resource.xml
+++ b/src/Bundle/Resources/config/services/routing/resource.xml
@@ -16,7 +16,6 @@
         <service id="sylius.routing.resource.route_collection_factory" class="Sylius\Resource\Symfony\Routing\Factory\Resource\ResourceRouteCollectionFactory">
             <argument type="service" id="sylius.routing.factory.operation_route" />
             <argument type="service" id="sylius.resource_metadata_collection.factory" />
-            <argument type="service" id="sylius.resource_registry" />
         </service>
         <service id="Sylius\Resource\Symfony\Routing\Factory\Resource\ResourceRouteCollectionFactoryInterface" alias="sylius.routing.resource.route_collection_factory" />
     </services>

--- a/src/Component/spec/Symfony/Routing/Factory/AttributesOperationRouteFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/AttributesOperationRouteFactorySpec.php
@@ -42,7 +42,6 @@ final class AttributesOperationRouteFactorySpec extends ObjectBehavior
             new AttributesResourceMetadataCollectionFactory(
                 $resourceRegistry->getWrappedObject(),
                 new OperationRouteNameFactory(),
-                'symfony',
             ),
         );
     }

--- a/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/OperationRouteFactorySpec.php
@@ -21,7 +21,6 @@ use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Delete;
 use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\Metadata\Index;
-use Sylius\Resource\Metadata\Metadata;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
@@ -43,15 +42,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_create_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Create();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Create())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/new')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -68,16 +71,20 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_index_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Index();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Index())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
-            new Index(),
+            $resource,
+            $operation,
         );
 
         $route->getPath()->shouldReturn('/dummies');
@@ -93,15 +100,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_show_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Show();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Show())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/{id}')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -118,15 +129,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_update_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Update();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Update())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/{id}/edit')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -143,15 +158,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_delete_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Delete();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Delete())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/{id}')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -168,15 +187,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_bulk_delete_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new BulkDelete();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new BulkDelete())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/bulk_delete')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -193,15 +216,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_bulk_update_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new BulkUpdate();
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new BulkUpdate())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('dummies/bulk_update')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -218,15 +245,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_custom_operations_routes(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new HttpOperation(methods: ['PATCH'], path: 'dummies/{id}/custom');
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new HttpOperation(methods: ['PATCH'], path: 'dummies/{id}/custom'))
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath(Argument::cetera())->willReturn('')->shouldNotBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata('app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -243,15 +274,20 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_routes_with_sections(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Show();
+        $resource = (new ResourceMetadata())
+            ->withSection('admin')
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Show())
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('/dummies/{id}')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata(alias: 'app.dummy', section: 'admin'),
+            $resource,
             $operation,
         );
 
@@ -269,15 +305,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_routes_with_vars(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Index(vars: ['subheader' => 'Managing your library']);
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Index(vars: ['subheader' => 'Managing your library']))
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('/dummies')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata(alias: 'app.dummy'),
+            $resource,
             $operation,
         );
 
@@ -293,15 +333,19 @@ final class OperationRouteFactorySpec extends ObjectBehavior
     function it_generates_routes_with_requirements(
         OperationRoutePathFactoryInterface $routePathFactory,
     ): void {
-        $operation = new Index(routeRequirements: ['type' => 'country|province|zone']);
+        $resource = (new ResourceMetadata())
+            ->withAlias('app.dummy')
+            ->withPluralName('dummies')
+        ;
 
-        $metadata = Metadata::fromAliasAndConfiguration('app.dummy', ['driver' => 'dummy_driver']);
+        $operation = (new Index(routeRequirements: ['type' => 'country|province|zone']))
+            ->withResource($resource)
+        ;
 
         $routePathFactory->createRoutePath($operation, 'dummies')->willReturn('/dummies')->shouldBeCalled();
 
         $route = $this->create(
-            $metadata,
-            new ResourceMetadata(alias: 'app.dummy'),
+            $resource,
             $operation,
         );
 

--- a/src/Component/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactory.php
@@ -134,6 +134,12 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
             $resource = $resource->withName($resourceConfiguration->getName());
         }
 
+        if (null === $resource->getPluralName()) {
+            $resourcePluralName = $resourceConfiguration->getPluralName();
+
+            $resource = $resource->withPluralName($resourcePluralName);
+        }
+
         return $resource;
     }
 
@@ -142,20 +148,6 @@ final class AttributesResourceMetadataCollectionFactory implements ResourceMetad
         $resourceConfiguration = $this->resourceRegistry->get($resource->getAlias() ?? '');
 
         $operation = $operation->withResource($resource);
-
-        if (null === $resource->getName()) {
-            $resourceName = $resourceConfiguration->getName();
-
-            $resource = $resource->withName($resourceName);
-            $operation = $operation->withResource($resource);
-        }
-
-        if (null === $resource->getPluralName()) {
-            $resourcePluralName = $resourceConfiguration->getPluralName();
-
-            $resource = $resource->withPluralName($resourcePluralName);
-            $operation = $operation->withResource($resource);
-        }
 
         if (null === $operation->getNormalizationContext()) {
             $operation = $operation->withNormalizationContext($resource->getNormalizationContext());

--- a/src/Component/src/Symfony/Routing/Factory/AttributesOperationRouteFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/AttributesOperationRouteFactory.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing\Factory;
 
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operations;
 use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -59,17 +58,16 @@ final class AttributesOperationRouteFactory implements AttributesOperationRouteF
 
     private function addRouteForOperation(RouteCollection $routeCollection, ResourceMetadata $resource, HttpOperation $operation): void
     {
-        $metadata = $this->resourceRegistry->get($resource->getAlias() ?? '');
         $routeName = $operation->getRouteName();
 
         Assert::notNull($routeName, sprintf('Operation %s has no route name. Please define one.', $operation::class));
 
-        $route = $this->createRoute($metadata, $resource, $operation);
+        $route = $this->createRoute($resource, $operation);
         $routeCollection->add($routeName, $route);
     }
 
-    private function createRoute(MetadataInterface $metadata, ResourceMetadata $resource, HttpOperation $operation): Route
+    private function createRoute(ResourceMetadata $resource, HttpOperation $operation): Route
     {
-        return $this->operationRouteFactory->create($metadata, $resource, $operation);
+        return $this->operationRouteFactory->create($resource, $operation);
     }
 }

--- a/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
@@ -15,10 +15,10 @@ namespace Sylius\Resource\Symfony\Routing\Factory;
 
 use Gedmo\Sluggable\Util\Urlizer;
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\Route;
+use Webmozart\Assert\Assert;
 
 /**
  * @experimental
@@ -30,9 +30,9 @@ final class OperationRouteFactory implements OperationRouteFactoryInterface
     ) {
     }
 
-    public function create(MetadataInterface $metadata, ResourceMetadata $resource, HttpOperation $operation): Route
+    public function create(ResourceMetadata $resource, HttpOperation $operation): Route
     {
-        $routePath = $operation->getPath() ?? $this->getDefaultRoutePath($metadata, $operation);
+        $routePath = $operation->getPath() ?? $this->getDefaultRoutePath($resource, $operation);
 
         if (null !== $routePrefix = $operation->getRoutePrefix()) {
             $routePath = $routePrefix . '/' . $routePath;
@@ -49,14 +49,17 @@ final class OperationRouteFactory implements OperationRouteFactoryInterface
         );
     }
 
-    private function getDefaultRoutePath(MetadataInterface $metadata, HttpOperation $operation): string
+    private function getDefaultRoutePath(ResourceMetadata $resource, HttpOperation $operation): string
     {
-        return $this->getDefaultRoutePathForOperation($metadata, $operation);
+        return $this->getDefaultRoutePathForOperation($resource, $operation);
     }
 
-    private function getDefaultRoutePathForOperation(MetadataInterface $metadata, HttpOperation $operation): string
+    private function getDefaultRoutePathForOperation(ResourceMetadata $resource, HttpOperation $operation): string
     {
-        $rootPath = sprintf('%s', Urlizer::urlize($metadata->getPluralName()));
+        $pluralName = $resource->getPluralName();
+        Assert::notNull($pluralName, 'Plural name of the resource should be defined');
+
+        $rootPath = sprintf('%s', Urlizer::urlize($pluralName));
 
         if (null !== $path = $operation->getPath()) {
             return $path;

--- a/src/Component/src/Symfony/Routing/Factory/OperationRouteFactoryInterface.php
+++ b/src/Component/src/Symfony/Routing/Factory/OperationRouteFactoryInterface.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing\Factory;
 
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Symfony\Component\Routing\Route;
 
@@ -23,5 +22,5 @@ use Symfony\Component\Routing\Route;
  */
 interface OperationRouteFactoryInterface
 {
-    public function create(MetadataInterface $metadata, ResourceMetadata $resource, HttpOperation $operation): Route;
+    public function create(ResourceMetadata $resource, HttpOperation $operation): Route;
 }

--- a/src/Component/src/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactory.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing\Factory\Resource;
 
 use Sylius\Resource\Metadata\HttpOperation;
-use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operations;
-use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\Routing\Factory\OperationRouteFactoryInterface;
@@ -32,7 +30,6 @@ final class ResourceRouteCollectionFactory implements ResourceRouteCollectionFac
     public function __construct(
         private readonly OperationRouteFactoryInterface $operationRouteFactory,
         private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
-        private readonly RegistryInterface $resourceRegistry,
     ) {
     }
 
@@ -65,7 +62,6 @@ final class ResourceRouteCollectionFactory implements ResourceRouteCollectionFac
         $alias = $resource->getAlias();
         Assert::notNull($alias, sprintf('Resource of %s has no alias.', $resource->getClass() ?? ''));
 
-        $metadata = $this->resourceRegistry->get($alias);
         $routeName = $operation->getRouteName();
 
         Assert::notNull($routeName, sprintf(
@@ -74,12 +70,12 @@ final class ResourceRouteCollectionFactory implements ResourceRouteCollectionFac
             $alias,
         ));
 
-        $route = $this->createRoute($metadata, $resource, $operation);
+        $route = $this->createRoute($resource, $operation);
         $routeCollection->add($routeName, $route);
     }
 
-    private function createRoute(MetadataInterface $metadata, ResourceMetadata $resource, HttpOperation $operation): Route
+    private function createRoute(ResourceMetadata $resource, HttpOperation $operation): Route
     {
-        return $this->operationRouteFactory->create($metadata, $resource, $operation);
+        return $this->operationRouteFactory->create($resource, $operation);
     }
 }

--- a/src/Component/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Component/tests/Metadata/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -474,6 +474,8 @@ final class AttributesResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertInstanceOf(ResourceMetadata::class, $resource);
         $this->assertSame('app.dummy', $resource->getAlias());
 
+        $this->assertSame('books', $resource->getPluralName());
+
         $operations = $resource->getOperations();
         $this->assertInstanceOf(Operations::class, $operations);
         $this->assertCount(4, $operations);

--- a/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
@@ -42,7 +42,6 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
                 $this->resourceRegistry,
                 new OperationRouteNameFactory(),
             ),
-            $this->resourceRegistry,
         );
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

It replaces #998 
For now, we have two very similar metadata classes for the resource.
- [Metadata](https://github.com/Sylius/SyliusResourceBundle/blob/1.13/src/Component/src/Metadata/Metadata.php) 
- [ResourceMetadata](https://github.com/Sylius/SyliusResourceBundle/blob/1.13/src/Component/src/Metadata/ResourceMetadata.php)

To calculate the route path, we use the plural name from the Metadata (the legacy one), but we can define the plural name on the ResourceMetadata. 

Before this implementation, the plural name was calculated by the inflector on the MetadataClass.

With this current PR, by default, it will continue to use the plural name from the inflector (from the Medadata class), but it will use the custom one if defined. It was intended to be the case with the previous implementation, but there was an issue and the operation route factory was using the automatic plural name only.

The other plan behind is also to prepare the legacy Metadata class removal at some point.
We will be able to move the automatic plural name on the getResourceDefaults method.