### PR TITLE
Fix configured resource without form

### DIFF
--- a/src/Component/spec/Symfony/Routing/Factory/AttributesOperationRouteFactorySpec.php
+++ b/src/Component/spec/Symfony/Routing/Factory/AttributesOperationRouteFactorySpec.php
@@ -60,6 +60,7 @@ final class AttributesOperationRouteFactorySpec extends ObjectBehavior
         $routeCollection = new RouteCollection();
 
         $metadata->getServiceId('repository')->willReturn('app.repository.dummy');
+        $metadata->hasClass('form')->willReturn(true);
         $metadata->getClass('form')->willReturn('App\Form');
         $metadata->getClass('model')->willReturn('App\Dummy');
         $metadata->getStateMachineComponent()->willReturn('symfony');

--- a/src/Component/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Component/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -91,12 +91,18 @@ trait OperationDefaultsTrait
         }
 
         if (null === $operation->getFormType()) {
-            $formType = $resource->getFormType() ?? $resourceConfiguration->getClass('form');
-            $operation = $operation->withFormType($formType);
+            $formType = $resource->getFormType();
+            $formType ??= $resourceConfiguration->hasClass('form') ? $resourceConfiguration->getClass('form') : null;
+
+            if (null !== $formType) {
+                $operation = $operation->withFormType($formType);
+            }
         }
 
-        $formOptions = $this->buildFormOptions($operation, $resourceConfiguration);
-        $operation = $operation->withFormOptions($formOptions);
+        if (null !== $operation->getFormType()) {
+            $formOptions = $this->buildFormOptions($operation, $resourceConfiguration);
+            $operation = $operation->withFormOptions($formOptions);
+        }
 
         if ($operation instanceof HttpOperation) {
             if (null === $operation->getRoutePrefix()) {

--- a/src/Component/tests/Metadata/Resource/Factory/php/php_file_with_resource_class.php
+++ b/src/Component/tests/Metadata/Resource/Factory/php/php_file_with_resource_class.php
@@ -11,6 +11,11 @@
 
 declare(strict_types=1);
 
+use Sylius\Resource\Metadata\Create;
+use Sylius\Resource\Metadata\Operations;
 use Sylius\Resource\Metadata\ResourceMetadata;
 
-return new ResourceMetadata(class: \stdClass::class);
+return (new ResourceMetadata(class: \stdClass::class))
+    ->withOperations(new Operations([
+        new Create(),
+    ]));


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (but it can happen only on 1.14 branch)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When we define a resource via an external php file, we registers the resource as a Sylius one.
But there will be no form by default which should be ok.

With autoregistration, or with a Resource from Sylius resource bundle config, the form type will be the `DefaultResourceType`. I think that'd be cool to remove that default form type and use it only if you need to (for RAD purpose).