### PR TITLE
Resource discovery: ignore comments/strings when detecting classes

### DIFF
--- a/src/Component/src/Reflection/ClassReflection.php
+++ b/src/Component/src/Reflection/ClassReflection.php
@@ -42,11 +42,19 @@ final class ClassReflection
                 throw new \RuntimeException(sprintf('Unable to read "%s" file', $file->getRealPath()));
             }
 
-            preg_match('/namespace (.+);/', $fileContent, $matches);
+            $cleanFileContent = '';
+            foreach (\PhpToken::tokenize($fileContent) as $t) {
+                if (\in_array($t->id, [T_COMMENT, T_DOC_COMMENT, T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING], true)) {
+                    continue;
+                }
+                $cleanFileContent .= $t->text;
+            }
+
+            preg_match('/namespace (.+);/', $cleanFileContent, $matches);
 
             $namespace = $matches[1] ?? null;
 
-            if (!preg_match('/class\s+(\w+)/', $fileContent, $matches)) {
+            if (!preg_match('/class\s+(\w+)/', $cleanFileContent, $matches)) {
                 // no class found
                 continue;
             }


### PR DESCRIPTION
The class scanner used a simple `/class\s+(\w+)/` regex on raw file contents. When the word "class" appeared in comments or strings (e.g. "grid class you have generated"), the regex captured "you" as a class name, leading to errors such as: "App\Entity\you"

This fixes the issue encountered when following the Sylius Stack documentation (Basic Operations cookbook): https://stack.sylius.com/cookbook/admin_panel/basic_operations

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT
