### PR TITLE
Add `#[Attribute]` annotation to validator constraints

### DIFF
--- a/src/Bundle/Validator/Constraints/Disabled.php
+++ b/src/Bundle/Validator/Constraints/Disabled.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 use Sylius\Bundle\ResourceBundle\Validator\DisabledValidator;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class Disabled extends Constraint
 {
     public string $message = 'sylius.resource.not_disabled';

--- a/src/Bundle/Validator/Constraints/Enabled.php
+++ b/src/Bundle/Validator/Constraints/Enabled.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 use Sylius\Bundle\ResourceBundle\Validator\EnabledValidator;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class Enabled extends Constraint
 {
     public string $message = 'sylius.resource.not_enabled';

--- a/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
+++ b/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 use Sylius\Bundle\ResourceBundle\Validator\UniqueWithinCollectionConstraintValidator;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UniqueWithinCollectionConstraint extends Constraint
 {
     public string $message = 'This code must be unique within this collection.';


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | improvement
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related ticket | https://github.com/Sylius/Sylius/pull/17910
| License         | MIT

According to the documentation:
https://symfony.com/doc/current/validation/custom_constraint.html
`Add #[\Attribute] to the constraint class if you want to use it as an attribute in other classes.`