### PR TITLE
Use formtype if configured

### DIFF
--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -150,7 +150,7 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
                         'model' => $className,
                         'controller' => ResourceController::class,
                         'factory' => Factory::class,
-                        'form' => DefaultResourceType::class,
+                        'form' => $resourceMetadata->getFormType() ?? DefaultResourceType::class,
                     ],
                     'driver' => $resourceMetadata->getDriver() ?? SyliusResourceBundle::DRIVER_DOCTRINE_ORM,
                 ];

--- a/tests/Bundle/DependencyInjection/Dummy/BookFormType.php
+++ b/tests/Bundle/DependencyInjection/Dummy/BookFormType.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy;
 
-use Sylius\Resource\Metadata\AsResource;
+use Symfony\Component\Form\AbstractType;
 
-#[AsResource(alias: 'app.book', formType: BookFormType::class)]
-final class BookWithAliasResource
+final class BookFormType extends AbstractType
 {
 }

--- a/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
@@ -23,6 +23,7 @@ use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 use Sylius\Bundle\ResourceBundle\Doctrine\ResourceMappingDriverChain;
 use Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType;
+use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\BookFormType;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\BookWithAliasResource;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\DummyResource;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\NoDriverResource;
@@ -147,7 +148,7 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
                     'model' => BookWithAliasResource::class,
                     'controller' => ResourceController::class,
                     'factory' => Factory::class,
-                    'form' => DefaultResourceType::class,
+                    'form' => BookFormType::class,
                 ],
                 'driver' => 'doctrine/orm',
             ],


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

If formType is configured on resource, use that instead of DefaultResourceType