### PR TITLE
Add filters from grid storage on redirect handler

### DIFF
--- a/src/Bundle/Resources/config/services/routing.xml
+++ b/src/Bundle/Resources/config/services/routing.xml
@@ -128,6 +128,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="sylius.expression_language.argument_parser.routing" />
             <argument type="service" id="sylius.routing.factory.operation_route_name_factory" />
+            <argument type="service" id="sylius.grid.filter_storage" on-invalid="null" />
         </service>
         <service id="Sylius\Resource\Symfony\Routing\RedirectHandlerInterface" alias="sylius.routing.redirect_handler" />
     </services>

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -54,7 +54,8 @@
         "phpspec/phpspec": "^7.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "sylius/grid": "^1.7 || ^1.13@alpha",
+        "sylius/grid": "^1.13",
+        "sylius/grid-bundle": "^1.13",
         "symfony/serializer": "^6.4 || ^7.1",
         "symfony/workflow": "^6.4 || ^7.1",
         "twig/twig": "^3.0"

--- a/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
+++ b/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Resource\Symfony\Routing;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Bundle\GridBundle\Storage\FilterStorageInterface;
 use Sylius\Resource\Metadata\BulkUpdate;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Delete;
@@ -31,11 +32,13 @@ final class RedirectHandlerSpec extends ObjectBehavior
         RouterInterface $router,
         ArgumentParserInterface $argumentParser,
         OperationRouteNameFactoryInterface $operationRouteNameFactory,
+        FilterStorageInterface $filterStorage,
     ): void {
         $this->beConstructedWith(
             $router,
             $argumentParser,
             $operationRouteNameFactory,
+            $filterStorage,
         );
     }
 
@@ -48,12 +51,14 @@ final class RedirectHandlerSpec extends ObjectBehavior
         \stdClass $data,
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data->id = 'xyz';
         $operation = new Create(redirectToRoute: 'app_dummy_index');
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', ['id' => 'xyz'])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -63,12 +68,14 @@ final class RedirectHandlerSpec extends ObjectBehavior
         \stdClass $data,
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data->code = 'xyz';
         $operation = new Create(redirectToRoute: 'app_dummy_index');
         $resource = new ResourceMetadata(alias: 'app.ok', identifier: 'code');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', ['code' => 'xyz'])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -77,12 +84,14 @@ final class RedirectHandlerSpec extends ObjectBehavior
     function it_redirects_to_resource_with_id_via_property_access(
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data = new BoardGameResource('uid');
         $operation = new Create(redirectToRoute: 'app_board_game_index');
         $resource = new ResourceMetadata(alias: 'app.board_game');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_board_game_index', ['id' => 'uid'])->willReturn('/board-games')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -92,12 +101,14 @@ final class RedirectHandlerSpec extends ObjectBehavior
         \stdClass $data,
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data->code = 'xyz';
         $operation = new Create(redirectToRoute: 'app_dummy_index', redirectArguments: ['code' => 'resource.code']);
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', ['code' => 'xyz'])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -107,6 +118,7 @@ final class RedirectHandlerSpec extends ObjectBehavior
         Request $request,
         RouterInterface $router,
         ArgumentParserInterface $argumentParser,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data = new BoardGameResource('uid');
         $operation = new Create(redirectToRoute: 'app_board_game_index', redirectArguments: ['id' => 'resource.id()']);
@@ -115,6 +127,7 @@ final class RedirectHandlerSpec extends ObjectBehavior
 
         $argumentParser->parseExpression('resource.id()', ['resource' => $data])->willReturn('uid');
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_board_game_index', ['id' => 'uid'])->willReturn('/board-games')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -124,13 +137,49 @@ final class RedirectHandlerSpec extends ObjectBehavior
         \stdClass $data,
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data->id = 'xyz';
         $operation = new Delete(redirectToRoute: 'app_dummy_index');
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
+
+        $this->redirectToResource($data, $operation, $request);
+    }
+
+    function it_uses_filters_from_grid_storage_when_redirecting_to_an_index_operation(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+        FilterStorageInterface $filterStorage,
+    ): void {
+        $data->id = 'xyz';
+        $operation = new Delete(redirectToRoute: 'app_dummy_index');
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = $operation->withResource($resource);
+
+        $filterStorage->all()->willReturn(['criteria' => ['enabled' => true]]);
+        $router->generate('app_dummy_index', ['criteria' => ['enabled' => true]])->willReturn('/dummies')->shouldBeCalled();
+
+        $this->redirectToResource($data, $operation, $request);
+    }
+
+    function it_do_not_use_filters_from_grid_storage_when_redirecting_to_an_update_operation(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+        FilterStorageInterface $filterStorage,
+    ): void {
+        $data->id = 'xyz';
+        $operation = new Create(redirectToRoute: 'app_dummy_update');
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = $operation->withResource($resource);
+
+        $filterStorage->all()->willReturn(['criteria' => ['enabled' => true]]);
+        $router->generate('app_dummy_update', ['id' => 'xyz'])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
     }
@@ -139,12 +188,14 @@ final class RedirectHandlerSpec extends ObjectBehavior
         \stdClass $data,
         Request $request,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
         $data->id = 'xyz';
         $operation = new BulkUpdate(redirectToRoute: 'app_dummy_index');
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = $operation->withResource($resource);
 
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
@@ -153,7 +204,9 @@ final class RedirectHandlerSpec extends ObjectBehavior
     function it_redirects_to_route(
         \stdClass $data,
         RouterInterface $router,
+        FilterStorageInterface $filterStorage,
     ): void {
+        $filterStorage->all()->willReturn([]);
         $router->generate('app_dummy_index', [])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToRoute($data, 'app_dummy_index');

--- a/src/Component/src/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/src/Symfony/Routing/RedirectHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Symfony\Routing;
 
+use Sylius\Bundle\GridBundle\Storage\FilterStorageInterface;
 use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
@@ -33,6 +34,7 @@ final class RedirectHandler implements RedirectHandlerInterface
         private RouterInterface $router,
         private ArgumentParserInterface $argumentParser,
         private OperationRouteNameFactoryInterface $operationRouteNameFactory,
+        private ?FilterStorageInterface $filterStorage = null,
     ) {
     }
 
@@ -44,7 +46,7 @@ final class RedirectHandler implements RedirectHandlerInterface
             throw new \RuntimeException(sprintf('Operation "%s" has no redirection route, but it should.', $operation->getName() ?? ''));
         }
 
-        $parameters = $this->getRouteArguments($data, $operation, $request);
+        $parameters = $this->getRouteArguments($data, $operation);
 
         return $this->redirectToRoute($data, $route, $parameters);
     }
@@ -53,17 +55,21 @@ final class RedirectHandler implements RedirectHandlerInterface
     {
         $route = $this->operationRouteNameFactory->createRouteName($operation, $newOperation);
 
-        $parameters = $this->getRouteArguments($data, $operation, $request);
+        $parameters = $this->getRouteArguments($data, $operation);
 
         return $this->redirectToRoute($data, $route, $parameters);
     }
 
     public function redirectToRoute(mixed $data, string $route, array $parameters = []): RedirectResponse
     {
+        if (\str_ends_with($route, '_index')) {
+            $parameters = array_merge($parameters, $this->filterStorage?->all() ?? []);
+        }
+
         return new RedirectResponse($this->router->generate($route, $parameters));
     }
 
-    private function getRouteArguments(mixed $data, HttpOperation $operation, Request $request): array
+    private function getRouteArguments(mixed $data, HttpOperation $operation): array
     {
         $resource = $operation->getResource();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On Sylius, it uses grid filters on redirectToIndex action.
https://github.com/Sylius/Sylius/blob/fb47637cef02d7573553b84315e1899f77221699/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php#L35

The new routing system has a new RedirectHandler service, so we need to implement this feature again.

Test when redirecting the create product to update operation.
![image](https://github.com/user-attachments/assets/7fb2996c-eeb6-464a-9d59-4a4bb773bce7)
