### PR TITLE
Add condition option on legacy routing

### DIFF
--- a/src/Bundle/Routing/Configuration.php
+++ b/src/Bundle/Routing/Configuration.php
@@ -43,6 +43,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('templates')->cannotBeEmpty()->end()
                 ->scalarNode('grid')->cannotBeEmpty()->end()
                 ->booleanNode('permission')->defaultValue(false)->end()
+                ->scalarNode('condition')->cannotBeEmpty()->end()
                 ->arrayNode('except')
                     ->scalarPrototype()->end()
                 ->end()

--- a/src/Bundle/Routing/ResourceLoader.php
+++ b/src/Bundle/Routing/ResourceLoader.php
@@ -179,7 +179,9 @@ final class ResourceLoader extends Loader
             ];
         }
 
-        return $this->routeFactory->createRoute($path, $defaults, [], [], '', [], $methods);
+        $condition = $configuration['condition'] ?? '';
+
+        return $this->routeFactory->createRoute($path, $defaults, [], [], '', [], $methods, $condition);
     }
 
     private function getRouteName(MetadataInterface $metadata, array $configuration, string $actionName): string

--- a/src/Bundle/spec/Routing/ResourceLoaderSpec.php
+++ b/src/Bundle/spec/Routing/ResourceLoaderSpec.php
@@ -95,7 +95,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -107,7 +107,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -119,7 +119,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -131,7 +131,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -148,7 +148,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -160,7 +160,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -200,7 +200,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/product-options/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_option_show', $showRoute)->shouldBeCalled();
@@ -212,7 +212,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_option_index', $indexRoute)->shouldBeCalled();
@@ -224,7 +224,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_option_create', $createRoute)->shouldBeCalled();
@@ -236,7 +236,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/product-options/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_option_update', $updateRoute)->shouldBeCalled();
@@ -253,7 +253,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/product-options/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_option_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -265,7 +265,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/product-options/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_option_delete', $deleteRoute)->shouldBeCalled();
@@ -313,7 +313,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{code}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/product-options/{code}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_option_show', $showRoute)->shouldBeCalled();
@@ -329,7 +329,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_option_index', $indexRoute)->shouldBeCalled();
@@ -345,7 +345,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_option_create', $createRoute)->shouldBeCalled();
@@ -361,7 +361,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{code}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/product-options/{code}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_option_update', $updateRoute)->shouldBeCalled();
@@ -382,7 +382,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/product-options/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_option_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -398,7 +398,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/product-options/{code}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/product-options/{code}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_option_delete', $deleteRoute)->shouldBeCalled();
@@ -439,7 +439,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/super-duper-products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -451,7 +451,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/super-duper-products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -463,7 +463,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/super-duper-products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -475,7 +475,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/super-duper-products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -492,7 +492,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/super-duper-products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -504,7 +504,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/super-duper-products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/super-duper-products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -545,7 +545,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -557,7 +557,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -570,7 +570,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -583,7 +583,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -600,7 +600,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -612,7 +612,113 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
+            ->willReturn($deleteRoute)
+        ;
+        $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
+
+        $this->load($configuration, 'sylius.resource')->shouldReturn($routeCollection);
+    }
+
+    function it_generates_routing_with_condition_if_specified(
+        RegistryInterface $resourceRegistry,
+        MetadataInterface $metadata,
+        RouteFactoryInterface $routeFactory,
+        RouteCollection $routeCollection,
+        Route $showRoute,
+        Route $indexRoute,
+        Route $createRoute,
+        Route $updateRoute,
+        Route $bulkDeleteRoute,
+        Route $deleteRoute,
+    ): void {
+        $resourceRegistry->get('sylius.product')->willReturn($metadata);
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+        $metadata->getPluralName()->willReturn('products');
+        $metadata->getServiceId('controller')->willReturn('sylius.controller.product');
+
+        $routeFactory->createRouteCollection()->willReturn($routeCollection);
+
+        $configuration =
+            <<<EOT
+alias: sylius.product
+condition: context.getHost() == env("APP_MAIN_HOST")
+EOT;
+
+        $showDefaults = [
+            '_controller' => 'sylius.controller.product::showAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], 'context.getHost() == env("APP_MAIN_HOST")')
+            ->willReturn($showRoute)
+        ;
+        $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
+
+        $indexDefaults = [
+            '_controller' => 'sylius.controller.product::indexAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], 'context.getHost() == env("APP_MAIN_HOST")')
+            ->willReturn($indexRoute)
+        ;
+        $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
+
+        $createDefaults = [
+            '_controller' => 'sylius.controller.product::createAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], 'context.getHost() == env("APP_MAIN_HOST")')
+            ->willReturn($createRoute)
+        ;
+        $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
+
+        $updateDefaults = [
+            '_controller' => 'sylius.controller.product::updateAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], 'context.getHost() == env("APP_MAIN_HOST")')
+            ->willReturn($updateRoute)
+        ;
+        $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
+
+        $bulkDeleteDefaults = [
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
+            '_sylius' => [
+                'permission' => false,
+                'paginate' => false,
+                'repository' => [
+                    'method' => 'findById',
+                    'arguments' => ['$ids'],
+                ],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], 'context.getHost() == env("APP_MAIN_HOST")')
+            ->willReturn($bulkDeleteRoute)
+        ;
+        $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
+
+        $deleteDefaults = [
+            '_controller' => 'sylius.controller.product::deleteAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], 'context.getHost() == env("APP_MAIN_HOST")')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -654,7 +760,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_admin_product_show', $showRoute)->shouldBeCalled();
@@ -667,7 +773,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_admin_product_index', $indexRoute)->shouldBeCalled();
@@ -680,7 +786,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_admin_product_create', $createRoute)->shouldBeCalled();
@@ -693,7 +799,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_admin_product_update', $updateRoute)->shouldBeCalled();
@@ -711,7 +817,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_admin_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -724,7 +830,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_admin_product_delete', $deleteRoute)->shouldBeCalled();
@@ -766,7 +872,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -779,7 +885,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -792,7 +898,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -805,7 +911,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -822,7 +928,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -834,7 +940,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -876,7 +982,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -889,7 +995,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -902,7 +1008,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -915,7 +1021,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -932,7 +1038,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -944,7 +1050,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -982,7 +1088,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -994,7 +1100,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1006,7 +1112,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -1043,7 +1149,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1055,7 +1161,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1111,7 +1217,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -1123,7 +1229,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1136,7 +1242,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1149,7 +1255,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -1166,7 +1272,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -1178,7 +1284,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -1218,7 +1324,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -1231,7 +1337,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1244,7 +1350,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $createDefaults, [], [], '', [], ['POST'])
+            ->createRoute('/products/', $createDefaults, [], [], '', [], ['POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1257,7 +1363,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $updateDefaults, [], [], '', [], ['PUT', 'PATCH'])
+            ->createRoute('/products/{id}', $updateDefaults, [], [], '', [], ['PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -1270,7 +1376,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -1309,7 +1415,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1321,7 +1427,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1371,7 +1477,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -1386,7 +1492,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1402,7 +1508,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1418,7 +1524,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -1438,7 +1544,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -1453,7 +1559,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -1494,7 +1600,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($showRoute)
         ;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -1506,7 +1612,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])
+            ->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'], '')
             ->willReturn($indexRoute)
         ;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -1518,7 +1624,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
             ->willReturn($createRoute)
         ;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -1530,7 +1636,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'], '')
             ->willReturn($updateRoute)
         ;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -1547,7 +1653,7 @@ EOT;
             ],
         ];
         $routeFactory
-            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'])
+            ->createRoute('/products/bulk-delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE'], '')
             ->willReturn($bulkDeleteRoute)
         ;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
@@ -1558,7 +1664,7 @@ EOT;
                 'permission' => true,
             ],
         ];
-        $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+        $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
                      ->willReturn($deleteRoute)
         ;
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

To create a bc-layer for the legacy routes in Sylius E-commerce project, I need to add some route conditions to existing routes.

On simple route, I'm able to create this condition:
```yaml
sylius_admin_product_create_simple:
    path: /products/new/simple
    methods: [GET, POST]
    condition: "context.isSyliusRoutingBcLayerEnabled() || context.isSyliusRoutingBcLayerEnabled('admin_product')"
    # ...
```

But I also need to add this condition on multiple routing definition like this following one and that's the reason of this PR.

```yaml
sylius_admin_product:
    resource: |
        alias: sylius.product
        condition: "context.isSyliusRoutingBcLayerEnabled() || context.isSyliusRoutingBcLayerEnabled('admin_product')"
        # ...
    type: sylius.resource
```

To bring more context, here is the RequestContext we will implement on Sylius core to create the bc-layer
```php
namespace Sylius\Bundle\CoreBundle\Routing;

use Symfony\Component\Routing\RequestContext as BaseRequestContext;

final class RequestContext extends BaseRequestContext
{
    public function __construct(
        BaseRequestContext $decorated,
        private array $bcLayerConfig,
    ) {
        // ...
    }

    public function isSyliusRoutingBcLayerEnabled(?string $key = null): bool
    {
        if (null === $key) {
            return $this->bcLayerConfig['enabled'] ?? false;
        }

        return $this->bcLayerConfig['routes'][$key]['enabled'] ?? false;
    }
}
```
