### PR TITLE
Recursive array argument handling on redirect parameters

### DIFF
--- a/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
+++ b/src/Component/spec/Symfony/Routing/RedirectHandlerSpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Resource\Symfony\Routing;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\GridBundle\Storage\FilterStorageInterface;
+use Sylius\Resource\Exception\InvalidArgumentException;
 use Sylius\Resource\Metadata\BulkUpdate;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Delete;
@@ -104,14 +105,30 @@ final class RedirectHandlerSpec extends ObjectBehavior
         FilterStorageInterface $filterStorage,
     ): void {
         $data->code = 'xyz';
-        $operation = new Create(redirectToRoute: 'app_dummy_index', redirectArguments: ['code' => 'resource.code']);
+        $operation = new Create(redirectToRoute: 'app_dummy_index', redirectArguments: ['code' => 'resource.code', 'criteria' => ['foo' => 'resource.code', 'bar' => 1]]);
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = $operation->withResource($resource);
 
         $filterStorage->all()->willReturn([]);
-        $router->generate('app_dummy_index', ['code' => 'xyz'])->willReturn('/dummies')->shouldBeCalled();
+        $router->generate('app_dummy_index', ['code' => 'xyz', 'criteria' => ['foo' => 'xyz', 'bar' => 1]])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
+    }
+
+    function it_throws_an_exception_when_trying_redirect_with_custom_arguments_that_are_not_scalar_ones(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+        FilterStorageInterface $filterStorage,
+    ): void {
+        $data->code = 'xyz';
+        $operation = new Create(redirectToRoute: 'app_dummy_index', redirectArguments: ['code' => 'resource.code', 'criteria' => ['foo' => 'resource.code', 'bar' => new \stdClass()]]);
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = $operation->withResource($resource);
+
+        $this->shouldThrow(
+            new InvalidArgumentException('Parameter "bar" should be a scalar or an array.'),
+        )->during('redirectToResource', [$data, $operation, $request]);
     }
 
     function it_redirects_to_resource_with_id_via_the_getter(
@@ -163,6 +180,23 @@ final class RedirectHandlerSpec extends ObjectBehavior
 
         $filterStorage->all()->willReturn(['criteria' => ['enabled' => true]]);
         $router->generate('app_dummy_index', ['criteria' => ['enabled' => true]])->willReturn('/dummies')->shouldBeCalled();
+
+        $this->redirectToResource($data, $operation, $request);
+    }
+
+    function it_does_not_use_grid_filters_when_redirect_parameters_are_defined_on_the_operation(
+        \stdClass $data,
+        Request $request,
+        RouterInterface $router,
+        FilterStorageInterface $filterStorage,
+    ): void {
+        $data->id = 'xyz';
+        $operation = new Delete(redirectToRoute: 'app_dummy_index', redirectArguments: ['criteria' => ['archival' => true]]);
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = $operation->withResource($resource);
+
+        $filterStorage->all()->willReturn(['criteria' => ['enabled' => true]]);
+        $router->generate('app_dummy_index', ['criteria' => ['archival' => true]])->willReturn('/dummies')->shouldBeCalled();
 
         $this->redirectToResource($data, $operation, $request);
     }

--- a/src/Component/src/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/src/Symfony/Routing/RedirectHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing;
 
 use Sylius\Bundle\GridBundle\Storage\FilterStorageInterface;
+use Sylius\Resource\Exception\InvalidArgumentException;
 use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
@@ -62,8 +63,8 @@ final class RedirectHandler implements RedirectHandlerInterface
 
     public function redirectToRoute(mixed $data, string $route, array $parameters = []): RedirectResponse
     {
-        if (\str_ends_with($route, '_index')) {
-            $parameters = array_merge($parameters, $this->filterStorage?->all() ?? []);
+        if (\str_ends_with($route, '_index') && [] === $parameters) {
+            $parameters = $this->filterStorage?->all() ?? [];
         }
 
         return new RedirectResponse($this->router->generate($route, $parameters));
@@ -97,7 +98,17 @@ final class RedirectHandler implements RedirectHandlerInterface
         $accessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($parameters as $key => $value) {
-            if (str_contains($value, 'resource.')) {
+            if (\is_array($value)) {
+                $parameters[$key] = $this->parseResourceValues($resource, $value, $data);
+
+                continue;
+            }
+
+            if (!\is_scalar($value)) {
+                throw new InvalidArgumentException(sprintf('Parameter "%s" should be a scalar or an array.', $key));
+            }
+
+            if (\is_string($value) && str_contains($value, 'resource.')) {
                 $propertyPath = substr($value, 9);
 
                 if (\is_object($data) && $accessor->isReadable($data, $propertyPath)) {
@@ -114,7 +125,8 @@ final class RedirectHandler implements RedirectHandlerInterface
                 $variables[$resourceName] = $data;
             }
 
-            $parameters[$key] = $this->argumentParser->parseExpression($value, $variables);
+            // TODO, the best way to detect if we need to parse an expression will need to add "@=" syntax.
+            $parameters[$key] = \is_string($value) ? $this->argumentParser->parseExpression($value, $variables) : $value;
         }
 
         return $parameters;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I'd like to be able to configure those redirect arguments:
```php
new Update(
    methods: ['PATCH', 'POST'],
    routeName: '_sylius_admin_promotion_archive',
    shortName: 'archive',
    formType: ArchivableType::class,
    notificationMessage: 'sylius.resource.update',
    redirectToRoute: 'sylius_admin_promotion_index',
    redirectArguments: [
        'criteria' => [
            'archival' => 0,
        ],
    ],
)
```

for that Sylius feature:
```gherkin
@api @ui
Scenario: Restoring an archival promotion
    Given the promotion "Christmas sale" is archived
    When I browse promotions
    And I filter archival promotions
    And I restore the "Christmas sale" promotion
    Then I should be viewing non archival promotions
    And I should see 2 promotions on the list
```