### PR TITLE
Use locale from kernel default locale

### DIFF
--- a/src/Bundle/SyliusResourceBundle.php
+++ b/src/Bundle/SyliusResourceBundle.php
@@ -30,6 +30,7 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\UnregisterHateoasD
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\WinzouStateMachinePass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\PagerfantaExtension;
 use Sylius\Resource\Symfony\DependencyInjection\Compiler\DisableMetadataCachePass;
+use Sylius\Resource\Symfony\DependencyInjection\Compiler\FallbackToKernelDefaultLocalePass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -50,6 +51,7 @@ final class SyliusResourceBundle extends Bundle
 
         $container->addCompilerPass(new CsrfTokenManagerPass());
         $container->addCompilerPass(new DisableMetadataCachePass());
+        $container->addCompilerPass(new FallbackToKernelDefaultLocalePass());
         $container->addCompilerPass(new DoctrineContainerRepositoryFactoryPass());
         $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass(new TargetEntitiesResolver()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RegisterFormBuilderPass());

--- a/src/Component/src/Symfony/DependencyInjection/Compiler/FallbackToKernelDefaultLocalePass.php
+++ b/src/Component/src/Symfony/DependencyInjection/Compiler/FallbackToKernelDefaultLocalePass.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class FallbackToKernelDefaultLocalePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (
+            $container->hasParameter('locale') ||
+            !$container->hasParameter('kernel.default_locale')
+        ) {
+            return;
+        }
+
+        /** @var string $locale */
+        $locale = $container->getParameter('kernel.default_locale');
+
+        $this->replaceLocaleInFlashHelper($container, $locale);
+        $this->replaceLocaleProvider($container, $locale);
+    }
+
+    private function replaceLocaleInFlashHelper(ContainerBuilder $container, string $locale): void
+    {
+        if (!$container->hasDefinition('sylius.resource_controller.flash_helper')) {
+            return;
+        }
+
+        $flashHelper = $container->getDefinition('sylius.resource_controller.flash_helper');
+        $flashHelper->replaceArgument(2, $locale);
+    }
+
+    private function replaceLocaleProvider(ContainerBuilder $container, string $locale): void
+    {
+        if (!$container->hasDefinition('sylius.translation_locale_provider.immutable')) {
+            return;
+        }
+
+        $localeProvider = $container->getDefinition('sylius.translation_locale_provider.immutable');
+        $localeProvider->replaceArgument(0, [$locale]);
+        $localeProvider->replaceArgument(1, $locale);
+    }
+}

--- a/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
+++ b/src/Component/tests/Symfony/DependencyInjection/Compiler/DisableMetadataCachePassTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\tests\Symfony\DependencyInjection\Compiler;
+namespace Sylius\Resource\Tests\Symfony\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sylius\Resource\Symfony\DependencyInjection\Compiler\DisableMetadataCachePass;

--- a/src/Component/tests/Symfony/DependencyInjection/Compiler/FallbackToKernelDefaultLocalePassTest.php
+++ b/src/Component/tests/Symfony/DependencyInjection/Compiler/FallbackToKernelDefaultLocalePassTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Symfony\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\Bundle\ResourceBundle\Controller\FlashHelper;
+use Sylius\Resource\Symfony\DependencyInjection\Compiler\FallbackToKernelDefaultLocalePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class FallbackToKernelDefaultLocalePassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_does_nothing_if_locale_parameter_has_been_defined(): void
+    {
+        $this->setParameter('locale', 'en_US');
+        $this->setDefinition('sylius.resource_controller.flash_helper', new Definition());
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius.resource_controller.flash_helper');
+    }
+
+    /** @test */
+    public function it_replaces_locale_argument_in_flash_helper(): void
+    {
+        $flashHelperDefinition = (new Definition(FlashHelper::class))->setArguments([
+            null,
+            null,
+            null,
+        ]);
+
+        $this->setParameter('kernel.default_locale', 'en_US');
+        $this->setDefinition('sylius.resource_controller.flash_helper', $flashHelperDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius.resource_controller.flash_helper');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sylius.resource_controller.flash_helper', 2, 'en_US');
+    }
+
+    /** @test */
+    public function it_replaces_locale_argument_in_translation_locale_provider(): void
+    {
+        $translationLocaleProviderDefinition = (new Definition(FlashHelper::class))->setArguments([
+            [],
+            null,
+        ]);
+
+        $this->setParameter('kernel.default_locale', 'en_US');
+        $this->setDefinition('sylius.translation_locale_provider.immutable', $translationLocaleProviderDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('sylius.translation_locale_provider.immutable');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sylius.translation_locale_provider.immutable', 0, ['en_US']);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sylius.translation_locale_provider.immutable', 1, 'en_US');
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new FallbackToKernelDefaultLocalePass());
+    }
+}

--- a/tests/Application/config/packages/framework.yaml
+++ b/tests/Application/config/packages/framework.yaml
@@ -2,11 +2,11 @@ framework:
     assets: false
     translator:
         default_path: '%kernel.project_dir%/translations'
-        fallbacks: ["%locale%"]
+        fallbacks: ["en_US"]
     secret: "%secret%"
     form: ~
     csrf_protection: true
-    default_locale: "%locale%"
+    default_locale: "en_US"
     session:
         handler_id: ~
         storage_factory_id: session.storage.factory.mock_file

--- a/tests/Application/config/services.yaml
+++ b/tests/Application/config/services.yaml
@@ -5,7 +5,6 @@ parameters:
     database_driver: pdo_sqlite
     database_path: "%kernel.project_dir%/config/db.sql"
 
-    locale: en_US
     secret: "Three can keep a secret, if two of them are dead."
 
 services:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | kind of
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #1032
| License         | MIT

The idea is to ensure we will not break userland application translations when removing dependency to a locale parameter.
