### PR TITLE
Gracefully handle rendering actions for non-resource grid view

### DIFF
--- a/src/Bundle/Grid/Renderer/TwigGridRenderer.php
+++ b/src/Bundle/Grid/Renderer/TwigGridRenderer.php
@@ -21,7 +21,6 @@ use Sylius\Component\Grid\Definition\Filter;
 use Sylius\Component\Grid\Renderer\GridRendererInterface;
 use Sylius\Component\Grid\View\GridViewInterface;
 use Twig\Environment;
-use Webmozart\Assert\Assert;
 
 final class TwigGridRenderer implements GridRendererInterface
 {
@@ -63,7 +62,9 @@ final class TwigGridRenderer implements GridRendererInterface
      */
     public function renderAction(GridViewInterface $gridView, Action $action, $data = null): string
     {
-        Assert::isInstanceOf($gridView, ResourceGridView::class);
+        if (!$gridView instanceof ResourceGridView) {
+            return $this->gridRenderer->renderAction($gridView, $action, $data);
+        }
 
         $type = $action->getType();
         if (!isset($this->actionTemplates[$type])) {

--- a/src/Bundle/spec/Grid/Renderer/TwigGridRendererSpec.php
+++ b/src/Bundle/spec/Grid/Renderer/TwigGridRendererSpec.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ResourceBundle\Grid\Parser\OptionsParserInterface;
 use Sylius\Bundle\ResourceBundle\Grid\View\ResourceGridView;
 use Sylius\Component\Grid\Definition\Action;
 use Sylius\Component\Grid\Renderer\GridRendererInterface;
+use Sylius\Component\Grid\View\GridView;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 
@@ -86,5 +87,28 @@ final class TwigGridRendererSpec extends ObjectBehavior
             ->shouldThrow(new \InvalidArgumentException('Missing template for action type "foo".'))
             ->during('renderAction', [$gridView, $action])
         ;
+    }
+
+    function it_calls_the_inner_renderer_with_a_non_resource_grid_view(
+        GridRendererInterface $gridRenderer,
+        GridView $gridView,
+        Action $action,
+    ): void {
+        $action->getType()->willReturn('link');
+        $action->getOptions()->willReturn([]);
+
+        $gridRenderer
+            ->renderAction($gridView, $action, null)
+            ->willReturn('foo')
+            ->shouldBeCalled();
+
+        $this->shouldNotThrow(
+            new \InvalidArgumentException(
+                sprintf('Expected an instance of %s. Got: %s', ResourceGridView::class, get_class($gridView)),
+            ),
+        )
+            ->during('renderAction', [$gridView, $action]);
+
+        $this->renderAction($gridView, $action)->shouldReturn('foo');
     }
 }


### PR DESCRIPTION
Gracefully handle rendering actions for non-resource grid view by degating the rendering to the inner twig grid renderer

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
