### PR TITLE
Add error handling on write processor

### DIFF
--- a/src/Bundle/Resources/config/services/state/processor.xml
+++ b/src/Bundle/Resources/config/services/state/processor.xml
@@ -17,10 +17,11 @@
     </imports>
 
     <services>
+        <service id="sylius.state_processor.main" alias="sylius.state_processor.respond" />
+
         <service id="sylius.state_processor.respond" class="Sylius\Resource\State\Processor\RespondProcessor">
             <argument type="service" id="sylius.state_responder" />
         </service>
-        <service id="sylius.state_processor.main" alias="sylius.state_processor.respond" />
 
         <service id="sylius.state_processor.write" class="Sylius\Resource\State\Processor\WriteProcessor" decorates="sylius.state_processor.main" decoration-priority="100">
             <argument type="service" id=".inner" />

--- a/src/Component/spec/Symfony/Session/Flash/FlashHelperSpec.php
+++ b/src/Component/spec/Symfony/Session/Flash/FlashHelperSpec.php
@@ -41,6 +41,23 @@ final class FlashHelperSpec extends ObjectBehavior
         $this->shouldHaveType(FlashHelper::class);
     }
 
+    function it_adds_success_flashes_with_custom_message(
+        Request $request,
+        SessionInterface $session,
+        FlashBagInterface $flashBag,
+    ): void {
+        $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $request->getSession()->willReturn($session);
+
+        $session->getBag('flashes')->willReturn($flashBag);
+
+        $flashBag->add('success', 'Custom message.')->shouldBeCalled();
+
+        $this->addSuccessFlash($operation, $context, 'Custom message.');
+    }
+
     function it_adds_success_flashes_with_specific_message(
         Request $request,
         SessionInterface $session,
@@ -91,7 +108,7 @@ final class FlashHelperSpec extends ObjectBehavior
         $this->addSuccessFlash($operation, $context);
     }
 
-    function it_adds_success_flashes_with_custom_message(
+    function it_adds_success_flashes_with_custom_message_on_its_operation(
         Request $request,
         SessionInterface $session,
         FlashBagInterface $flashBag,
@@ -184,6 +201,73 @@ final class FlashHelperSpec extends ObjectBehavior
         $flashBag->add('success', 'Admin users was removed successfully.')->shouldBeCalled();
 
         $this->addSuccessFlash($operation, $context);
+    }
+
+    function it_adds_error_flashes_with_custom_message(
+        Request $request,
+        SessionInterface $session,
+        FlashBagInterface $flashBag,
+    ): void {
+        $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $request->getSession()->willReturn($session);
+
+        $session->getBag('flashes')->willReturn($flashBag);
+
+        $flashBag->add('error', 'Custom error message.')->shouldBeCalled();
+
+        $this->addErrorFlash($operation, $context, 'Custom error message.');
+    }
+
+    function it_adds_error_flashes_with_specific_message(
+        Request $request,
+        SessionInterface $session,
+        FlashBagInterface $flashBag,
+        TranslatorBagInterface $translator,
+        MessageCatalogueInterface $messageCatalogue,
+    ): void {
+        $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $request->getSession()->willReturn($session);
+
+        $session->getBag('flashes')->willReturn($flashBag);
+
+        $translator->getCatalogue()->willReturn($messageCatalogue);
+
+        $messageCatalogue->has('app.dummy.create_error', 'flashes')->willReturn(true)->shouldBeCalled();
+
+        $translator->trans('app.dummy.create_error', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Cannot create Dummy resource.')->shouldBeCalled();
+
+        $flashBag->add('error', 'Cannot create Dummy resource.')->shouldBeCalled();
+
+        $this->addErrorFlash($operation, $context);
+    }
+
+    function it_adds_error_flashes_with_fallback_message(
+        Request $request,
+        SessionInterface $session,
+        FlashBagInterface $flashBag,
+        TranslatorBagInterface $translator,
+        MessageCatalogueInterface $messageCatalogue,
+    ): void {
+        $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request->getWrappedObject()));
+
+        $request->getSession()->willReturn($session);
+
+        $session->getBag('flashes')->willReturn($flashBag);
+
+        $translator->getCatalogue()->willReturn($messageCatalogue);
+
+        $messageCatalogue->has('app.dummy.create_error', 'flashes')->willReturn(false)->shouldBeCalled();
+
+        $translator->trans('sylius.resource.create_error', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Cannot create Dummy resource.')->shouldBeCalled();
+
+        $flashBag->add('error', 'Cannot create Dummy resource.')->shouldBeCalled();
+
+        $this->addErrorFlash($operation, $context);
     }
 
     function it_translates_flashes_from_event_when_translator_is_not_a_bag(

--- a/src/Component/src/Doctrine/Common/State/RemoveProcessor.php
+++ b/src/Component/src/Doctrine/Common/State/RemoveProcessor.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Doctrine\Common\State;
 
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager as DoctrineObjectManager;
 use Sylius\Resource\Context\Context;
+use Sylius\Resource\Exception\DeleteResourceException;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Reflection\ClassInfoTrait;
 use Sylius\Resource\State\ProcessorInterface;
@@ -34,8 +36,12 @@ final class RemoveProcessor implements ProcessorInterface
             return null;
         }
 
-        $manager->remove($data);
-        $manager->flush();
+        try {
+            $manager->remove($data);
+            $manager->flush();
+        } catch (ForeignKeyConstraintViolationException) {
+            throw new DeleteResourceException();
+        }
 
         return null;
     }

--- a/src/Component/src/Exception/DeleteResourceException.php
+++ b/src/Component/src/Exception/DeleteResourceException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Exception;
+
+class DeleteResourceException extends WriteResourceException
+{
+    public function __construct(
+        ?string $resourceName = null,
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        if (empty($message)) {
+            $message = sprintf('Cannot delete, the %s is in use.', $resourceName ?? 'resource');
+        }
+
+        parent::__construct($resourceName, $message, $code, $previous);
+    }
+}

--- a/src/Component/src/Exception/WriteResourceException.php
+++ b/src/Component/src/Exception/WriteResourceException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Exception;
+
+class WriteResourceException extends RuntimeException
+{
+    public function __construct(
+        private readonly ?string $resourceName = null,
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getResourceName(): ?string
+    {
+        return $this->resourceName;
+    }
+}

--- a/src/Component/src/State/Processor/FlashProcessor.php
+++ b/src/Component/src/State/Processor/FlashProcessor.php
@@ -18,6 +18,7 @@ use Sylius\Resource\Context\Option\RequestOption;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\State\ProcessorInterface;
 use Sylius\Resource\Symfony\Session\Flash\FlashHelperInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -50,8 +51,19 @@ final class FlashProcessor implements ProcessorInterface
             return $this->processor->process($data, $operation, $context);
         }
 
-        $this->flashHelper->addSuccessFlash($operation, $context);
+        $this->addFlash($request, $operation, $context);
 
         return $this->processor->process($data, $operation, $context);
+    }
+
+    private function addFlash(Request $request, Operation $operation, Context $context): void
+    {
+        if ($request->attributes->has('error')) {
+            $this->flashHelper->addErrorFlash($operation, $context);
+
+            return;
+        }
+
+        $this->flashHelper->addSuccessFlash($operation, $context);
     }
 }

--- a/src/Component/src/State/Processor/WriteProcessor.php
+++ b/src/Component/src/State/Processor/WriteProcessor.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Resource\State\Processor;
 
 use Sylius\Resource\Context\Context;
+use Sylius\Resource\Context\Option\RequestOption;
+use Sylius\Resource\Exception\WriteResourceException;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\State\ProcessorInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,6 +41,13 @@ final class WriteProcessor implements ProcessorInterface
             return $this->processor->process($data, $operation, $context);
         }
 
-        return $this->processor->process($this->locatorProcessor->process($data, $operation, $context), $operation, $context);
+        try {
+            return $this->processor->process($this->locatorProcessor->process($data, $operation, $context), $operation, $context);
+        } catch (WriteResourceException $exception) {
+            $request = $context->get(RequestOption::class)?->request();
+            $request?->attributes->set('error', $exception->getMessage());
+
+            return $this->processor->process(null, $operation, $context);
+        }
     }
 }

--- a/src/Component/src/Symfony/Session/Flash/FlashHelper.php
+++ b/src/Component/src/Symfony/Session/Flash/FlashHelper.php
@@ -34,9 +34,14 @@ final class FlashHelper implements FlashHelperInterface
     ) {
     }
 
-    public function addSuccessFlash(Operation $operation, Context $context): void
+    public function addSuccessFlash(Operation $operation, Context $context, ?string $message = null): void
     {
-        $this->addFlashFromOperation($operation, $context, 'success');
+        $this->addFlashFromOperation($operation, $context, 'success', $message);
+    }
+
+    public function addErrorFlash(Operation $operation, Context $context, ?string $message = null): void
+    {
+        $this->addFlashFromOperation($operation, $context, 'error', $message);
     }
 
     public function addFlashFromEvent(GenericEvent $event, Context $context): void
@@ -46,9 +51,9 @@ final class FlashHelper implements FlashHelperInterface
         $this->addFlash($message, $event->getMessageType(), $context);
     }
 
-    private function addFlashFromOperation(Operation $operation, Context $context, string $type): void
+    private function addFlashFromOperation(Operation $operation, Context $context, string $type, ?string $message): void
     {
-        $message = $this->buildOperationMessage($operation, $type);
+        $message ??= $this->buildOperationMessage($operation, $type);
 
         $this->addFlash($message, $type, $context);
     }
@@ -74,8 +79,12 @@ final class FlashHelper implements FlashHelperInterface
         $resource = $operation->getResource();
         Assert::notNull($resource);
 
-        $key = $operation->getNotificationMessage() ?? sprintf('%s.%s.%s', $resource->getApplicationName() ?? '', $resource->getName() ?? '', $operation->getShortName() ?? '');
-        $fallbackKey = sprintf('sylius.resource.%s', $operation->getShortName() ?? '');
+        $keySuffix = 'error' === $type ? '_error' : '';
+
+        $key = 'success' === $type ? $operation->getNotificationMessage() : null;
+        $key ??= sprintf('%s.%s.%s', $resource->getApplicationName() ?? '', $resource->getName() ?? '', ($operation->getShortName() ?? '') . $keySuffix);
+
+        $fallbackKey = sprintf('sylius.resource.%s', ($operation->getShortName() ?? '') . $keySuffix);
 
         $parameters = $this->getTranslationParameters($operation);
 

--- a/src/Component/src/Symfony/Session/Flash/FlashHelper.php
+++ b/src/Component/src/Symfony/Session/Flash/FlashHelper.php
@@ -79,12 +79,10 @@ final class FlashHelper implements FlashHelperInterface
         $resource = $operation->getResource();
         Assert::notNull($resource);
 
-        $keySuffix = 'error' === $type ? '_error' : '';
-
+        $translationKeySuffix = sprintf('%s%s', $operation->getShortName() ?? '', 'error' === $type ? '_error' : '');
         $key = 'success' === $type ? $operation->getNotificationMessage() : null;
-        $key ??= sprintf('%s.%s.%s', $resource->getApplicationName() ?? '', $resource->getName() ?? '', ($operation->getShortName() ?? '') . $keySuffix);
-
-        $fallbackKey = sprintf('sylius.resource.%s', ($operation->getShortName() ?? '') . $keySuffix);
+        $key ??= sprintf('%s.%s.%s', $resource->getApplicationName() ?? '', $resource->getName() ?? '', $translationKeySuffix);
+        $fallbackKey = sprintf('sylius.resource.%s', $translationKeySuffix);
 
         $parameters = $this->getTranslationParameters($operation);
 

--- a/src/Component/src/Symfony/Session/Flash/FlashHelperInterface.php
+++ b/src/Component/src/Symfony/Session/Flash/FlashHelperInterface.php
@@ -22,7 +22,9 @@ use Sylius\Resource\Symfony\EventDispatcher\GenericEvent;
  */
 interface FlashHelperInterface
 {
-    public function addSuccessFlash(Operation $operation, Context $context): void;
+    public function addSuccessFlash(Operation $operation, Context $context, ?string $message = null): void;
+
+    public function addErrorFlash(Operation $operation, Context $context, ?string $message = null): void;
 
     public function addFlashFromEvent(GenericEvent $event, Context $context): void;
 }

--- a/src/Component/tests/State/Processor/FlashProcessorTest.php
+++ b/src/Component/tests/State/Processor/FlashProcessorTest.php
@@ -22,6 +22,7 @@ use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\State\Processor\FlashProcessor;
 use Sylius\Resource\State\ProcessorInterface;
 use Sylius\Resource\Symfony\Session\Flash\FlashHelperInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -47,11 +48,12 @@ final class FlashProcessorTest extends TestCase
     }
 
     /** @test */
-    public function it_adds_flash(): void
+    public function it_adds_success_flash(): void
     {
         $request = $this->prophesize(Request::class);
         $operation = $this->prophesize(HttpOperation::class);
 
+        $request->attributes = new ParameterBag();
         $request->getRequestFormat()->willReturn('html')->shouldBeCalled();
         $request->isMethodSafe()->willReturn(false)->shouldBeCalled();
 
@@ -62,6 +64,27 @@ final class FlashProcessorTest extends TestCase
         $this->decorated->process(['foo' => 'fighters'], $operation, $context)->willReturn(['foo' => 'fighters'])->shouldBeCalled();
 
         $this->flashHelper->addSuccessFlash($operation, $context)->shouldBeCalled();
+
+        $this->flashProcessor->process(['foo' => 'fighters'], $operation->reveal(), $context);
+    }
+
+    /** @test */
+    public function it_adds_error_flash(): void
+    {
+        $request = $this->prophesize(Request::class);
+        $operation = $this->prophesize(HttpOperation::class);
+
+        $request->attributes = new ParameterBag(['error' => 'Cannot delete, the resource is in use.']);
+        $request->getRequestFormat()->willReturn('html')->shouldBeCalled();
+        $request->isMethodSafe()->willReturn(false)->shouldBeCalled();
+
+        $operation->canWrite()->willReturn(null)->shouldBeCalled();
+
+        $context = new Context(new RequestOption($request->reveal()));
+
+        $this->decorated->process(['foo' => 'fighters'], $operation, $context)->willReturn(['foo' => 'fighters'])->shouldBeCalled();
+
+        $this->flashHelper->addErrorFlash($operation, $context)->shouldBeCalled();
 
         $this->flashProcessor->process(['foo' => 'fighters'], $operation->reveal(), $context);
     }

--- a/tests/Application/src/Shared/Infrastructure/Symfony/Messenger/MessengerCommandBus.php
+++ b/tests/Application/src/Shared/Infrastructure/Symfony/Messenger/MessengerCommandBus.php
@@ -34,9 +34,9 @@ final class MessengerCommandBus implements CommandBusInterface
             return $this->handle($command);
         } catch (HandlerFailedException $e) {
             /** @var array{0: \Throwable} $exceptions */
-            $exceptions = $e->getNestedExceptions();
+            $exceptions = $e->getWrappedExceptions();
 
-            throw $exceptions[0];
+            throw reset($exceptions);
         }
     }
 }

--- a/tests/Application/src/Shared/Infrastructure/Symfony/Messenger/MessengerQueryBus.php
+++ b/tests/Application/src/Shared/Infrastructure/Symfony/Messenger/MessengerQueryBus.php
@@ -34,9 +34,9 @@ final class MessengerQueryBus implements QueryBusInterface
             return $this->handle($query);
         } catch (HandlerFailedException $e) {
             /** @var array{0: \Throwable} $exceptions */
-            $exceptions = $e->getNestedExceptions();
+            $exceptions = $e->getWrappedExceptions();
 
-            throw $exceptions[0];
+            throw reset($exceptions);
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This will handle this part of the resource controller:
https://github.com/Sylius/SyliusResourceBundle/blob/1.14/src/Bundle/Controller/ResourceController.php#L356

It will fix that error on Sylius E-commerce:
![image](https://github.com/user-attachments/assets/3f9a9b0a-9afb-4f0b-ba82-6fe6862aa9c1)

To allow throwing exceptions on writing process, we should move the flash processing directly on the write processor.
It's easier to catch error and add the right flash message. Then writing failure will still call the respond processing.

**After**
![Capture d’écran du 2025-07-10 09-55-34](https://github.com/user-attachments/assets/3c0aed60-8ce7-4376-8ae7-c72fafe0a586)
