### PR TITLE
Add repository variables for factory

### DIFF
--- a/src/Bundle/Resources/config/services/expression_language.xml
+++ b/src/Bundle/Resources/config/services/expression_language.xml
@@ -30,6 +30,11 @@
             <tag name="sylius.routing_variables" />
         </service>
 
+        <service id="sylius.expression_language.variables.sylius_repositories" class="Sylius\Resource\Symfony\ExpressionLanguage\SyliusRepositoriesVariables">
+            <argument type="tagged_locator" tag="sylius.repository" />
+            <tag name="sylius.resource_factory_variables" />
+        </service>
+
         <service id="sylius.expression_language.variables_collection.factory" class="Sylius\Resource\Symfony\ExpressionLanguage\VariablesCollection">
             <argument type="tagged_iterator" tag="sylius.resource_factory_variables" />
         </service>

--- a/src/Component/src/Symfony/ExpressionLanguage/SyliusRepositoriesVariables.php
+++ b/src/Component/src/Symfony/ExpressionLanguage/SyliusRepositoriesVariables.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Symfony\ExpressionLanguage;
+
+use Psr\Container\ContainerInterface;
+
+final class SyliusRepositoriesVariables implements VariablesInterface
+{
+    public function __construct(
+        private readonly ContainerInterface $repositories,
+    ) {
+    }
+
+    public function getVariables(): array
+    {
+        return [
+            'sylius_repositories' => $this->repositories,
+        ];
+    }
+}

--- a/src/Component/tests/Symfony/ExpressionLanguage/SyliusRepositoriesVariablesTest.php
+++ b/src/Component/tests/Symfony/ExpressionLanguage/SyliusRepositoriesVariablesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Symfony\ExpressionLanguage;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Sylius\Resource\Symfony\ExpressionLanguage\SyliusRepositoriesVariables;
+
+final class SyliusRepositoriesVariablesTest extends TestCase
+{
+    public function testItReturnsTheSyliusRepositoryVariables(): void
+    {
+        $syliusRepositories = $this->createMock(ContainerInterface::class);
+
+        $syliusRepositoriesVariables = new SyliusRepositoriesVariables($syliusRepositories);
+
+        $this->assertSame(['sylius_repositories' => $syliusRepositories], $syliusRepositoriesVariables->getVariables());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no/yes
| New feature?    | no/yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

### Documentation

We'll need to add that new variable on this documentation
https://stack.sylius.com/resource/index/resource_factories#pass-arguments-to-your-method

### **Example of usage**

Creating a taxon from a parent
The path is `/admin/taxons/new/{id}`
So the `id` comes from the request attributes.

**Previous implementation**

```yaml
sylius_admin_taxon_create_for_parent:
    # ...
    defaults:
        _controller: sylius.controller.taxon::createAction
        _sylius:
            # ...
            factory:
                method: createForParent
                arguments: ['expr:notFoundOnNull(service("sylius.repository.taxon").find($id))']
```

`service` is a function which can retrieve "public" services. The public services are not the recommanded way. Due to performance issues, the services are private by default.
`$id` is parsed with the Sylius\Bundle\ResourceBundle\Provider\RequestParameterProvider which is kind of magic, and the syntax with a "$" is a little bit strange.

**New implementation**
```php
use Sylius\Bundle\AdminBundle\Form\Type\TaxonType;
use Sylius\Resource\Metadata\BulkDelete;
use Sylius\Resource\Metadata\Create;
use Sylius\Resource\Metadata\Delete;
use Sylius\Resource\Metadata\Operations;
use Sylius\Resource\Metadata\ResourceMetadata;
use Sylius\Resource\Metadata\Update;

return (new ResourceMetadata())
    // ...
    ->withOperations(new Operations([
        // ...
        new Create(
           // ...
            factoryMethod: 'createForParent',
            factoryArguments: ['parent' => "throw_not_found_on_null(sylius_repositories.get('sylius.repository.taxon').find(request.attributes.get('id')))"],
        ),
    ]))
;
```

With that new implementation for the new routing system, it used sth that is more natural in Symfony applications and with current Expression language usages that we can see on serveral Symfony packages.
You can use the `request` object directly with all its methods.
You can use all the Sylius repositories to find an object and passed it as an argument to your factory method.

In addition, I think it could be cool to add sth more generic for Symfony applications with Doctrine.
Accessing entity_manager directly is not safe, cause there are methods to flush... or things that we do not want to have access here.
Maybe a `doctrine_repository(Dummy:class)` function, could be perfect for this.