### PR TITLE
fix:  class reflection was wrongly parsing docblocks

### DIFF
--- a/src/Component/legacy/tests/Dummy/DummyClassWithDocBlock.php
+++ b/src/Component/legacy/tests/Dummy/DummyClassWithDocBlock.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Tests\Dummy;
+
+/**
+ * This docblock for this class explains what to do.
+ */
+final class DummyClassWithDocBlock
+{
+}

--- a/src/Component/legacy/tests/Reflection/ClassReflectionTest.php
+++ b/src/Component/legacy/tests/Reflection/ClassReflectionTest.php
@@ -19,6 +19,7 @@ use App\Entity\Route\ShowBookWithPriority;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Resource\Tests\Dummy\DummyClassOne;
 use Sylius\Component\Resource\Tests\Dummy\DummyClassTwo;
+use Sylius\Component\Resource\Tests\Dummy\DummyClassWithDocBlock;
 use Sylius\Component\Resource\Tests\Dummy\TraitPass;
 use Sylius\Resource\Annotation\SyliusCrudRoutes;
 use Sylius\Resource\Annotation\SyliusRoute;
@@ -38,16 +39,25 @@ final class ClassReflectionTest extends TestCase
     /** @test */
     public function it_returns_resource_classes_from_a_directory(): void
     {
-        $resources = ClassReflection::getResourcesByPath(__DIR__ . '/../Dummy');
+        $resources = iterator_to_array(ClassReflection::getResourcesByPath(__DIR__ . '/../Dummy'));
 
         $this->assertContains(DummyClassOne::class, $resources);
         $this->assertContains(DummyClassTwo::class, $resources);
     }
 
     /** @test */
+    public function it_excludes_docblock_comments(): void
+    {
+        $resources = iterator_to_array(ClassReflection::getResourcesByPath(__DIR__ . '/../Dummy'));
+
+        $this->assertContains(DummyClassWithDocBlock::class, $resources);
+        $this->assertNotContains('This docblock for this class explains what to do', $resources);
+    }
+
+    /** @test */
     public function it_excludes_traits(): void
     {
-        $resources = ClassReflection::getResourcesByPath(__DIR__ . '/../Dummy');
+        $resources = iterator_to_array(ClassReflection::getResourcesByPath(__DIR__ . '/../Dummy'));
 
         $this->assertNotContains(TraitPass::class, $resources);
     }

--- a/src/Component/src/Reflection/ClassReflection.php
+++ b/src/Component/src/Reflection/ClassReflection.php
@@ -46,7 +46,7 @@ final class ClassReflection
 
             $namespace = $matches[1] ?? null;
 
-            if (!preg_match('/class\s+(\w+)/', $fileContent, $matches)) {
+            if (!preg_match('/^(?:\s*(?:final|abstract|readonly)\s+)*class\s+(\w+)/mi', $fileContent, $matches)) {
                 // no class found
                 continue;
             }


### PR DESCRIPTION
Attempt to fix https://github.com/Sylius/SyliusResourceBundle/issues/1011, following up on work already done here https://github.com/Sylius/SyliusResourceBundle/pull/1016

This prevents the issue of doc block comments containing the word class from mistakenly being parsed.
As mentioned in #1016 , this is only a quick fix, perhaps we could resort to https://github.com/nikic/PHP-Parser in the future instead? 

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | [fixes #1011](https://github.com/Sylius/SyliusResourceBundle/issues/1011), [following #1016](https://github.com/Sylius/SyliusResourceBundle/pull/1016)
| License         | MIT
