### PR TITLE
[ExpressionLanguage] Add providers on argument parsers

### DIFF
--- a/src/Bundle/Resources/config/services/expression_language.xml
+++ b/src/Bundle/Resources/config/services/expression_language.xml
@@ -42,19 +42,26 @@
             <argument type="tagged_iterator" tag="sylius.routing_variables" />
         </service>
 
+        <service id="sylius.expression_language.providers.throw_not_found_on_null" class="Sylius\Resource\Symfony\ExpressionLanguage\Provider\ThrowNotFoundOnNullExpressionFunctionProvider">
+            <tag name="sylius.resource_factory_providers" />
+        </service>
+
         <service id="sylius.expression_language.argument_parser.factory" class="Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParser">
             <argument type="service" id="sylius.resource_factory.expression_language" />
             <argument type="service" id="sylius.expression_language.variables_collection.factory"  />
+            <argument type="tagged_iterator" tag="sylius.resource_factory_providers" />
         </service>
 
         <service id="sylius.expression_language.argument_parser.repository" class="Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParser">
             <argument type="service" id="sylius.repository.expression_language" />
             <argument type="service" id="sylius.expression_language.variables_collection.repository"  />
+            <argument type="tagged_iterator" tag="sylius.repository_providers" />
         </service>
 
         <service id="sylius.expression_language.argument_parser.routing" class="Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParser">
             <argument type="service" id="sylius.routing.expression_language" />
             <argument type="service" id="sylius.expression_language.variables_collection.routing"  />
+            <argument type="tagged_iterator" tag="sylius.routing_providers" />
         </service>
     </services>
 </container>

--- a/src/Component/src/Symfony/ExpressionLanguage/ArgumentParser.php
+++ b/src/Component/src/Symfony/ExpressionLanguage/ArgumentParser.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Symfony\ExpressionLanguage;
 
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Webmozart\Assert\Assert;
 
 /**
  * @experimental
@@ -21,9 +23,15 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 final class ArgumentParser implements ArgumentParserInterface
 {
     public function __construct(
-        private ExpressionLanguage $expressionLanguage,
-        private VariablesCollectionInterface $variablesCollection,
+        private readonly ExpressionLanguage $expressionLanguage,
+        private readonly VariablesCollectionInterface $variablesCollection,
+        readonly ?iterable $providers = null,
     ) {
+        foreach ($providers ?? [] as $provider) {
+            Assert::isInstanceOf($provider, ExpressionFunctionProviderInterface::class);
+
+            $this->expressionLanguage->registerProvider($provider);
+        }
     }
 
     public function parseExpression(string $expression, array $variables = []): mixed

--- a/src/Component/src/Symfony/ExpressionLanguage/Provider/ThrowNotFoundOnNullExpressionFunctionProvider.php
+++ b/src/Component/src/Symfony/ExpressionLanguage/Provider/ThrowNotFoundOnNullExpressionFunctionProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Symfony\ExpressionLanguage\Provider;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ThrowNotFoundOnNullExpressionFunctionProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'throw_not_found_on_null',
+                function (string $value, string ...$args): string {
+                    $message = $args[0] ?? '';
+
+                    return sprintf(
+                        '(null !== %1$s) ? %1$s : throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException(%2$s)',
+                        $value,
+                        $message,
+                    );
+                },
+                function (array $arguments, mixed $value, ?string $message = null): mixed {
+                    if (null === $value) {
+                        throw new NotFoundHttpException($message ?? '');
+                    }
+
+                    return $value;
+                },
+            ),
+        ];
+    }
+}

--- a/src/Component/tests/Symfony/ExpressionLanguage/ArgumentParserTest.php
+++ b/src/Component/tests/Symfony/ExpressionLanguage/ArgumentParserTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Resource\tests\Symfony\ExpressionLanguage;
+namespace Sylius\Resource\Tests\Symfony\ExpressionLanguage;
 
 use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -31,6 +31,7 @@ final class ArgumentParserTest extends KernelTestCase
         $this->assertTrue($argumentParser->parseExpression('token.getUser() === null'));
         $this->assertTrue($argumentParser->parseExpression('user === null'));
         $this->assertTrue($argumentParser->parseExpression('request === null'));
+        $this->assertTrue($argumentParser->parseExpression('throw_not_found_on_null(true)'));
     }
 
     public function testRepositoryArgumentParser(): void

--- a/src/Component/tests/Symfony/ExpressionLanguage/Provider/ThrowNotFoundOnNullExpressionFunctionProviderTest.php
+++ b/src/Component/tests/Symfony/ExpressionLanguage/Provider/ThrowNotFoundOnNullExpressionFunctionProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Symfony\ExpressionLanguage\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Symfony\ExpressionLanguage\Provider\ThrowNotFoundOnNullExpressionFunctionProvider;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ThrowNotFoundOnNullExpressionFunctionProviderTest extends TestCase
+{
+    private ExpressionLanguage $expressionLanguage;
+
+    protected function setUp(): void
+    {
+        $this->expressionLanguage = new ExpressionLanguage();
+        $this->expressionLanguage->registerProvider(new ThrowNotFoundOnNullExpressionFunctionProvider());
+    }
+
+    public function test_it_returns_the_value_when_not_null(): void
+    {
+        $result = $this->expressionLanguage->evaluate('throw_not_found_on_null(value)', [
+            'value' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $result);
+    }
+
+    public function test_it_throws_not_found_exception_when_null_with_empty_message(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('');
+
+        $this->expressionLanguage->evaluate('throw_not_found_on_null(value)', [
+            'value' => null,
+        ]);
+    }
+
+    public function test_it_throws_not_found_exception_when_null_with_custom_message(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Custom message.');
+
+        $this->expressionLanguage->evaluate('throw_not_found_on_null(value, "Custom message.")', [
+            'value' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

```php
<?php

use Sylius\Resource\Metadata\Create;
use Sylius\Resource\Metadata\Operations;
use Sylius\Resource\Metadata\ResourceMetadata;

return (new ResourceMetadata())
    // ...
    ->withOperations(operations: new Operations(operations: [
        new Create(
            // ...
            factoryMethod: 'createForProduct',
            factoryArguments: [
                "throw_not_found_on_null(sylius_repositories.get('sylius.repository.product').find(request.attributes.get('productId'))), 'Product not found."
            ],
        ),
    ]))
;

```