### PR TITLE
Add argument parser for resource and operation vars

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -195,6 +195,7 @@
         <PossiblyNullArgument>
             <errorLevel type="suppress">
                 <file name="src/Bundle/Grid/Parser/OptionsParser.php" />
+                <file name="src/Component/src/Metadata/Operation/HttpOperationInitiator.php" />
             </errorLevel>
         </PossiblyNullArgument>
 

--- a/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
+++ b/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
@@ -30,6 +30,15 @@ final class LegacyRequestContextInitiator implements RequestContextInitiatorInte
         private RequestContextInitiatorInterface $decorated,
         private ?VarsResolverInterface $varsResolver = null,
     ) {
+        if (null === $varsResolver) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.14',
+                'Not passing an instance of "%s" as the fourth constructor argument for "%s" is deprecated and will not be supported in 2.0.',
+                VarsResolverInterface::class,
+                self::class,
+            );
+        }
     }
 
     public function initializeContext(Request $request): Context

--- a/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
+++ b/src/Bundle/Context/Initiator/LegacyRequestContextInitiator.php
@@ -19,6 +19,7 @@ use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Initiator\RequestContextInitiatorInterface;
 use Sylius\Resource\Context\Option\MetadataOption;
 use Sylius\Resource\Metadata\RegistryInterface;
+use Sylius\Resource\Symfony\ExpressionLanguage\VarsResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 final class LegacyRequestContextInitiator implements RequestContextInitiatorInterface
@@ -27,6 +28,7 @@ final class LegacyRequestContextInitiator implements RequestContextInitiatorInte
         private RegistryInterface $resourceRegistry,
         private RequestConfigurationFactoryInterface $requestConfigurationFactory,
         private RequestContextInitiatorInterface $decorated,
+        private ?VarsResolverInterface $varsResolver = null,
     ) {
     }
 
@@ -49,7 +51,19 @@ final class LegacyRequestContextInitiator implements RequestContextInitiatorInte
         }
 
         $configuration = $this->requestConfigurationFactory->create($metadata, $request);
+        $configurationVars = $this->resolveVars($configuration->getVars());
+
+        $configuration->getParameters()->set('vars', $configurationVars);
 
         return $context->with(new MetadataOption($metadata), new RequestConfigurationOption($configuration));
+    }
+
+    private function resolveVars(array $vars): array
+    {
+        if (null === $this->varsResolver) {
+            return $vars;
+        }
+
+        return $this->varsResolver->resolve($vars);
     }
 }

--- a/src/Bundle/Resources/config/services/context.xml
+++ b/src/Bundle/Resources/config/services/context.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="sylius.resource_registry" />
             <argument type="service" id="sylius.resource_controller.request_configuration_factory" />
             <argument type="service" id=".inner" />
+            <argument type="service" id="sylius.expression_language.vars_resolver.metadata" />
         </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services/expression_language.xml
+++ b/src/Bundle/Resources/config/services/expression_language.xml
@@ -13,18 +13,21 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="sylius.metadata.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
         <service id="sylius.resource_factory.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
         <service id="sylius.repository.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
         <service id="sylius.routing.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
 
         <service id="sylius.expression_language.variables.token" class="Sylius\Resource\Symfony\ExpressionLanguage\TokenVariables">
             <argument type="service" id="security.token_storage" on-invalid="null" />
+            <tag name="sylius.metadata_variables" />
             <tag name="sylius.resource_factory_variables" />
             <tag name="sylius.repository_variables" />
         </service>
 
         <service id="sylius.expression_language.variables.request" class="Sylius\Resource\Symfony\ExpressionLanguage\RequestVariables">
             <argument type="service" id="request_stack" />
+            <tag name="sylius.metadata_variables" />
             <tag name="sylius.resource_factory_variables" />
             <tag name="sylius.repository_variables" />
             <tag name="sylius.routing_variables" />
@@ -32,7 +35,12 @@
 
         <service id="sylius.expression_language.variables.sylius_repositories" class="Sylius\Resource\Symfony\ExpressionLanguage\SyliusRepositoriesVariables">
             <argument type="tagged_locator" tag="sylius.repository" />
+            <tag name="sylius.metadata_variables" />
             <tag name="sylius.resource_factory_variables" />
+        </service>
+
+        <service id="sylius.expression_language.variables_collection.metadata" class="Sylius\Resource\Symfony\ExpressionLanguage\VariablesCollection">
+            <argument type="tagged_iterator" tag="sylius.metadata_variables" />
         </service>
 
         <service id="sylius.expression_language.variables_collection.factory" class="Sylius\Resource\Symfony\ExpressionLanguage\VariablesCollection">
@@ -48,7 +56,18 @@
         </service>
 
         <service id="sylius.expression_language.providers.throw_not_found_on_null" class="Sylius\Resource\Symfony\ExpressionLanguage\Provider\ThrowNotFoundOnNullExpressionFunctionProvider">
+            <tag name="sylius.metadata_providers" />
             <tag name="sylius.resource_factory_providers" />
+        </service>
+
+        <service id="sylius.expression_language.vars_resolver.metadata" class="Sylius\Resource\Symfony\ExpressionLanguage\VarsResolver">
+            <argument type="service" id="sylius.expression_language.argument_parser.metadata" />
+        </service>
+
+        <service id="sylius.expression_language.argument_parser.metadata" class="Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParser">
+            <argument type="service" id="sylius.metadata.expression_language" />
+            <argument type="service" id="sylius.expression_language.variables_collection.metadata"  />
+            <argument type="tagged_iterator" tag="sylius.metadata_providers" />
         </service>
 
         <service id="sylius.expression_language.argument_parser.factory" class="Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParser">

--- a/src/Bundle/Resources/config/services/metadata/resource_metadata_operation.xml
+++ b/src/Bundle/Resources/config/services/metadata/resource_metadata_operation.xml
@@ -16,6 +16,7 @@
         <service id="sylius.resource_metadata_operation.initiator.http_operation" class="Sylius\Resource\Metadata\Operation\HttpOperationInitiator">
             <argument type="service" id="sylius.resource_registry" />
             <argument type="service" id="sylius.resource_metadata_collection.factory" />
+            <argument type="service" id="sylius.expression_language.vars_resolver.metadata" />
         </service>
         <service id="Sylius\Resource\Metadata\Operation\HttpOperationInitiatorInterface" alias="sylius.resource_metadata_operation.initiator.http_operation" />
     </services>

--- a/src/Bundle/spec/Context/Initiator/LegacyRequestContextInitiatorSpec.php
+++ b/src/Bundle/spec/Context/Initiator/LegacyRequestContextInitiatorSpec.php
@@ -49,7 +49,10 @@ final class LegacyRequestContextInitiatorSpec extends ObjectBehavior
         MetadataInterface $metadata,
         RequestConfiguration $requestConfiguration,
     ): void {
-        $request->attributes = new ParameterBag(['_sylius' => ['resource' => 'app.dummy']]);
+        $parameterBag = new ParameterBag(['_sylius' => ['resource' => 'app.dummy']]);
+        $requestConfiguration->getParameters()->willReturn($parameterBag);
+        $requestConfiguration->getVars()->willReturn([]);
+        $request->attributes = $parameterBag;
 
         $decorated->initializeContext($request)->willReturn(new Context());
 

--- a/src/Component/src/Metadata/Operation/HttpOperationInitiator.php
+++ b/src/Component/src/Metadata/Operation/HttpOperationInitiator.php
@@ -26,6 +26,15 @@ final class HttpOperationInitiator implements HttpOperationInitiatorInterface
         private ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
         private ?VarsResolverInterface $varsResolver = null,
     ) {
+        if (null === $varsResolver) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.14',
+                'Not passing an instance of "%s" as the third constructor argument for "%s" is deprecated and will not be supported in 2.0.',
+                VarsResolverInterface::class,
+                self::class,
+            );
+        }
     }
 
     public function initializeOperation(Request $request): ?HttpOperation
@@ -61,20 +70,19 @@ final class HttpOperationInitiator implements HttpOperationInitiatorInterface
 
     private function getOperationWithVars(HttpOperation $operation): HttpOperation
     {
-        $operationVars = null !== $operation->getVars() ? $this->resolveVars($operation->getVars()) : null;
+        $operationVars = $operation->getVars();
+        $resolvedOperationVars = $operationVars !== null ? $this->resolveVars($operationVars) : null;
 
-        if (null !== $operationVars) {
-            $operation = $operation->withVars($operationVars);
-        }
+        $resourceVars = $operation->getResource()?->getVars();
+        $resolvedResourceVars = $resourceVars !== null ? $this->resolveVars($resourceVars) : null;
 
-        $resource = $operation->getResource();
-        $resourceVars = $resource?->getVars();
-
-        if (null === $resourceVars) {
+        if (null === $resolvedOperationVars && null === $resolvedResourceVars) {
             return $operation;
         }
 
-        return $operation->withVars(\array_merge($this->resolveVars($resourceVars), $operationVars ?? []));
+        $mergedVars = array_merge($resolvedResourceVars ?? [], $resolvedOperationVars ?? []);
+
+        return $operation->withVars($mergedVars);
     }
 
     private function resolveVars(array $vars): array

--- a/src/Component/src/Metadata/Operation/HttpOperationInitiator.php
+++ b/src/Component/src/Metadata/Operation/HttpOperationInitiator.php
@@ -16,6 +16,7 @@ namespace Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Sylius\Resource\Symfony\ExpressionLanguage\VarsResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 final class HttpOperationInitiator implements HttpOperationInitiatorInterface
@@ -23,6 +24,7 @@ final class HttpOperationInitiator implements HttpOperationInitiatorInterface
     public function __construct(
         private RegistryInterface $resourceRegistry,
         private ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private ?VarsResolverInterface $varsResolver = null,
     ) {
     }
 
@@ -54,6 +56,33 @@ final class HttpOperationInitiator implements HttpOperationInitiatorInterface
             ->getOperation($metadata->getAlias(), $operationName)
         ;
 
-        return $operation;
+        return $this->getOperationWithVars($operation);
+    }
+
+    private function getOperationWithVars(HttpOperation $operation): HttpOperation
+    {
+        $operationVars = null !== $operation->getVars() ? $this->resolveVars($operation->getVars()) : null;
+
+        if (null !== $operationVars) {
+            $operation = $operation->withVars($operationVars);
+        }
+
+        $resource = $operation->getResource();
+        $resourceVars = $resource?->getVars();
+
+        if (null === $resourceVars) {
+            return $operation;
+        }
+
+        return $operation->withVars(\array_merge($this->resolveVars($resourceVars), $operationVars ?? []));
+    }
+
+    private function resolveVars(array $vars): array
+    {
+        if (null === $this->varsResolver) {
+            return $vars;
+        }
+
+        return $this->varsResolver->resolve($vars);
     }
 }

--- a/src/Component/src/Symfony/ExpressionLanguage/VarsResolver.php
+++ b/src/Component/src/Symfony/ExpressionLanguage/VarsResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Symfony\ExpressionLanguage;
+
+/**
+ * @experimental
+ */
+final class VarsResolver implements VarsResolverInterface
+{
+    public function __construct(
+        private readonly ArgumentParser $argumentParser,
+    ) {
+    }
+
+    public function resolve(array $vars): array
+    {
+        foreach ($vars as $key => $value) {
+            if (\is_array($value)) {
+                $vars[$key] = $this->resolve($value);
+
+                continue;
+            }
+
+            // Parse only vars that contain expressions
+            if (!str_starts_with($value, '@=')) {
+                continue;
+            }
+
+            $value = str_replace('@=', '', $value);
+
+            $vars[$key] = $this->argumentParser->parseExpression($value);
+        }
+
+        return $vars;
+    }
+}

--- a/src/Component/src/Symfony/ExpressionLanguage/VarsResolverInterface.php
+++ b/src/Component/src/Symfony/ExpressionLanguage/VarsResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Symfony\ExpressionLanguage;
+
+/**
+ * @experimental
+ */
+interface VarsResolverInterface
+{
+    public function resolve(array $vars): array;
+}

--- a/src/Component/tests/Metadata/Operation/HttpOperationInitiatorTest.php
+++ b/src/Component/tests/Metadata/Operation/HttpOperationInitiatorTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operation\HttpOperationInitiator;
 use Sylius\Resource\Metadata\Operations;
@@ -24,6 +25,7 @@ use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\Symfony\ExpressionLanguage\VarsResolverInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -35,10 +37,13 @@ final class HttpOperationInitiatorTest extends TestCase
 
     private ResourceMetadataCollectionFactoryInterface|ObjectProphecy $resourceMetadataCollectionFactory;
 
+    private VarsResolverInterface|ObjectProphecy $varsResolver;
+
     protected function setUp(): void
     {
         $this->resourceRegistry = $this->prophesize(RegistryInterface::class);
         $this->resourceMetadataCollectionFactory = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $this->varsResolver = $this->prophesize(VarsResolverInterface::class);
     }
 
     public function testItIsInitializable(): void
@@ -46,6 +51,7 @@ final class HttpOperationInitiatorTest extends TestCase
         $initiator = new HttpOperationInitiator(
             $this->resourceRegistry->reveal(),
             $this->resourceMetadataCollectionFactory->reveal(),
+            $this->varsResolver->reveal(),
         );
 
         $this->assertInstanceOf(HttpOperationInitiator::class, $initiator);
@@ -72,6 +78,8 @@ final class HttpOperationInitiatorTest extends TestCase
         $metadata->getAlias()->willReturn('app.dummy');
 
         $operation->getName()->willReturn('app_dummy_index');
+        $operation->getVars()->willReturn(null);
+        $operation->getResource()->willReturn(null);
 
         $operations = new Operations();
         $operations->add('app_dummy_index', $operation->reveal());
@@ -87,6 +95,48 @@ final class HttpOperationInitiatorTest extends TestCase
         );
 
         $this->assertSame($operation->reveal(), $initiator->initializeOperation($request->reveal()));
+    }
+
+    public function testResolvesOperationVars(): void
+    {
+        $request = $this->prophesize(Request::class);
+        $attributes = $this->prophesize(ParameterBag::class);
+        $metadata = $this->prophesize(MetadataInterface::class);
+        $operation = new Index(name: 'app_dummy_index', vars: ['product' => '@=get_current_product()']);
+
+        $request->attributes = $attributes;
+
+        $attributes->get('_route')->willReturn('app_dummy_index');
+        $attributes->all('_sylius')->willReturn([
+            'resource' => 'app.dummy',
+        ]);
+        $attributes->set('_sylius', ['resource' => 'app.dummy', 'resource_class' => 'App\DummyResource'])->shouldBeCalled();
+
+        $this->resourceRegistry->get('app.dummy')->willReturn($metadata);
+
+        $metadata->getClass('model')->willReturn('App\DummyResource');
+        $metadata->getAlias()->willReturn('app.dummy');
+
+        $operations = new Operations();
+        $operations->add('app_dummy_index', $operation);
+
+        $product = new \stdClass();
+        $this->varsResolver->resolve(['product' => '@=get_current_product()'])->willReturn(['product' => $product])->shouldBeCalled();
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = (new ResourceMetadata(alias: 'app.dummy'))->withOperations($operations);
+
+        $this->resourceMetadataCollectionFactory->create('App\DummyResource')->willReturn($resourceMetadataCollection);
+
+        $initiator = new HttpOperationInitiator(
+            $this->resourceRegistry->reveal(),
+            $this->resourceMetadataCollectionFactory->reveal(),
+            $this->varsResolver->reveal(),
+        );
+
+        $result = $initiator->initializeOperation($request->reveal());
+        $this->assertNotNull($result);
+        $this->assertSame(['product' => $product], $result->getVars());
     }
 
     public function testItReturnsNullWhenRequestHasNoSyliusOptions(): void

--- a/src/Component/tests/Metadata/Operation/HttpOperationInitiatorTest.php
+++ b/src/Component/tests/Metadata/Operation/HttpOperationInitiatorTest.php
@@ -97,7 +97,7 @@ final class HttpOperationInitiatorTest extends TestCase
         $this->assertSame($operation->reveal(), $initiator->initializeOperation($request->reveal()));
     }
 
-    public function testResolvesOperationVars(): void
+    public function testItResolvesOperationVars(): void
     {
         $request = $this->prophesize(Request::class);
         $attributes = $this->prophesize(ParameterBag::class);

--- a/src/Component/tests/Metadata/Resource/Factory/VarsResourceMetadataCollectionFactoryTest.php
+++ b/src/Component/tests/Metadata/Resource/Factory/VarsResourceMetadataCollectionFactoryTest.php
@@ -23,6 +23,7 @@ use Sylius\Resource\Metadata\Resource\Factory\VarsResourceMetadataCollectionFact
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
+use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
 
 final class VarsResourceMetadataCollectionFactoryTest extends TestCase
 {
@@ -32,10 +33,13 @@ final class VarsResourceMetadataCollectionFactoryTest extends TestCase
 
     private VarsResourceMetadataCollectionFactory $factory;
 
+    private ArgumentParserInterface|ObjectProphecy $argumentParser;
+
     protected function setUp(): void
     {
         $this->decorated = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $this->factory = new VarsResourceMetadataCollectionFactory($this->decorated->reveal());
+        $this->argumentParser = $this->prophesize(ArgumentParserInterface::class);
+        $this->factory = new VarsResourceMetadataCollectionFactory($this->decorated->reveal(), $this->argumentParser->reveal());
     }
 
     public function testItIsInitializable(): void
@@ -43,7 +47,7 @@ final class VarsResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertInstanceOf(VarsResourceMetadataCollectionFactory::class, $this->factory);
     }
 
-    public function testItMergeResourceVarsWithOperationVars(): void
+    public function testItMergesResourceVarsWithOperationVars(): void
     {
         $resource = new ResourceMetadata(
             alias: 'app.book',

--- a/src/Component/tests/Symfony/ExpressionLanguage/ArgumentParserTest.php
+++ b/src/Component/tests/Symfony/ExpressionLanguage/ArgumentParserTest.php
@@ -18,6 +18,22 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class ArgumentParserTest extends KernelTestCase
 {
+    public function testMetadataArgumentParser(): void
+    {
+        self::bootKernel();
+
+        $container = static::getContainer();
+
+        /** @var ArgumentParserInterface $argumentParser */
+        $argumentParser = $container->get('sylius.expression_language.argument_parser.metadata');
+
+        $this->assertInstanceOf(ArgumentParserInterface::class, $argumentParser);
+        $this->assertTrue($argumentParser->parseExpression('token.getUser() === null'));
+        $this->assertTrue($argumentParser->parseExpression('user === null'));
+        $this->assertTrue($argumentParser->parseExpression('request === null'));
+        $this->assertTrue($argumentParser->parseExpression('throw_not_found_on_null(true)'));
+    }
+
     public function testResourceFactoryArgumentParser(): void
     {
         self::bootKernel();

--- a/src/Component/tests/Symfony/ExpressionLanguage/VarsResolverTest.php
+++ b/src/Component/tests/Symfony/ExpressionLanguage/VarsResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Symfony\ExpressionLanguage;
+
+use Sylius\Resource\Symfony\ExpressionLanguage\VarsResolverInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class VarsResolverTest extends KernelTestCase
+{
+    public function testMetadataVarsResolver(): void
+    {
+        $container = static::getContainer();
+
+        /** @var VarsResolverInterface $varsResolver */
+        $varsResolver = $container->get('sylius.expression_language.vars_resolver.metadata');
+
+        $this->assertInstanceOf(VarsResolverInterface::class, $varsResolver);
+        $this->assertEquals(['has_user' => true], $varsResolver->resolve(['has_user' => '@=token.getUser() === null']));
+        $this->assertEquals(['parameters' => ['has_user' => true]], $varsResolver->resolve(['parameters' => ['has_user' => '@=token.getUser() === null']]));
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The feature we need with the new routing system

**Previous implementation:**
```yaml
sylius_admin_catalog_promotion_product_variant_index:
    path: /catalog-promotions/{id}/variants
    defaults:
        _sylius:
            vars:
                catalogPromotion: expr:service('sylius.repository.catalog_promotion').find($id)
```

**New implementation:**
```php
new Index(vars: [
    'catalogPromotion' => "@=sylius_repositories.get('sylius.repository.catalog_promotion').find(request.attributes.get('id')",
]);
```

**Note**
`@=` is the synthax for expression that is used on Symfony dependency injection and Twig Hooks

Example on Sylius E-commerce admin panel
The product is used on the breadcrumb.

![image](https://github.com/user-attachments/assets/6a42d4c4-3ea9-405e-a25a-b733c30df5f5)
