### PR TITLE
Align new route paths and add a bc layer to keep legacy paths

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -51,6 +51,9 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('sylius.resource_controller.authorization_checker.disabled')
                     ->cannotBeEmpty()
                 ->end()
+                ->booleanNode('routing_path_bc_layer')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -67,6 +67,7 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
 
         $container->setParameter('sylius.resource.mapping', $config['mapping']);
         $container->setParameter('sylius.resource.settings', $config['settings']);
+        $container->setParameter('sylius.routing_path_bc_layer', $config['routing_path_bc_layer']);
         $container->setAlias('sylius.resource_controller.authorization_checker', $config['authorization_checker']);
 
         $this->registerMetadataConfiguration($container, $config);

--- a/src/Bundle/Resources/config/services/routing.xml
+++ b/src/Bundle/Resources/config/services/routing.xml
@@ -25,6 +25,7 @@
                 <service class="Sylius\Bundle\ResourceBundle\Routing\RouteFactory" />
             </argument>
             <argument>%kernel.environment%</argument>
+            <argument>%sylius.routing_path_bc_layer%</argument>
             <tag name="routing.loader" />
             <deprecated package="sylius/resource" version="1.13">The "%service_id%" service is deprecated since sylius/resource-bundle 1.13 and will be removed in sylius/resource-bundle 2.0. Use "sylius.symfony.routing.loader.resource" instead.</deprecated>
         </service>

--- a/src/Bundle/Routing/ResourceLoader.php
+++ b/src/Bundle/Routing/ResourceLoader.php
@@ -27,14 +27,11 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class ResourceLoader extends Loader
 {
-    private RegistryInterface $resourceRegistry;
-
-    private RouteFactoryInterface $routeFactory;
-
     public function __construct(
-        RegistryInterface $resourceRegistry,
-        RouteFactoryInterface $routeFactory,
+        private RegistryInterface $resourceRegistry,
+        private RouteFactoryInterface $routeFactory,
         ?string $env = null,
+        private ?bool $routingPathBcLayer = null,
     ) {
         parent::__construct($env);
 
@@ -69,36 +66,55 @@ final class ResourceLoader extends Loader
         $metadata = $this->resourceRegistry->get($configuration['alias']);
         $routes = $this->routeFactory->createRouteCollection();
 
-        $rootPath = sprintf('/%s/', $configuration['path'] ?? Urlizer::urlize($metadata->getPluralName()));
+        $rootPath = sprintf('/%s', $configuration['path'] ?? Urlizer::urlize($metadata->getPluralName()));
         $identifier = sprintf('{%s}', $configuration['identifier']);
 
+        /** @var bool $bcLayerEnabled */
+        $bcLayerEnabled = $this->routingPathBcLayer ?? true;
+        $trailingSlash = $bcLayerEnabled ? '/' : '';
+
         if (in_array('index', $routesToGenerate, true)) {
-            $indexRoute = $this->createRoute($metadata, $configuration, $rootPath, 'index', ['GET'], $isApi);
+            $indexRoute = $this->createRoute($metadata, $configuration, $rootPath . $trailingSlash, 'index', ['GET'], $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'index'), $indexRoute);
         }
 
         if (in_array('create', $routesToGenerate, true)) {
-            $createRoute = $this->createRoute($metadata, $configuration, $isApi ? $rootPath : $rootPath . 'new', 'create', $isApi ? ['POST'] : ['GET', 'POST'], $isApi);
+            $createRoute = $this->createRoute($metadata, $configuration, $isApi ? $rootPath . $trailingSlash : $rootPath . '/new', 'create', $isApi ? ['POST'] : ['GET', 'POST'], $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'create'), $createRoute);
         }
 
         if (in_array('update', $routesToGenerate, true)) {
-            $updateRoute = $this->createRoute($metadata, $configuration, $isApi ? $rootPath . $identifier : $rootPath . $identifier . '/edit', 'update', $isApi ? ['PUT', 'PATCH'] : ['GET', 'PUT', 'PATCH'], $isApi);
+            $httpMethods = ['GET', 'PUT', 'PATCH'];
+            if (!$bcLayerEnabled) {
+                $httpMethods[] = 'POST';
+            }
+
+            $updateRoute = $this->createRoute($metadata, $configuration, $isApi ? $rootPath . '/' . $identifier : $rootPath . '/' . $identifier . '/edit', 'update', $isApi ? ['PUT', 'PATCH'] : $httpMethods, $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'update'), $updateRoute);
         }
 
         if (in_array('show', $routesToGenerate, true)) {
-            $showRoute = $this->createRoute($metadata, $configuration, $rootPath . $identifier, 'show', ['GET'], $isApi);
+            $showRoute = $this->createRoute($metadata, $configuration, $rootPath . '/' . $identifier, 'show', ['GET'], $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'show'), $showRoute);
         }
 
         if (!$isApi && in_array('bulkDelete', $routesToGenerate, true)) {
-            $bulkDeleteRoute = $this->createRoute($metadata, $configuration, $rootPath . 'bulk-delete', 'bulkDelete', ['DELETE'], $isApi);
+            $httpMethods = ['DELETE'];
+            if (!$bcLayerEnabled) {
+                $httpMethods[] = 'POST';
+            }
+
+            $bulkDeleteRoute = $this->createRoute($metadata, $configuration, $rootPath . '/' . ($bcLayerEnabled ? 'bulk-delete' : 'bulk_delete'), 'bulkDelete', $httpMethods, $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'bulk_delete'), $bulkDeleteRoute);
         }
 
         if (in_array('delete', $routesToGenerate, true)) {
-            $deleteRoute = $this->createRoute($metadata, $configuration, $rootPath . $identifier, 'delete', ['DELETE'], $isApi);
+            $httpMethods = ['DELETE'];
+            if (!$bcLayerEnabled) {
+                $httpMethods[] = 'POST';
+            }
+
+            $deleteRoute = $this->createRoute($metadata, $configuration, $isApi ? $rootPath . '/' . $identifier : $rootPath . '/' . $identifier . ($bcLayerEnabled ? '' : '/delete'), 'delete', $isApi ? ['DELETE'] : $httpMethods, $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'delete'), $deleteRoute);
         }
 

--- a/src/Bundle/spec/Routing/ResourceLoaderSpec.php
+++ b/src/Bundle/spec/Routing/ResourceLoaderSpec.php
@@ -168,6 +168,208 @@ EOT;
         $this->load($configuration, 'sylius.resource')->shouldReturn($routeCollection);
     }
 
+    function it_generates_new_routing_paths_if_bc_layer_is_disabled(
+        RegistryInterface $resourceRegistry,
+        MetadataInterface $metadata,
+        RouteFactoryInterface $routeFactory,
+        RouteCollection $routeCollection,
+        Route $showRoute,
+        Route $indexRoute,
+        Route $createRoute,
+        Route $updateRoute,
+        Route $bulkDeleteRoute,
+        Route $deleteRoute,
+    ): void {
+        $this->beConstructedWith($resourceRegistry, $routeFactory, null, false);
+
+        $resourceRegistry->get('sylius.product')->willReturn($metadata);
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+        $metadata->getPluralName()->willReturn('products');
+        $metadata->getServiceId('controller')->willReturn('sylius.controller.product');
+
+        $routeFactory->createRouteCollection()->willReturn($routeCollection);
+
+        $configuration =
+            <<<EOT
+alias: sylius.product
+EOT;
+
+        $showDefaults = [
+            '_controller' => 'sylius.controller.product::showAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
+            ->willReturn($showRoute)
+        ;
+        $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
+
+        $indexDefaults = [
+            '_controller' => 'sylius.controller.product::indexAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products', $indexDefaults, [], [], '', [], ['GET'], '')
+            ->willReturn($indexRoute)
+        ;
+        $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
+
+        $createDefaults = [
+            '_controller' => 'sylius.controller.product::createAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'], '')
+            ->willReturn($createRoute)
+        ;
+        $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
+
+        $updateDefaults = [
+            '_controller' => 'sylius.controller.product::updateAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH', 'POST'], '')
+            ->willReturn($updateRoute)
+        ;
+        $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
+
+        $bulkDeleteDefaults = [
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
+            '_sylius' => [
+                'permission' => false,
+                'paginate' => false,
+                'repository' => [
+                    'method' => 'findById',
+                    'arguments' => ['$ids'],
+                ],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/bulk_delete', $bulkDeleteDefaults, [], [], '', [], ['DELETE', 'POST'], '')
+            ->willReturn($bulkDeleteRoute)
+        ;
+        $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
+
+        $deleteDefaults = [
+            '_controller' => 'sylius.controller.product::deleteAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}/delete', $deleteDefaults, [], [], '', [], ['DELETE', 'POST'], '')
+            ->willReturn($deleteRoute)
+        ;
+        $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
+
+        $this->load($configuration, 'sylius.resource')->shouldReturn($routeCollection);
+    }
+
+    function it_generates_new_api_routing_paths_if_bc_layer_is_disabled(
+        RegistryInterface $resourceRegistry,
+        MetadataInterface $metadata,
+        RouteFactoryInterface $routeFactory,
+        RouteCollection $routeCollection,
+        Route $showRoute,
+        Route $indexRoute,
+        Route $createRoute,
+        Route $updateRoute,
+        Route $bulkDeleteRoute,
+        Route $deleteRoute,
+    ): void {
+        $this->beConstructedWith($resourceRegistry, $routeFactory, null, false);
+
+        $resourceRegistry->get('sylius.product')->willReturn($metadata);
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+        $metadata->getPluralName()->willReturn('products');
+        $metadata->getServiceId('controller')->willReturn('sylius.controller.product');
+
+        $routeFactory->createRouteCollection()->willReturn($routeCollection);
+
+        $configuration =
+            <<<EOT
+alias: sylius.product
+EOT;
+
+        $showDefaults = [
+            '_controller' => 'sylius.controller.product::showAction',
+            '_sylius' => [
+                'permission' => false,
+                'serialization_groups' => ['Default', 'Detailed'],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'], '')
+            ->willReturn($showRoute)
+        ;
+        $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
+
+        $indexDefaults = [
+            '_controller' => 'sylius.controller.product::indexAction',
+            '_sylius' => [
+                'permission' => false,
+                'serialization_groups' => ['Default'],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products', $indexDefaults, [], [], '', [], ['GET'], '')
+            ->willReturn($indexRoute)
+        ;
+        $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
+
+        $createDefaults = [
+            '_controller' => 'sylius.controller.product::createAction',
+            '_sylius' => [
+                'permission' => false,
+                'serialization_groups' => ['Default', 'Detailed'],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products', $createDefaults, [], [], '', [], ['POST'], '')
+            ->willReturn($createRoute)
+        ;
+        $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
+
+        $updateDefaults = [
+            '_controller' => 'sylius.controller.product::updateAction',
+            '_sylius' => [
+                'permission' => false,
+                'serialization_groups' => ['Default', 'Detailed'],
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $updateDefaults, [], [], '', [], ['PUT', 'PATCH'], '')
+            ->willReturn($updateRoute)
+        ;
+        $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
+
+        $deleteDefaults = [
+            '_controller' => 'sylius.controller.product::deleteAction',
+            '_sylius' => [
+                'permission' => false,
+                'csrf_protection' => false,
+            ],
+        ];
+        $routeFactory
+            ->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'], '')
+            ->willReturn($deleteRoute)
+        ;
+        $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
+
+        $this->load($configuration, 'sylius.resource_api')->shouldReturn($routeCollection);
+    }
+
     function it_generates_urlized_paths_for_resources_with_multiple_words_in_name(
         RegistryInterface $resourceRegistry,
         MetadataInterface $metadata,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

To allow both new and old routing systems working together, we defines new route conditions.

**on legacy routes**
```
sylius_admin_product:
    resource: |
        # ...
        condition: "context.isSyliusRoutingBcLayerEnabled('admin_product')"
    type: sylius.resource
```

**on new routes**

```php
return (new ResourceMetadata())
    >withClass('%sylius.model.product.class%')
    // ...
    ->withRouteCondition("not context.isSyliusRoutingBcLayerEnabled('admin_product')")
;
```

But to make that works, we need to have two different route names. Otherwise, there is only one Symfony route with the same condition. 

Here is an example of what we need:
- legacy one: `sylius_admin_product_index` (we keep the orginal name)
- new one: `_sylius_admin_product_index` (we prefix the name).

**bc-layer disabled**
![image](https://github.com/user-attachments/assets/b1dca027-fe04-4c8d-b675-6996733cc118)

**bc-layer enabled**
![image](https://github.com/user-attachments/assets/e469f043-0bc9-4e0e-a135-7a4e3811fc7b)

But we need the **both paths match exactly** (and http methods too).
That's the reason of that current PR.

**Bc-layer enabled**
<img width="840" height="129" alt="image" src="https://github.com/user-attachments/assets/0cba7f37-8a81-4a25-becf-b4f653e0a090" />

**Bc-layer disabled**
<img width="862" height="133" alt="image" src="https://github.com/user-attachments/assets/84639e9d-8d66-4d66-ad12-5e127e5f3aae" />

That seems to work on Sylius E-commerce. The two errors I have are solved in another PR.
<img width="1510" height="1206" alt="image" src="https://github.com/user-attachments/assets/6b066851-2bcf-46e3-8a9f-fe63b1305064" />
