### PR TITLE
Add an error message for non existing repository method & suggest to use CreatePaginatorTrait

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -40,6 +40,7 @@
                 <referencedFunction name="ReflectionClass::getAttributes" />
                 <file name="src/Bundle/Form/DataTransformer/CollectionToStringTransformer.php" />
                 <file name="src/Component/src/Doctrine/Persistence/InMemoryRepository.php" />
+                <file name="src/Component/src/Symfony/Request/State/Provider.php" />
             </errorLevel>
         </ArgumentTypeCoercion>
 

--- a/src/Bundle/Doctrine/ORM/CreatePaginatorTrait.php
+++ b/src/Bundle/Doctrine/ORM/CreatePaginatorTrait.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Doctrine\ORM;
+
+use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Pagerfanta\PagerfantaInterface;
+use Sylius\Resource\Model\ResourceInterface;
+
+/**
+ * @mixin DoctrineEntityRepository
+ */
+trait CreatePaginatorTrait
+{
+    /**
+     * @return iterable<int, ResourceInterface>
+     */
+    public function createPaginator(array $criteria = [], array $sorting = []): iterable
+    {
+        $queryBuilder = $this->createQueryBuilder('o');
+
+        $this->applyCriteria($queryBuilder, $criteria);
+        $this->applySorting($queryBuilder, $sorting);
+
+        return $this->getPaginator($queryBuilder);
+    }
+
+    protected function getPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
+    {
+        if (!class_exists(QueryAdapter::class)) {
+            throw new \LogicException('You can not use the "paginator" if Pargefanta Doctrine ORM Adapter is not available. Try running "composer require pagerfanta/doctrine-orm-adapter".');
+        }
+
+        // Use output walkers option in the query adapter should be false as it affects performance greatly (see sylius/sylius#3775)
+        return new Pagerfanta(new QueryAdapter($queryBuilder, false, false));
+    }
+
+    /**
+     * @param array $objects
+     */
+    protected function getArrayPaginator($objects): PagerfantaInterface
+    {
+        return new Pagerfanta(new ArrayAdapter($objects));
+    }
+
+    protected function applyCriteria(QueryBuilder $queryBuilder, array $criteria = []): void
+    {
+        foreach ($criteria as $property => $value) {
+            if (!in_array($property, array_merge($this->getClassMetadata()->getAssociationNames(), $this->getClassMetadata()->getFieldNames()), true)) {
+                continue;
+            }
+
+            $name = $this->getPropertyName($property);
+
+            if (null === $value) {
+                $queryBuilder->andWhere($queryBuilder->expr()->isNull($name));
+            } elseif (is_array($value)) {
+                $queryBuilder->andWhere($queryBuilder->expr()->in($name, $value));
+            } elseif ('' !== $value) {
+                $parameter = str_replace('.', '_', $property);
+                $queryBuilder
+                    ->andWhere($queryBuilder->expr()->eq($name, ':' . $parameter))
+                    ->setParameter($parameter, $value)
+                ;
+            }
+        }
+    }
+
+    protected function applySorting(QueryBuilder $queryBuilder, array $sorting = []): void
+    {
+        foreach ($sorting as $property => $order) {
+            if (!in_array($property, array_merge($this->getClassMetadata()->getAssociationNames(), $this->getClassMetadata()->getFieldNames()), true)) {
+                continue;
+            }
+
+            if (!empty($order)) {
+                $queryBuilder->addOrderBy($this->getPropertyName($property), $order);
+            }
+        }
+    }
+
+    protected function getPropertyName(string $name): string
+    {
+        if (!str_contains($name, '.')) {
+            return 'o' . '.' . $name;
+        }
+
+        return $name;
+    }
+}

--- a/src/Bundle/Doctrine/ORM/ResourceRepositoryTrait.php
+++ b/src/Bundle/Doctrine/ORM/ResourceRepositoryTrait.php
@@ -13,23 +13,16 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Doctrine\ORM;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\QueryBuilder;
-use Pagerfanta\Adapter\ArrayAdapter;
-use Pagerfanta\Doctrine\ORM\QueryAdapter;
-use Pagerfanta\Pagerfanta;
+use Doctrine\ORM\EntityRepository as DoctrineEntityRepository;
 use Sylius\Resource\Model\ResourceInterface;
 
 /**
- * @property EntityManagerInterface $_em
- * @property ClassMetadata          $_class
- *
- * @method QueryBuilder createQueryBuilder(string $alias, string $indexBy = null)
- * @method ?object      find($id, $lockMode = null, $lockVersion = null)
+ * @mixin DoctrineEntityRepository
  */
 trait ResourceRepositoryTrait
 {
+    use CreatePaginatorTrait;
+
     public function add(ResourceInterface $resource): void
     {
         $this->getEntityManager()->persist($resource);
@@ -42,81 +35,5 @@ trait ResourceRepositoryTrait
             $this->getEntityManager()->remove($resource);
             $this->getEntityManager()->flush();
         }
-    }
-
-    /**
-     * @return iterable<int, ResourceInterface>
-     */
-    public function createPaginator(array $criteria = [], array $sorting = []): iterable
-    {
-        $queryBuilder = $this->createQueryBuilder('o');
-
-        $this->applyCriteria($queryBuilder, $criteria);
-        $this->applySorting($queryBuilder, $sorting);
-
-        return $this->getPaginator($queryBuilder);
-    }
-
-    protected function getPaginator(QueryBuilder $queryBuilder): Pagerfanta
-    {
-        if (!class_exists(QueryAdapter::class)) {
-            throw new \LogicException('You can not use the "paginator" if Pargefanta Doctrine ORM Adapter is not available. Try running "composer require pagerfanta/doctrine-orm-adapter".');
-        }
-
-        // Use output walkers option in the query adapter should be false as it affects performance greatly (see sylius/sylius#3775)
-        return new Pagerfanta(new QueryAdapter($queryBuilder, false, false));
-    }
-
-    /**
-     * @param array $objects
-     */
-    protected function getArrayPaginator($objects): Pagerfanta
-    {
-        return new Pagerfanta(new ArrayAdapter($objects));
-    }
-
-    protected function applyCriteria(QueryBuilder $queryBuilder, array $criteria = []): void
-    {
-        foreach ($criteria as $property => $value) {
-            if (!in_array($property, array_merge($this->getClassMetadata()->getAssociationNames(), $this->getClassMetadata()->getFieldNames()), true)) {
-                continue;
-            }
-
-            $name = $this->getPropertyName($property);
-
-            if (null === $value) {
-                $queryBuilder->andWhere($queryBuilder->expr()->isNull($name));
-            } elseif (is_array($value)) {
-                $queryBuilder->andWhere($queryBuilder->expr()->in($name, $value));
-            } elseif ('' !== $value) {
-                $parameter = str_replace('.', '_', $property);
-                $queryBuilder
-                    ->andWhere($queryBuilder->expr()->eq($name, ':' . $parameter))
-                    ->setParameter($parameter, $value)
-                ;
-            }
-        }
-    }
-
-    protected function applySorting(QueryBuilder $queryBuilder, array $sorting = []): void
-    {
-        foreach ($sorting as $property => $order) {
-            if (!in_array($property, array_merge($this->getClassMetadata()->getAssociationNames(), $this->getClassMetadata()->getFieldNames()), true)) {
-                continue;
-            }
-
-            if (!empty($order)) {
-                $queryBuilder->addOrderBy($this->getPropertyName($property), $order);
-            }
-        }
-    }
-
-    protected function getPropertyName(string $name): string
-    {
-        if (false === strpos($name, '.')) {
-            return 'o' . '.' . $name;
-        }
-
-        return $name;
     }
 }

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -69,7 +69,7 @@
         <service id="Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType" alias="sylius.form.type.default" />
 
         <service id="sylius.registry.resource_repository" class="Sylius\Component\Registry\ServiceRegistry" public="false">
-            <argument>Sylius\Component\Resource\Repository\RepositoryInterface</argument>
+            <argument>Doctrine\Persistence\ObjectRepository</argument>
             <argument>resource repository</argument>
         </service>
         <service id="sylius.registry.form_builder" class="Sylius\Component\Registry\ServiceRegistry" public="false">

--- a/src/Component/spec/Symfony/Request/State/ProviderSpec.php
+++ b/src/Component/spec/Symfony/Request/State/ProviderSpec.php
@@ -16,10 +16,12 @@ namespace spec\Sylius\Resource\Symfony\Request\State;
 use Pagerfanta\Pagerfanta;
 use PhpSpec\ObjectBehavior;
 use Psr\Container\ContainerInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\CreatePaginatorTrait;
 use Sylius\Component\Resource\Tests\Dummy\RepositoryWithCallables;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Sylius\Resource\Exception\RuntimeException;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
@@ -171,5 +173,39 @@ final class ProviderSpec extends ObjectBehavior
 
         $response = $this->provide($operation, new Context(new RequestOption($request->getWrappedObject())));
         $response->shouldReturn($stdClass);
+    }
+
+    function it_throws_an_exception_when_repository_method_does_not_exist(
+        Operation $operation,
+        Request $request,
+        ContainerInterface $locator,
+    ): void {
+        $operation->getRepository()->willReturn('App\Repository');
+        $operation->getRepositoryMethod()->willReturn('notFoundMethod');
+        $operation->getRepositoryArguments()->willReturn(['id' => "request.attributes.get('id')"]);
+
+        $locator->has('App\Repository')->willReturn(true);
+        $locator->get('App\Repository')->willReturn(new \stdClass());
+
+        $errorMessage = sprintf('Method "notFoundMethod" not found on repository "%s". You can either add it or configure another one in the repositoryMethod option for your operation.', \stdClass::class);
+
+        $this->shouldThrow(new RuntimeException($errorMessage))->during('provide', [$operation, new Context(new RequestOption($request->getWrappedObject()))]);
+    }
+
+    function it_throws_an_exception_when_repository_method_does_not_exist_and_suggest_to_use_create_paginator_if_it_is_appropriated(
+        Operation $operation,
+        Request $request,
+        ContainerInterface $locator,
+    ): void {
+        $operation->getRepository()->willReturn('App\Repository');
+        $operation->getRepositoryMethod()->willReturn('createPaginator');
+        $operation->getRepositoryArguments()->willReturn(['id' => "request.attributes.get('id')"]);
+
+        $locator->has('App\Repository')->willReturn(true);
+        $locator->get('App\Repository')->willReturn(new \stdClass());
+
+        $errorMessage = sprintf('Method "createPaginator" not found on repository "%s". You can use the "%s" trait on this repository class.', \stdClass::class, CreatePaginatorTrait::class);
+
+        $this->shouldThrow(new RuntimeException($errorMessage))->during('provide', [$operation, new Context(new RequestOption($request->getWrappedObject()))]);
     }
 }

--- a/src/Component/src/Symfony/Request/State/Provider.php
+++ b/src/Component/src/Symfony/Request/State/Provider.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Symfony\Request\State;
 
-use Pagerfanta\Pagerfanta;
+use Pagerfanta\PagerfantaInterface;
 use Psr\Container\ContainerInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\CreatePaginatorTrait;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
+use Sylius\Resource\Exception\RuntimeException;
 use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Resource\Metadata\Operation;
@@ -59,13 +61,27 @@ final class Provider implements ProviderInterface
                 $defaultMethod = 'findById';
             }
 
-            $method = $operation->getRepositoryMethod() ?? $defaultMethod;
+            $customMethod = $operation->getRepositoryMethod();
+            $method = $customMethod ?? $defaultMethod;
 
             if (!$this->locator->has($repository)) {
-                throw new \RuntimeException(sprintf('Repository "%s" not found on operation "%s"', $repository, $operation->getName() ?? ''));
+                throw new RuntimeException(sprintf('Repository "%s" not found on operation "%s".', $repository, $operation->getName() ?? ''));
             }
 
+            /** @var object $repositoryInstance */
             $repositoryInstance = $this->locator->get($repository);
+
+            if (
+                !str_starts_with($method, 'find') &&  // to allow magic calls on Doctrine repository methods
+                !\method_exists($repositoryInstance, $method)) {
+                $errorMessage = sprintf('Method "%s" not found on repository "%s". You can either add it or configure another one in the repositoryMethod option for your operation.', $method, get_debug_type($repositoryInstance));
+
+                if ('createPaginator' === $method) {
+                    $errorMessage = sprintf('Method "%s" not found on repository "%s". You can use the "%s" trait on this repository class.', $method, get_debug_type($repositoryInstance), CreatePaginatorTrait::class);
+                }
+
+                throw new RuntimeException($errorMessage);
+            }
 
             // make it as callable
             /** @var callable $repository */
@@ -91,7 +107,7 @@ final class Provider implements ProviderInterface
 
         $data = $repository(...$arguments);
 
-        if ($data instanceof Pagerfanta) {
+        if ($data instanceof PagerfantaInterface) {
             $currentPage = $request->query->getInt('page', 1);
             $data->setCurrentPage($currentPage);
         }

--- a/tests/Application/src/Subscription/Entity/Subscription.php
+++ b/tests/Application/src/Subscription/Entity/Subscription.php
@@ -37,6 +37,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     routePrefix: '/admin',
 )]
 #[Index(grid: 'app_subscription')]
+#[Index(shortName: 'withoutGrid', template: 'crud/index.html.twig')]
 #[Create]
 #[Update]
 #[Delete]
@@ -66,7 +67,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[Api\Delete]
 #[Api\Get]
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: SubscriptionRepository::class)]
 class Subscription implements ResourceInterface
 {
     #[ORM\Column(type: 'string')]

--- a/tests/Application/src/Subscription/Entity/SubscriptionRepository.php
+++ b/tests/Application/src/Subscription/Entity/SubscriptionRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Subscription\Entity;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\CreatePaginatorTrait;
+
+final class SubscriptionRepository extends ServiceEntityRepository
+{
+    use CreatePaginatorTrait;
+
+    public function __construct(
+        public readonly ManagerRegistry $registry,
+    ) {
+        parent::__construct($this->registry, Subscription::class);
+    }
+}

--- a/tests/Application/templates/crud/index.html.twig
+++ b/tests/Application/templates/crud/index.html.twig
@@ -4,7 +4,7 @@
     <h1>{{ (operation.resource.applicationName ~ '.ui.' ~ operation.resource.pluralName)|trans }}</h1>
 
     {% set grid = resources %}
-    {% set definition = grid.definition %}
+    {% set definition = grid.definition|default(null) %}
 
     {% if definition.actionGroups.bulk is defined and definition.getEnabledActions('bulk')|length > 0 %}
         {% for action in definition.getEnabledActions('bulk') %}
@@ -12,33 +12,39 @@
         {% endfor %}
     {% endif %}
 
-    <table>
-        <thead>
-        <tr>
-            {% for field in definition.fields %}
-                {% if field.enabled %}
-                    <th class="sylius-table-column-{{ field.name }}">{{ field.label|trans }}</th>
-                {% endif %}
-                {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
-                    <th class="sylius-table-column-actions">Actions</th>
-                {% endif %}
-            {% endfor %}
-        </tr>
-        </thead>
-        <tbody>
-        {% for resource in resources.data %}
+    {% if not definition %}
+        This template doesn't support non-grid data.
+    {% endif %}
+
+    {% if definition %}
+        <table>
+            <thead>
             <tr>
-                {% for field in definition.enabledFields %}
-                    <td>{{ sylius_grid_render_field(grid, field, resource) }}</td>
-                    <td>
-                        {% for action in definition.getEnabledActions('item') %}
-                            {{ sylius_grid_render_action(grid, action, resource) }}
-                        {% endfor %}
-                    </td>
+                {% for field in definition.fields %}
+                    {% if field.enabled %}
+                        <th class="sylius-table-column-{{ field.name }}">{{ field.label|trans }}</th>
+                    {% endif %}
+                    {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
+                        <th class="sylius-table-column-actions">Actions</th>
+                    {% endif %}
                 {% endfor %}
             </tr>
-        {% endfor %}
-        </tbody>
+            </thead>
+            <tbody>
+            {% for resource in resources.data %}
+                <tr>
+                    {% for field in definition.enabledFields %}
+                        <td>{{ sylius_grid_render_field(grid, field, resource) }}</td>
+                        <td>
+                            {% for action in definition.getEnabledActions('item') %}
+                                {{ sylius_grid_render_action(grid, action, resource) }}
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+            </tbody>
 
-    </table>
+        </table>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (better error message)
| New feature?    |
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When using the "make:entity", a repository is created automatically, and normally it can be used directly with the new routing system without implementing the Sylius repository interface.
But here, in a collection operation, we define this createPaginator by default.

So here, first, the idea is to be more precise on what's happening when the default method and suggest using CreatePaginatorTrait.

That's another point, but we should also warn (or just fix it) about a non-grid object on the BootstrapAdminUi grid template.

Before
<img width="1067" height="482" alt="image" src="https://github.com/user-attachments/assets/fc0c2dbf-2ad9-4d87-a517-ba1d91ecb5e1" />

After
<img width="1067" height="482" alt="image" src="https://github.com/user-attachments/assets/0dbff1ef-d1d2-411b-8f7a-ef1a132481f1" />
