### PR TITLE
[Routing] Using Symfony string for routing path instead of Gedmo urlizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,29 @@ on:
 jobs:
     tests:
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ORM ${{ matrix.orm }}"
+        name: >
+            PHP ${{ matrix.php }},
+            Symfony ${{ matrix.symfony }},
+            ORM ${{ matrix.orm }}
+            ${{ matrix['behat-transliterator'] != '' && matrix['gedmo-doctrine-extensions'] != ''
+                && format('(with Behat transliterator {0} & Gedmo {1})', matrix['behat-transliterator'], matrix['gedmo-doctrine-extensions'])
+                || '' }}
         strategy:
             fail-fast: false
             matrix:
                 orm: ['2.*', '3.*']
                 php: ["8.2", "8.3"]
+                behat-transliterator: [""]
                 composer-flags: ['--no-scripts --prefer-stable --prefer-dist']
+                gedmo-doctrine-extensions: [""]
                 symfony: ["6.4.*", "7.4.*"]
+                include:
+                    # with Behat transliterator and Gedmo Doctrine extensions optional packages
+                    -   behat-transliterator: '^1.2'
+                        gedmo-doctrine-extensions: '^3.17.1'
+                        php: "8.3"
+                        orm: "3.*"
+                        symfony: "7.4.*"
 
         steps:
             -
@@ -58,10 +73,22 @@ jobs:
                 run: composer remove --dev willdurand/hateoas-bundle --no-update --no-scripts
 
             -
-              name: Install MongoDB ODM package
-              run: |
-                composer require --dev doctrine/mongodb-odm-bundle "^5.0" --no-update --no-scripts
-                (cd src/Component && composer require --dev doctrine/mongodb-odm "^2.8" --no-update --no-scripts)
+                name: Install Behat transliterator
+                if: matrix.behat-transliterator != ''
+                run: |
+                    composer require --dev behat/transliterator "${{ matrix.behat-transliterator }}" --no-update --no-scripts
+
+            -
+                name: Install Gedmo Doctrine Extension
+                if: matrix.gedmo-doctrine-extensions != ''
+                run: |
+                    composer require --dev gedmo/doctrine-extensions "${{ matrix.gedmo-doctrine-extensions }}" --no-update --no-scripts
+
+            -
+                name: Install MongoDB ODM package
+                run: |
+                    composer require --dev doctrine/mongodb-odm-bundle "^5.0" --no-update --no-scripts
+                    (cd src/Component && composer require --dev doctrine/mongodb-odm "^2.8" --no-update --no-scripts)
 
             -
                 name: Install dependencies
@@ -148,7 +175,7 @@ jobs:
                     composer remove --dev winzou/state-machine-bundle --no-scripts
                     (cd tests/Application && bin/console cache:clear --env=test_without_state_machine)
                     (cd tests/Application && bin/console lint:container --env=test_without_state_machine)
-                    composer require winzou/state-machine-bundle --no-scripts
+                    composer require --dev winzou/state-machine-bundle --no-scripts
 
             -
                 name: Run lint container without sylius/grid-bundle package

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,20 +2,83 @@
 
 ### FROM `1.13.x` to `1.14.x`
 
+#### Minimal Requirements
+
 The minimum required PHP version is now 8.2.
+
+#### Routing Path
+
+Routing paths may have been changed depending on your configuration.
+
+| behat/transliterator | Routing Path BC-layer | Routing paths |
+|----------------------|-----------------------|---------------|
+| ✅ Installed          | ✅ Enabled by default  | ✅ Unchanged   |
+| ❌ Not installed      | ❌ Disabled by default | ❌ Changed     |
+
+If you want to keep the previous paths, please follow these following steps:
+
+1/ Make sure to have Behat transliterator installed.
+
+```shell
+composer require behat/transliterator
+```
+
+2/ Ensure routing path bc-layer is enabled
+
+```yaml
+# config/packages/
+sylius_resource:
+    routing_path_bc_layer: true
+```
+
+When using the `ResourceController` for your routes and when the routing bath bc layer is enabled, the routing path
+contains a trailing slash by default. In 2.x, it will be removed.
+You can disable the bc-layer to remove these trailing slashes on all your routes and be prepared for 2.x area.
+
+If you are using the new Routing system with `AsResource` attribute and operations, this change has no effect, there is
+no trailing slash in both configuration.
+
+```yaml
+# config/packages/
+sylius_resource:
+    routing_path_bc_layer: false
+```
+
+| Routing system               | Routing Path BC-layer | Trailing slash |
+|------------------------------|-----------------------|----------------|
+| Using the ResourceController | ✅ Enabled             | ✅              |
+| Using the ResourceController | ❌ Disabled            | ❌              |
+| Using AsResource attribute   | ✅ Enabled             | ❌              |
+| Using AsResource attribute   | ❌ Disabled            | ❌              |
+
+The routing path uses dashes to separate words by default. Eg: `/shipping-categories`.
+On the new routing system only, you can use configure the bundle to use underscores instead. Eg: `/shipping_categories`
+
+```yaml
+# config/packages/
+sylius_resource:
+    path_segment_name_generator: sylius.metadata.path_segment_name_generator.underscore
+```
+
+Note that even if this is configurable, it's recommended to use dashes to separate the words for SEO.
+
+*Source:*
+* https://developers.google.com/search/docs/crawling-indexing/url-structure
 
 ## UPGRADE FOR `1.13.x`
 
 ### FROM `1.12.x` to `1.13.x`
 
-The `Sylius\Resource\Exception\VariantWithNoOptionsValuesException` and `Sylius\Component\Resource\Exception\VariantWithNoOptionsValuesException` 
+The `Sylius\Resource\Exception\VariantWithNoOptionsValuesException` and
+`Sylius\Component\Resource\Exception\VariantWithNoOptionsValuesException`
 classes have been deprecated and will be removed in `2.0`.
 
 ## UPGRADE FOR `1.12.x`
 
 ### FROM `1.11.x` to `1.12.x`
 
-In preparation of removal, following dependencies were moved to optional requirements. If still in use by your app, require them explicitly in your `composer.json`.
+In preparation of removal, following dependencies were moved to optional requirements. If still in use by your app,
+require them explicitly in your `composer.json`.
 
 * friendsofsymfony/rest-bundle
 * jms/serializer-bundle
@@ -26,14 +89,15 @@ In preparation of removal, following dependencies were moved to optional require
 
 ### FROM `1.11.0` to `1.11.1`
 
-The `Sylius\Bundle\ResourceBundle\EventListener\ORMTranslatableListener` service has become a Doctrine subscriber again 
+The `Sylius\Bundle\ResourceBundle\EventListener\ORMTranslatableListener` service has become a Doctrine subscriber again
 to fully support Symfony 5.
 
 ### FROM `1.10.x` to `1.11.x`
 
 We remove the default mapping paths which are used to read PHP 8 attributes to build routes.
 
-To configure this default value, please edit your `config/packages/sylius_resource.yaml` file to add your mapping paths manually:
+To configure this default value, please edit your `config/packages/sylius_resource.yaml` file to add your mapping paths
+manually:
 
 ```yaml
 # config/packages/sylius_resource.yaml
@@ -43,25 +107,29 @@ sylius_resource:
             - '%kernel.project_dir%/src/Entity'
 ```
 
-These following services are now Doctrine listeners instead of Doctrine subscribers (@see https://github.com/symfony/symfony/issues/49586)
+These following services are now Doctrine listeners instead of Doctrine subscribers (
+@see https://github.com/symfony/symfony/issues/49586)
 
 * Sylius\Bundle\ResourceBundle\EventListener\ORMTranslatableListener
 * Sylius\Bundle\ResourceBundle\EventListener\ORMRepositoryClassSubscriber
 * Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber
 
-Applied the `UniqueEntity` constraint for `locale` and `translatable` fields, and added `NotBlank` & `Locale` constraints for the `locale` property in classes extending `Sylius\Resource\Model\AbstractTranslation`.
+Applied the `UniqueEntity` constraint for `locale` and `translatable` fields, and added `NotBlank` & `Locale`
+constraints for the `locale` property in classes extending `Sylius\Resource\Model\AbstractTranslation`.
 
-Applied the `Valid` constraint for the `getTranslations` method for objects implementing `Sylius\Resource\Model\TranslatableInterface`.
-
+Applied the `Valid` constraint for the `getTranslations` method for objects implementing
+`Sylius\Resource\Model\TranslatableInterface`.
 
 ## UPGRADE FOR `1.10.x`
 
 ### FROM `1.9.x` to `1.10.x`
 
-- failed form response status code returned from the `ResourceController::createAction` and `ResourceController::updateAction` changed from `200` to `422`
+- failed form response status code returned from the `ResourceController::createAction` and
+  `ResourceController::updateAction` changed from `200` to `422`
 
-  see: https://github.com/Sylius/SyliusResourceBundle/pull/488. This is technically a bug fix, but could break the application
-  if your logic is based on this bugged previous status code  
+  see: https://github.com/Sylius/SyliusResourceBundle/pull/488. This is technically a bug fix, but could break the
+  application
+  if your logic is based on this bugged previous status code
 
 ## UPGRADE FOR `1.7.x`
 
@@ -70,38 +138,42 @@ Applied the `Valid` constraint for the `getTranslations` method for objects impl
 #### Dependencies
 
 - `jms/serializer` and `jms/serializer-bundle` from `2.x` to `3.x`:
-  
-  follow their upgrade process for [the component](https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md#from-2x-to-300) 
+
+  follow their upgrade process
+  for [the component](https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md#from-2x-to-300)
   and [the bundle](https://github.com/schmittjoh/JMSSerializerBundle/blob/master/UPGRADING.md#upgrading-from-2x-to-30);
   if you're getting errors about serializing the entity manager, consider changing the serialized type
   from `array` to `iterable` for Doctrine collections in your models
 
 - `friendsofsymfony/rest-bundle` from `2.x` to `3.x`:
-  
+
   follow their [upgrade process](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/3.x/UPGRADING-3.0.md);
   if you're using this bundle to render HTML templates as well, replace it with direct calls to Twig
-  and handle only the REST logic via this bundle ([see this PR for more](https://github.com/Sylius/SyliusResourceBundle/pull/167/files))
-  
+  and handle only the REST logic via this
+  bundle ([see this PR for more](https://github.com/Sylius/SyliusResourceBundle/pull/167/files))
+
 - `willdurand/hateoas` from `2.x` to `3.x`:
-  
+
   follow their [upgrade process](https://github.com/willdurand/Hateoas/blob/master/UPGRADING.md#from-2120-to-300)
-  
+
 - from `white-october/pagerfanta-bundle` `^1.0` to `babdev/pagerfanta-bundle` `^2.5`:
-  
-  follow their [upgrade process](https://github.com/BabDev/PagerfantaBundle/blob/2.x/UPGRADE-2.0.md#migrate-from-whiteoctoberpagerfantabundle-1x-to-babdevpagerfantabundle-20)  
+
+  follow
+  their [upgrade process](https://github.com/BabDev/PagerfantaBundle/blob/2.x/UPGRADE-2.0.md#migrate-from-whiteoctoberpagerfantabundle-1x-to-babdevpagerfantabundle-20)
 
 - `doctrine/persistence` from `1.x` to `2.x` (if applicable):
-  
+
   replace `Doctrine\Common\Persistence` with `Doctrine\Persistence` in your codebase
 
 #### Example
 
-You can find an exemplary upgrade to this version of ResourceBundle on Sylius repository in [this PR](https://github.com/Sylius/Sylius/pull/12084).
+You can find an exemplary upgrade to this version of ResourceBundle on Sylius repository
+in [this PR](https://github.com/Sylius/Sylius/pull/12084).
 
 ## UPGRADE FOR `1.3.x`
 
 ### FROM `1.3.x` TO `1.3.13`
 
 If you're using an "Accept" HTTP header to set the serialization groups, you need to define allowed groups
-either by passing them as default in `serialization_groups` setting or marking them as allowed in 
+either by passing them as default in `serialization_groups` setting or marking them as allowed in
 `allowed_serialization_groups` setting, both settings are set in the route definition (under `_sylius` key).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,7 @@ Routing paths may have been changed depending on your configuration.
 
 If you want to keep the previous paths, please follow these following steps:
 
-1/ Make sure to have Behat transliterator installed.
+1. Make sure to have Behat transliterator installed.
 
 ```shell
 composer require behat/transliterator
@@ -31,9 +31,9 @@ sylius_resource:
     routing_path_bc_layer: true
 ```
 
-When using the `ResourceController` for your routes and when the routing bath bc layer is enabled, the routing path
+When using the `ResourceController` for your routes and when the BC-layer is enabled, the routing path
 contains a trailing slash by default. In 2.x, it will be removed.
-You can disable the bc-layer to remove these trailing slashes on all your routes and be prepared for 2.x area.
+You can disable the BC-layer to remove these trailing slashes on all your routes and be prepared for the 2.x release.
 
 If you are using the new Routing system with `AsResource` attribute and operations, this change has no effect, there is
 no trailing slash in both configuration.
@@ -52,7 +52,7 @@ sylius_resource:
 | Using AsResource attribute   | ❌ Disabled            | ❌              |
 
 The routing path uses dashes to separate words by default. Eg: `/shipping-categories`.
-On the new routing system only, you can use configure the bundle to use underscores instead. Eg: `/shipping_categories`
+On the new routing system only, you can configure using underscores instead. Eg: `/shipping_categories`
 
 ```yaml
 # config/packages/

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,11 @@
     "require": {
         "php": "^8.2",
         "babdev/pagerfanta-bundle": "^4.4",
-        "behat/transliterator": "^1.2",
         "doctrine/annotations": "^2.0",
         "doctrine/collections": "^2.2",
         "doctrine/event-manager": "^1.1 || ^2.0",
         "doctrine/inflector": "^2.0",
         "doctrine/persistence": "^3.3",
-        "gedmo/doctrine-extensions": "^3.17.1",
         "sylius/registry": "^1.2",
         "symfony/config": "^6.4 || ^7.4",
         "symfony/deprecation-contracts": "^3.5",
@@ -45,6 +43,7 @@
         "symfony/routing": "^6.4 || ^7.4",
         "symfony/security-core": "^6.4 || ^7.4",
         "symfony/security-csrf": "^6.4 || ^7.4",
+        "symfony/string": "^6.4 || ^7.4",
         "symfony/translation": "^6.4 || ^7.4",
         "symfony/twig-bundle": "^6.4 || ^7.4",
         "symfony/validator": "^6.4 || ^7.4",
@@ -97,9 +96,11 @@
         "zenstruck/foundry": "^2.3 <2.7"
     },
     "conflict": {
+        "behat/transliterator": "<1.2",
         "doctrine/orm": "<2.18",
         "doctrine/doctrine-bundle": "<2.0 || ^3.0",
         "friendsofsymfony/rest-bundle": "<3.0",
+        "gedmo/doctrine-extensions": "<3.17.1",
         "jms/serializer-bundle": "<3.5",
         "pagerfanta/pagerfanta" : "<4.4",
         "willdurand/hateoas-bundle": "<2.0 || ^3.0",

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -55,8 +55,10 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('sylius.resource_controller.authorization_checker.disabled')
                     ->cannotBeEmpty()
                 ->end()
-                ->booleanNode('routing_path_bc_layer')
-                    ->defaultTrue()
+                ->booleanNode('routing_path_bc_layer')->end()
+                ->scalarNode('path_segment_name_generator')
+                    ->defaultValue('sylius.metadata.path_segment_name_generator.dash')
+                    ->info('Specify a path name generator to use.')
                 ->end()
             ->end()
         ;

--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection;
 
+use Behat\Transliterator\Transliterator;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineODMDriver;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineORMDriver;
@@ -72,8 +73,21 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
 
         $container->setParameter('sylius.resource.mapping', $config['mapping']);
         $container->setParameter('sylius.resource.settings', $config['settings']);
-        $container->setParameter('sylius.routing_path_bc_layer', $config['routing_path_bc_layer']);
+
+        $routingPathBcLayer = $config['routing_path_bc_layer'] ?? null;
+
+        if (null === $routingPathBcLayer) {
+            $routingPathBcLayer = class_exists(Transliterator::class);
+        }
+
+        if ($routingPathBcLayer && !class_exists(Transliterator::class)) {
+            throw new RuntimeException(sprintf('The routing path bc-layer is enabled but behat/transliterator package is not installed.'));
+        }
+
+        $container->setParameter('sylius.routing_path_bc_layer', $routingPathBcLayer);
+
         $container->setAlias('sylius.resource_controller.authorization_checker', $config['authorization_checker']);
+        $container->setAlias('sylius.path_segment_name_generator', $config['path_segment_name_generator']);
 
         $this->registerMetadataConfiguration($container, $config);
         $this->autoRegisterResources($config, $container);

--- a/src/Bundle/Resources/config/services/metadata/inflector.php
+++ b/src/Bundle/Resources/config/services/metadata/inflector.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Sylius\Resource\Metadata\Inflector\Inflector;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('sylius.metadata.inflector', Inflector::class);
+};

--- a/src/Bundle/Resources/config/services/metadata/path_segment_name_generator.php
+++ b/src/Bundle/Resources/config/services/metadata/path_segment_name_generator.php
@@ -21,13 +21,13 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('sylius.metadata.path_segment_name_generator.underscore', UnderscorePathSegmentNameGenerator::class)
         ->args([
-            service('sylius.metadata.inflector')->nullOnInvalid(),
+            service('sylius.metadata.inflector'),
         ])
     ;
 
     $services->set('sylius.metadata.path_segment_name_generator.dash', DashPathSegmentNameGenerator::class)
         ->args([
-            service('sylius.metadata.inflector')->nullOnInvalid(),
+            service('sylius.metadata.inflector'),
         ])
     ;
 };

--- a/src/Bundle/Resources/config/services/metadata/path_segment_name_generator.php
+++ b/src/Bundle/Resources/config/services/metadata/path_segment_name_generator.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
+use Sylius\Resource\Metadata\Operation\UnderscorePathSegmentNameGenerator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('sylius.metadata.path_segment_name_generator.underscore', UnderscorePathSegmentNameGenerator::class)
+        ->args([
+            service('sylius.metadata.inflector')->nullOnInvalid(),
+        ])
+    ;
+
+    $services->set('sylius.metadata.path_segment_name_generator.dash', DashPathSegmentNameGenerator::class)
+        ->args([
+            service('sylius.metadata.inflector')->nullOnInvalid(),
+        ])
+    ;
+};

--- a/src/Bundle/Resources/config/services/metadata/resource_metadata_collection.php
+++ b/src/Bundle/Resources/config/services/metadata/resource_metadata_collection.php
@@ -67,7 +67,7 @@ return static function (ContainerConfigurator $container) {
         ->decorate('sylius.resource_metadata_collection.factory', null, 300)
         ->args([
             service('.inner'),
-            service('sylius.metadata.inflector')->nullOnInvalid(),
+            service('sylius.metadata.inflector'),
             param('sylius.routing_path_bc_layer'),
             service('sylius.resource_registry'),
         ]);

--- a/src/Bundle/Resources/config/services/metadata/resource_metadata_collection.php
+++ b/src/Bundle/Resources/config/services/metadata/resource_metadata_collection.php
@@ -20,6 +20,7 @@ use Sylius\Resource\Metadata\Resource\Factory\EventShortNameResourceMetadataColl
 use Sylius\Resource\Metadata\Resource\Factory\FactoryResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\Factory\MutatorResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\Factory\PhpFileResourceMetadataCollectionFactory;
+use Sylius\Resource\Metadata\Resource\Factory\PluralNameResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\Factory\ProviderResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\Factory\RedirectResourceMetadataCollectionFactory;
 use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -60,6 +61,15 @@ return static function (ContainerConfigurator $container) {
             service('sylius.metadata.mutator_collection.resource'),
             service('sylius.metadata.mutator_collection.operation'),
             service('.inner'),
+        ]);
+
+    $services->set('sylius.resource_metadata_collection.factory.plural_name', PluralNameResourceMetadataCollectionFactory::class)
+        ->decorate('sylius.resource_metadata_collection.factory', null, 300)
+        ->args([
+            service('.inner'),
+            service('sylius.metadata.inflector')->nullOnInvalid(),
+            param('sylius.routing_path_bc_layer'),
+            service('sylius.resource_registry'),
         ]);
 
     $services->set('sylius.resource_metadata_collection.factory.state_machine', StateMachineResourceMetadataCollectionFactory::class)

--- a/src/Bundle/Resources/config/services/routing.php
+++ b/src/Bundle/Resources/config/services/routing.php
@@ -136,7 +136,11 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('sylius.routing.factory.operation_route', OperationRouteFactory::class)
         ->private()
-        ->args([service('sylius.routing.factory.operation_route_path_factory')]);
+        ->args([
+            service('sylius.routing.factory.operation_route_path_factory'),
+            service('sylius.path_segment_name_generator'),
+            param('sylius.routing_path_bc_layer'),
+        ]);
 
     $services->alias(OperationRouteFactoryInterface::class, 'sylius.routing.factory.operation_route');
 

--- a/src/Bundle/Routing/ResourceLoader.php
+++ b/src/Bundle/Routing/ResourceLoader.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Routing;
 
+use Behat\Transliterator\Transliterator;
 use Gedmo\Sluggable\Util\Urlizer;
+use Sylius\Resource\Exception\RuntimeException;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Inflector\InflectorInterface;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\RegistryInterface;
 use Symfony\Component\Config\Definition\Processor;
@@ -27,16 +31,18 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class ResourceLoader extends Loader
 {
+    private InflectorInterface $inflector;
+
     public function __construct(
         private RegistryInterface $resourceRegistry,
         private RouteFactoryInterface $routeFactory,
         ?string $env = null,
         private ?bool $routingPathBcLayer = null,
+        ?InflectorInterface $inflector = null,
     ) {
         parent::__construct($env);
 
-        $this->resourceRegistry = $resourceRegistry;
-        $this->routeFactory = $routeFactory;
+        $this->inflector = $inflector ?? new Inflector();
     }
 
     public function load($resource, $type = null): RouteCollection
@@ -66,7 +72,7 @@ final class ResourceLoader extends Loader
         $metadata = $this->resourceRegistry->get($configuration['alias']);
         $routes = $this->routeFactory->createRouteCollection();
 
-        $rootPath = sprintf('/%s', $configuration['path'] ?? Urlizer::urlize($metadata->getPluralName()));
+        $rootPath = $configuration['path'] ?? $this->getRootPath($metadata->getPluralName());
         $identifier = sprintf('{%s}', $configuration['identifier']);
 
         /** @var bool $bcLayerEnabled */
@@ -124,6 +130,19 @@ final class ResourceLoader extends Loader
     public function supports($resource, $type = null): bool
     {
         return 'sylius.resource' === $type || 'sylius.resource_api' === $type;
+    }
+
+    private function getRootPath(string $pluralName): string
+    {
+        if ($this->routingPathBcLayer) {
+            if (!class_exists(Urlizer::class) || !class_exists(Transliterator::class)) {
+                throw new RuntimeException('Cannot use the routing bc-layer when the "behat/transliterator" package is not installed. Try to disable the routing path bc-layer in the Sylius Resource Bundle configuration using "sylius_resource.routing_path_bc_layer: false"');
+            }
+
+            return sprintf('/%s', Urlizer::urlize($pluralName));
+        }
+
+        return $this->inflector->dashize($pluralName);
     }
 
     private function createRoute(

--- a/src/Component/src/Exception/LogicException.php
+++ b/src/Component/src/Exception/LogicException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Component/src/Metadata/Inflector/Inflector.php
+++ b/src/Component/src/Metadata/Inflector/Inflector.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Inflector;
+
+use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\String\UnicodeString;
+
+final class Inflector implements InflectorInterface
+{
+    public function tableize(string $string): string
+    {
+        return (new UnicodeString($string))->snake()->toString();
+    }
+
+    public function pluralize(string $string): string
+    {
+        $pluralize = (new EnglishInflector())->pluralize($string);
+
+        return $pluralize ? array_pop($pluralize) : '';
+    }
+
+    public function dashize(string $string): string
+    {
+        return strtr($this->tableize($string), ['_' => '-']);
+    }
+}

--- a/src/Component/src/Metadata/Inflector/InflectorInterface.php
+++ b/src/Component/src/Metadata/Inflector/InflectorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Inflector;
+
+interface InflectorInterface
+{
+    public function tableize(string $string): string;
+
+    public function pluralize(string $string): string;
+
+    public function dashize(string $string): string;
+}

--- a/src/Component/src/Metadata/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Component/src/Metadata/Operation/DashPathSegmentNameGenerator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Metadata\Operation;
 
-use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Inflector\InflectorInterface;
 
 /**
@@ -21,12 +20,9 @@ use Sylius\Resource\Metadata\Inflector\InflectorInterface;
  */
 final class DashPathSegmentNameGenerator implements PathSegmentNameGeneratorInterface
 {
-    private readonly InflectorInterface $inflector;
-
     public function __construct(
-        ?InflectorInterface $inflector = null,
+        private readonly InflectorInterface $inflector,
     ) {
-        $this->inflector = $inflector ?? new Inflector();
     }
 
     /**

--- a/src/Component/src/Metadata/Operation/DashPathSegmentNameGenerator.php
+++ b/src/Component/src/Metadata/Operation/DashPathSegmentNameGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Operation;
+
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Inflector\InflectorInterface;
+
+/**
+ * Generate a path name with a dash separator according to a string and whether it's a collection or not.
+ */
+final class DashPathSegmentNameGenerator implements PathSegmentNameGeneratorInterface
+{
+    private readonly InflectorInterface $inflector;
+
+    public function __construct(
+        ?InflectorInterface $inflector = null,
+    ) {
+        $this->inflector = $inflector ?? new Inflector();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSegmentName(string $name, bool $pluralize = true): string
+    {
+        return $pluralize ? $this->inflector->dashize($this->inflector->pluralize($name)) : $this->inflector->dashize($name);
+    }
+}

--- a/src/Component/src/Metadata/Operation/PathSegmentNameGeneratorInterface.php
+++ b/src/Component/src/Metadata/Operation/PathSegmentNameGeneratorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Operation;
+
+/**
+ * Generates a path name according to a string and whether it's a collection or not.
+ */
+interface PathSegmentNameGeneratorInterface
+{
+    /**
+     * Transforms a given string to a valid path name which can be pluralized (eg. for collections).
+     *
+     * @param string $name Usually a ResourceMetadata shortname
+     *
+     * @return string A string that is a part of the route name
+     */
+    public function getSegmentName(string $name, bool $pluralize = true): string;
+}

--- a/src/Component/src/Metadata/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Component/src/Metadata/Operation/UnderscorePathSegmentNameGenerator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Metadata\Operation;
 
-use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Inflector\InflectorInterface;
 
 /**
@@ -21,12 +20,9 @@ use Sylius\Resource\Metadata\Inflector\InflectorInterface;
  */
 final class UnderscorePathSegmentNameGenerator implements PathSegmentNameGeneratorInterface
 {
-    private readonly InflectorInterface $inflector;
-
     public function __construct(
-        ?InflectorInterface $inflector = null,
+        private readonly InflectorInterface $inflector,
     ) {
-        $this->inflector = $inflector ?? new Inflector();
     }
 
     /**

--- a/src/Component/src/Metadata/Operation/UnderscorePathSegmentNameGenerator.php
+++ b/src/Component/src/Metadata/Operation/UnderscorePathSegmentNameGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Operation;
+
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Inflector\InflectorInterface;
+
+/**
+ * Generate a path name with an underscore separator according to a string and whether it's a collection or not.
+ */
+final class UnderscorePathSegmentNameGenerator implements PathSegmentNameGeneratorInterface
+{
+    private readonly InflectorInterface $inflector;
+
+    public function __construct(
+        ?InflectorInterface $inflector = null,
+    ) {
+        $this->inflector = $inflector ?? new Inflector();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSegmentName(string $name, bool $pluralize = true): string
+    {
+        $name = $this->inflector->tableize($name);
+
+        return $pluralize ? $this->inflector->pluralize($name) : $name;
+    }
+}

--- a/src/Component/src/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactory.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Resource\Metadata\Resource\Factory;
 
 use Sylius\Resource\Exception\LogicException;
-use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Inflector\InflectorInterface;
-use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
 use Sylius\Resource\Metadata\ResourceMetadata;
@@ -26,15 +24,12 @@ use Sylius\Resource\Metadata\ResourceMetadata;
  */
 final class PluralNameResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {
-    private InflectorInterface $inflector;
-
     public function __construct(
         private readonly ResourceMetadataCollectionFactoryInterface $decorated,
-        ?InflectorInterface $inflector = null,
+        private readonly InflectorInterface $inflector,
         private readonly bool $routingBcLayerEnabled = true,
         private readonly ?RegistryInterface $resourceRegistry = null,
     ) {
-        $this->inflector = $inflector ?? new Inflector();
     }
 
     public function create(string $resourceClass): ResourceMetadataCollection
@@ -43,29 +38,29 @@ final class PluralNameResourceMetadataCollectionFactory implements ResourceMetad
 
         /** @var ResourceMetadata $resource */
         foreach ($resourceCollectionMetadata->getIterator() as $i => $resource) {
-            $resourceConfiguration = $this->resourceRegistry?->get($resource->getAlias() ?? '');
-
-            $resourceCollectionMetadata[$i] = $this->addDefaults($resource, $resourceConfiguration);
+            $resourceCollectionMetadata[$i] = $this->addDefaults($resource);
         }
 
         return $resourceCollectionMetadata;
     }
 
-    private function addDefaults(ResourceMetadata $resource, ?MetadataInterface $resourceConfiguration = null): ResourceMetadata
+    private function addDefaults(ResourceMetadata $resource): ResourceMetadata
     {
         if (null !== $resource->getPluralName()) {
             return $resource;
         }
 
         if ($this->routingBcLayerEnabled) {
-            $pluralName = $resourceConfiguration?->getPluralName()
-                ?? throw new LogicException(sprintf(
+            if (null === $this->resourceRegistry) {
+                throw new LogicException(sprintf(
                     'Routing Bc-Layer is enabled, but the resource registry is not passed as constructor arguments of "%s" class.',
                     self::class,
-                ))
-            ;
+                ));
+            }
 
-            return $resource->withPluralName($pluralName);
+            $resourceConfiguration = $this->resourceRegistry->get($resource->getAlias() ?? '');
+
+            return $resource->withPluralName($resourceConfiguration->getPluralName());
         }
 
         /**

--- a/src/Component/src/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Metadata\Resource\Factory;
+
+use Sylius\Resource\Exception\LogicException;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Inflector\InflectorInterface;
+use Sylius\Resource\Metadata\MetadataInterface;
+use Sylius\Resource\Metadata\RegistryInterface;
+use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Resource\Metadata\ResourceMetadata;
+
+/**
+ * @experimental
+ */
+final class PluralNameResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    private InflectorInterface $inflector;
+
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+        ?InflectorInterface $inflector = null,
+        private readonly bool $routingBcLayerEnabled = true,
+        private readonly ?RegistryInterface $resourceRegistry = null,
+    ) {
+        $this->inflector = $inflector ?? new Inflector();
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceCollectionMetadata = $this->decorated->create($resourceClass);
+
+        /** @var ResourceMetadata $resource */
+        foreach ($resourceCollectionMetadata->getIterator() as $i => $resource) {
+            $resourceConfiguration = $this->resourceRegistry?->get($resource->getAlias() ?? '');
+
+            $resourceCollectionMetadata[$i] = $this->addDefaults($resource, $resourceConfiguration);
+        }
+
+        return $resourceCollectionMetadata;
+    }
+
+    private function addDefaults(ResourceMetadata $resource, ?MetadataInterface $resourceConfiguration = null): ResourceMetadata
+    {
+        if (null !== $resource->getPluralName()) {
+            return $resource;
+        }
+
+        if ($this->routingBcLayerEnabled) {
+            $pluralName = $resourceConfiguration?->getPluralName()
+                ?? throw new LogicException(sprintf(
+                    'Routing Bc-Layer is enabled, but the resource registry is not passed as constructor arguments of "%s" class.',
+                    self::class,
+                ))
+            ;
+
+            return $resource->withPluralName($pluralName);
+        }
+
+        /**
+         * Resource name has already been configured.
+         *
+         * @see OperationDefaultsTrait
+         *
+         * @var string $resourceName
+         */
+        $resourceName = $resource->getName();
+
+        return $resource->withPluralName($this->inflector->pluralize($resourceName));
+    }
+}

--- a/src/Component/src/Model/ResourceLogEntry.php
+++ b/src/Component/src/Model/ResourceLogEntry.php
@@ -14,6 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Resource\Model;
 
 use Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry;
+use Sylius\Resource\Exception\RuntimeException;
+
+if (!class_exists(AbstractLogEntry::class)) {
+    throw new RuntimeException(sprintf('Cannot use the "%s" class when the "gedmo/doctrine-extensions" package is not installed.', ResourceLogEntry::class));
+}
 
 abstract class ResourceLogEntry extends AbstractLogEntry implements ResourceInterface
 {

--- a/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Symfony\Routing\Factory;
 
+use Behat\Transliterator\Transliterator;
 use Gedmo\Sluggable\Util\Urlizer;
+use Sylius\Resource\Exception\RuntimeException;
 use Sylius\Resource\Metadata\HttpOperation;
 use Sylius\Resource\Metadata\MetadataInterface;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\Route;
@@ -27,12 +30,14 @@ final class OperationRouteFactory implements OperationRouteFactoryInterface
 {
     public function __construct(
         private OperationRoutePathFactoryInterface $routePathFactory,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+        private bool $routingPathBcLayer = true,
     ) {
     }
 
     public function create(MetadataInterface $metadata, ResourceMetadata $resource, HttpOperation $operation): Route
     {
-        $routePath = $operation->getPath() ?? $this->getDefaultRoutePath($metadata, $operation);
+        $routePath = $operation->getPath() ?? $this->getDefaultRoutePath($metadata, $resource, $operation);
 
         if (null !== $routePrefix = $operation->getRoutePrefix()) {
             $routePath = $routePrefix . '/' . $routePath;
@@ -50,20 +55,34 @@ final class OperationRouteFactory implements OperationRouteFactoryInterface
         );
     }
 
-    private function getDefaultRoutePath(MetadataInterface $metadata, HttpOperation $operation): string
+    private function getDefaultRoutePath(MetadataInterface $legacyMetadata, ResourceMetadata $resource, HttpOperation $operation): string
     {
-        return $this->getDefaultRoutePathForOperation($metadata, $operation);
+        return $this->getDefaultRoutePathForOperation($legacyMetadata, $resource, $operation);
     }
 
-    private function getDefaultRoutePathForOperation(MetadataInterface $metadata, HttpOperation $operation): string
+    private function getDefaultRoutePathForOperation(MetadataInterface $legacyMetadata, ResourceMetadata $resource, HttpOperation $operation): string
     {
-        $rootPath = sprintf('%s', Urlizer::urlize($metadata->getPluralName()));
-
         if (null !== $path = $operation->getPath()) {
             return $path;
         }
 
-        return $this->routePathFactory->createRoutePath($operation, $rootPath);
+        return $this->routePathFactory->createRoutePath($operation, $this->getRootPath($legacyMetadata, $resource));
+    }
+
+    private function getRootPath(MetadataInterface $legacyMetadata, ResourceMetadata $resource): string
+    {
+        if ($this->routingPathBcLayer) {
+            if (!class_exists(Urlizer::class) || !class_exists(Transliterator::class)) {
+                throw new RuntimeException('Cannot use the routing bc-layer when the "behat/transliterator" package is not installed. Try to disable the routing path bc-layer in the Sylius Resource Bundle configuration using "sylius_resource.routing_path_bc_layer: false"');
+            }
+
+            return Urlizer::urlize($legacyMetadata->getPluralName());
+        }
+
+        return $this->pathSegmentNameGenerator->getSegmentName(
+            name: $resource->getPluralName() ?? '',
+            pluralize: false,
+        );
     }
 
     private function getSyliusOptions(ResourceMetadata $resource, HttpOperation $operation): array

--- a/src/Component/tests/Metadata/Inflector/InflectorTest.php
+++ b/src/Component/tests/Metadata/Inflector/InflectorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Metadata\Inflector;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+
+#[CoversClass(Inflector::class)]
+final class InflectorTest extends TestCase
+{
+    #[DataProvider('tableizeProvider')]
+    public function testTableize(string $expected, string $string): void
+    {
+        $this->assertSame($expected, (new Inflector())->tableize($string));
+    }
+
+    #[DataProvider('pluralizeProvider')]
+    public function testPluralize(string $expected, string $string): void
+    {
+        $this->assertSame($expected, (new Inflector())->pluralize($string));
+    }
+
+    #[DataProvider('dashizeProvider')]
+    public function testDashize(string $expected, string $string): void
+    {
+        $this->assertSame($expected, (new Inflector())->dashize($string));
+    }
+
+    public static function tableizeProvider(): iterable
+    {
+        yield ['book', 'Book'];
+        yield ['stephen_king_book', 'StephenKingBook'];
+    }
+
+    public static function pluralizeProvider(): iterable
+    {
+        yield ['books', 'book'];
+        yield ['products', 'product'];
+        yield ['orders', 'order'];
+    }
+
+    public static function dashizeProvider(): iterable
+    {
+        yield ['stephen-king-book', 'StephenKingBook'];
+        yield ['stephen-king-book', 'Stephen_King_Book'];
+        yield ['stephen-king-book', 'Stephen King Book'];
+    }
+}

--- a/src/Component/tests/Metadata/Operation/DashPathSegmentNameGeneratorTest.php
+++ b/src/Component/tests/Metadata/Operation/DashPathSegmentNameGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Metadata\Operation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
+
+#[CoversClass(DashPathSegmentNameGenerator::class)]
+final class DashPathSegmentNameGeneratorTest extends TestCase
+{
+    #[DataProvider('segmentNameProvider')]
+    public function testGettingSegmentName(string $expected, string $name, bool $pluralize): void
+    {
+        $this->assertSame($expected, (new DashPathSegmentNameGenerator())->getSegmentName($name, $pluralize));
+    }
+
+    public static function segmentNameProvider(): iterable
+    {
+        yield ['stephen-king-book', 'StephenKingBook', false];
+        yield ['stephen-king-book', 'Stephen_King_Book', false];
+        yield ['stephen-king-book', 'Stephen King Book', false];
+        yield ['stephen-king-books', 'StephenKingBook', true];
+        yield ['stephen-king-books', 'Stephen_King_Book', true];
+        yield ['stephen-king-books', 'Stephen King Book', true];
+    }
+}

--- a/src/Component/tests/Metadata/Operation/DashPathSegmentNameGeneratorTest.php
+++ b/src/Component/tests/Metadata/Operation/DashPathSegmentNameGeneratorTest.php
@@ -16,6 +16,7 @@ namespace Sylius\Resource\Tests\Metadata\Operation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 
 #[CoversClass(DashPathSegmentNameGenerator::class)]
@@ -24,7 +25,7 @@ final class DashPathSegmentNameGeneratorTest extends TestCase
     #[DataProvider('segmentNameProvider')]
     public function testGettingSegmentName(string $expected, string $name, bool $pluralize): void
     {
-        $this->assertSame($expected, (new DashPathSegmentNameGenerator())->getSegmentName($name, $pluralize));
+        $this->assertSame($expected, (new DashPathSegmentNameGenerator(new Inflector()))->getSegmentName($name, $pluralize));
     }
 
     public static function segmentNameProvider(): iterable

--- a/src/Component/tests/Metadata/Operation/UnderscorePathSegmentNameGeneratorTest.php
+++ b/src/Component/tests/Metadata/Operation/UnderscorePathSegmentNameGeneratorTest.php
@@ -16,6 +16,7 @@ namespace Sylius\Resource\Tests\Metadata\Operation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Operation\UnderscorePathSegmentNameGenerator;
 
 #[CoversClass(UnderscorePathSegmentNameGenerator::class)]
@@ -24,7 +25,7 @@ final class UnderscorePathSegmentNameGeneratorTest extends TestCase
     #[DataProvider('segmentNameProvider')]
     public function testGettingSegmentName(string $expected, string $name, bool $pluralize): void
     {
-        $this->assertSame($expected, (new UnderscorePathSegmentNameGenerator())->getSegmentName($name, $pluralize));
+        $this->assertSame($expected, (new UnderscorePathSegmentNameGenerator(new Inflector()))->getSegmentName($name, $pluralize));
     }
 
     public static function segmentNameProvider(): iterable

--- a/src/Component/tests/Metadata/Operation/UnderscorePathSegmentNameGeneratorTest.php
+++ b/src/Component/tests/Metadata/Operation/UnderscorePathSegmentNameGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Metadata\Operation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Metadata\Operation\UnderscorePathSegmentNameGenerator;
+
+#[CoversClass(UnderscorePathSegmentNameGenerator::class)]
+final class UnderscorePathSegmentNameGeneratorTest extends TestCase
+{
+    #[DataProvider('segmentNameProvider')]
+    public function testGettingSegmentName(string $expected, string $name, bool $pluralize): void
+    {
+        $this->assertSame($expected, (new UnderscorePathSegmentNameGenerator())->getSegmentName($name, $pluralize));
+    }
+
+    public static function segmentNameProvider(): iterable
+    {
+        yield ['stephen_king_book', 'StephenKingBook', false];
+        yield ['stephen_king_book', 'Stephen_King_Book', false];
+        yield ['stephen_king_book', 'Stephen King Book', false];
+        yield ['stephen_king_books', 'StephenKingBook', true];
+        yield ['stephen_king_books', 'Stephen_King_Book', true];
+        yield ['stephen_king_books', 'Stephen King Book', true];
+    }
+}

--- a/src/Component/tests/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactoryTest.php
+++ b/src/Component/tests/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Metadata\Resource\Factory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Exception\LogicException;
+use Sylius\Resource\Metadata\Metadata;
+use Sylius\Resource\Metadata\RegistryInterface;
+use Sylius\Resource\Metadata\Resource\Factory\PluralNameResourceMetadataCollectionFactory;
+use Sylius\Resource\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Sylius\Resource\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Resource\Metadata\ResourceMetadata;
+
+#[CoversClass(PluralNameResourceMetadataCollectionFactory::class)]
+final class PluralNameResourceMetadataCollectionFactoryTest extends TestCase
+{
+    private ResourceMetadataCollectionFactoryInterface&MockObject $decorated;
+
+    private RegistryInterface&MockObject $registry;
+
+    protected function setUp(): void
+    {
+        $this->decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $this->registry = $this->createMock(RegistryInterface::class);
+    }
+
+    public function testItConfiguresDefaultPluralNameOnResourcesWithRoutingBcLayerEnabled(): void
+    {
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: true, resourceRegistry: $this->registry);
+        $resource = new ResourceMetadata(alias: 'app.book', name: 'book');
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $this->decorated->method('create')->with('App\Resource')->willReturn($resourceMetadataCollection);
+        $this->registry->method('get')->with('app.book')->willReturn(Metadata::fromAliasAndConfiguration('app.book', ['driver' => 'doctrine/orm']));
+
+        $resourceMetadataCollection = $factory->create('App\Resource');
+        $resourceOutput = $resourceMetadataCollection[0];
+
+        $this->assertInstanceOf(ResourceMetadata::class, $resourceOutput);
+        $this->assertSame('books', $resourceOutput->getPluralName());
+    }
+
+    public function testItConfiguresDefaultPluralNameOnResourcesWithRoutingBcLayerDisabled(): void
+    {
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: false);
+        $resource = new ResourceMetadata(name: 'book');
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $this->decorated->method('create')->with('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $resourceMetadataCollection = $factory->create('App\Resource');
+        $resourceOutput = $resourceMetadataCollection[0];
+
+        $this->assertInstanceOf(ResourceMetadata::class, $resourceOutput);
+        $this->assertSame('books', $resourceOutput->getPluralName());
+    }
+
+    public function testItThrowAnExceptionWithRoutingBcLayerEnabledWhenResourceRegistryIsNotPassedAsConstructorArguments(): void
+    {
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: true);
+        $resource = new ResourceMetadata(alias: 'app.book', name: 'book');
+
+        $resourceMetadataCollection = new ResourceMetadataCollection();
+        $resourceMetadataCollection[] = $resource;
+
+        $this->decorated->method('create')->with('App\Resource')->willReturn($resourceMetadataCollection);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Routing Bc-Layer is enabled, but the resource registry is not passed as constructor arguments of "%s" class.',
+            PluralNameResourceMetadataCollectionFactory::class,
+        ));
+
+        $factory->create('App\Resource');
+    }
+}

--- a/src/Component/tests/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactoryTest.php
+++ b/src/Component/tests/Metadata/Resource/Factory/PluralNameResourceMetadataCollectionFactoryTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Exception\LogicException;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\Metadata;
 use Sylius\Resource\Metadata\RegistryInterface;
 use Sylius\Resource\Metadata\Resource\Factory\PluralNameResourceMetadataCollectionFactory;
@@ -39,7 +40,7 @@ final class PluralNameResourceMetadataCollectionFactoryTest extends TestCase
 
     public function testItConfiguresDefaultPluralNameOnResourcesWithRoutingBcLayerEnabled(): void
     {
-        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: true, resourceRegistry: $this->registry);
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, inflector: new Inflector(), resourceRegistry: $this->registry, routingBcLayerEnabled: true);
         $resource = new ResourceMetadata(alias: 'app.book', name: 'book');
 
         $resourceMetadataCollection = new ResourceMetadataCollection();
@@ -57,7 +58,7 @@ final class PluralNameResourceMetadataCollectionFactoryTest extends TestCase
 
     public function testItConfiguresDefaultPluralNameOnResourcesWithRoutingBcLayerDisabled(): void
     {
-        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: false);
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, inflector: new Inflector(), routingBcLayerEnabled: false);
         $resource = new ResourceMetadata(name: 'book');
 
         $resourceMetadataCollection = new ResourceMetadataCollection();
@@ -74,7 +75,7 @@ final class PluralNameResourceMetadataCollectionFactoryTest extends TestCase
 
     public function testItThrowAnExceptionWithRoutingBcLayerEnabledWhenResourceRegistryIsNotPassedAsConstructorArguments(): void
     {
-        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, routingBcLayerEnabled: true);
+        $factory = new PluralNameResourceMetadataCollectionFactory(decorated: $this->decorated, inflector: new Inflector(), routingBcLayerEnabled: true);
         $resource = new ResourceMetadata(alias: 'app.book', name: 'book');
 
         $resourceMetadataCollection = new ResourceMetadataCollection();

--- a/src/Component/tests/Symfony/Routing/Factory/AttributesOperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/AttributesOperationRouteFactoryTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\RegistryInterface;
@@ -49,7 +50,7 @@ final class AttributesOperationRouteFactoryTest extends TestCase
 
         $this->attributesOperationRouteFactory = new AttributesOperationRouteFactory(
             $this->resourceRegistry,
-            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(new Inflector()), false),
             new AttributesResourceMetadataCollectionFactory(
                 $this->resourceRegistry,
                 new OperationRouteNameFactory(),
@@ -148,7 +149,7 @@ final class AttributesOperationRouteFactoryTest extends TestCase
 
         $factory = new AttributesOperationRouteFactory(
             $this->resourceRegistry,
-            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(new Inflector()), false),
             $resourceMetadataFactory,
         );
 

--- a/src/Component/tests/Symfony/Routing/Factory/AttributesOperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/AttributesOperationRouteFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Tests\Symfony\Routing\Factory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Resource\Metadata\Create;
@@ -32,6 +33,7 @@ use Sylius\Resource\Symfony\Routing\Factory\RouteName\OperationRouteNameFactory;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\RouteCollection;
 
+#[CoversClass(AttributesOperationRouteFactory::class)]
 final class AttributesOperationRouteFactoryTest extends TestCase
 {
     private RegistryInterface $resourceRegistry;
@@ -47,11 +49,10 @@ final class AttributesOperationRouteFactoryTest extends TestCase
 
         $this->attributesOperationRouteFactory = new AttributesOperationRouteFactory(
             $this->resourceRegistry,
-            new OperationRouteFactory($this->routePathFactory),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
             new AttributesResourceMetadataCollectionFactory(
                 $this->resourceRegistry,
                 new OperationRouteNameFactory(),
-                'symfony',
             ),
         );
     }
@@ -123,6 +124,7 @@ final class AttributesOperationRouteFactoryTest extends TestCase
         $resource = new ResourceMetadata(
             alias: 'app.dummy',
             name: 'dummy',
+            pluralName: 'dummies',
             operations: [
                 'app_dummy_custom' => $nonHttpOperation,
                 'app_dummy_index' => $httpOperation,
@@ -138,9 +140,6 @@ final class AttributesOperationRouteFactoryTest extends TestCase
             ->with(\stdClass::class)
             ->willReturn($resourceCollection);
 
-        $metadata = $this->createDummyMetadataMock();
-        $this->resourceRegistry->method('get')->with('app.dummy')->willReturn($metadata);
-
         $this->routePathFactory
             ->expects($this->once())
             ->method('createRoutePath')
@@ -149,7 +148,7 @@ final class AttributesOperationRouteFactoryTest extends TestCase
 
         $factory = new AttributesOperationRouteFactory(
             $this->resourceRegistry,
-            new OperationRouteFactory($this->routePathFactory),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
             $resourceMetadataFactory,
         );
 

--- a/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
@@ -33,13 +33,13 @@ final class OperationRouteFactoryTest extends TestCase
 
     private OperationRouteFactory $operationRouteFactory;
 
-    private OperationRouteFactory $legacyOperationRouteFactory;
+    private OperationRouteFactory $bcOperationRouteFactory;
 
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
         $this->operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), false);
-        $this->legacyOperationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), true);
+        $this->bcOperationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), true);
     }
 
     public function testItCreatesRouteWithDefaultPathWithBcLayer(): void
@@ -58,7 +58,7 @@ final class OperationRouteFactoryTest extends TestCase
             ->with($operation, 'books')
             ->willReturn('/books');
 
-        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+        $route = $this->bcOperationRouteFactory->create($metadata, $resource, $operation);
 
         $this->assertInstanceOf(Route::class, $route);
         $this->assertSame('/books', $route->getPath());
@@ -117,7 +117,7 @@ final class OperationRouteFactoryTest extends TestCase
             ->with($operation, 'books')
             ->willReturn('/books');
 
-        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+        $route = $this->bcOperationRouteFactory->create($metadata, $resource, $operation);
 
         $this->assertSame('/admin//books', $route->getPath());
     }
@@ -325,7 +325,7 @@ final class OperationRouteFactoryTest extends TestCase
             ->with($operation, 'book-categories')
             ->willReturn('/book-categories');
 
-        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+        $route = $this->bcOperationRouteFactory->create($metadata, $resource, $operation);
 
         $this->assertSame('/book-categories', $route->getPath());
     }

--- a/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
@@ -17,6 +17,7 @@ use Behat\Transliterator\Transliterator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Metadata\Operation\UnderscorePathSegmentNameGenerator;
@@ -38,8 +39,8 @@ final class OperationRouteFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), false);
-        $this->bcOperationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), true);
+        $this->operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(new Inflector()), false);
+        $this->bcOperationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(new Inflector()), true);
     }
 
     public function testItCreatesRouteWithDefaultPathWithBcLayer(): void
@@ -332,7 +333,7 @@ final class OperationRouteFactoryTest extends TestCase
 
     public function testItUrlizesPluralNameUsingUnderscoreAsSeparator(): void
     {
-        $operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new UnderscorePathSegmentNameGenerator(), false);
+        $operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new UnderscorePathSegmentNameGenerator(new Inflector()), false);
 
         $metadata = $this->createMock(MetadataInterface::class);
 

--- a/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
@@ -13,33 +13,64 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Tests\Symfony\Routing\Factory;
 
+use Behat\Transliterator\Transliterator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\MetadataInterface;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
+use Sylius\Resource\Metadata\Operation\UnderscorePathSegmentNameGenerator;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Symfony\Routing\Factory\OperationRouteFactory;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 use Symfony\Component\Routing\Route;
 
+#[CoversClass(OperationRouteFactory::class)]
 final class OperationRouteFactoryTest extends TestCase
 {
     private OperationRoutePathFactoryInterface $routePathFactory;
 
     private OperationRouteFactory $operationRouteFactory;
 
+    private OperationRouteFactory $legacyOperationRouteFactory;
+
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->operationRouteFactory = new OperationRouteFactory($this->routePathFactory);
+        $this->operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), false);
+        $this->legacyOperationRouteFactory = new OperationRouteFactory($this->routePathFactory, new DashPathSegmentNameGenerator(), true);
+    }
+
+    public function testItCreatesRouteWithDefaultPathWithBcLayer(): void
+    {
+        $this->markAsSkippedIfBcLayerCannotBeEnabled();
+
+        $metadata = $this->createMock(MetadataInterface::class);
+        $metadata->method('getPluralName')->willReturn('books');
+
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = new Index();
+
+        $this->routePathFactory
+            ->expects($this->once())
+            ->method('createRoutePath')
+            ->with($operation, 'books')
+            ->willReturn('/books');
+
+        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertSame('/books', $route->getPath());
+        $this->assertSame('sylius.main_controller', $route->getDefault('_controller'));
+        $this->assertSame(['resource' => 'app.book'], $route->getDefault('_sylius'));
     }
 
     public function testItCreatesRouteWithDefaultPath(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
-        $resource = new ResourceMetadata(alias: 'app.book');
+        $resource = new ResourceMetadata(alias: 'app.book', pluralName: 'books');
         $operation = new Index();
 
         $this->routePathFactory
@@ -71,12 +102,31 @@ final class OperationRouteFactoryTest extends TestCase
         $this->assertSame('/custom/books/list', $route->getPath());
     }
 
-    public function testItCreatesRouteWithRoutePrefix(): void
+    public function testItCreatesRouteWithRoutePrefixWithBcLayer(): void
     {
+        $this->markAsSkippedIfBcLayerCannotBeEnabled();
+
         $metadata = $this->createMock(MetadataInterface::class);
         $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = (new Index())->withRoutePrefix('/admin');
+
+        $this->routePathFactory
+            ->method('createRoutePath')
+            ->with($operation, 'books')
+            ->willReturn('/books');
+
+        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertSame('/admin//books', $route->getPath());
+    }
+
+    public function testItCreatesRouteWithRoutePrefix(): void
+    {
+        $metadata = $this->createMock(MetadataInterface::class);
+
+        $resource = new ResourceMetadata(alias: 'app.book', pluralName: 'books');
         $operation = (new Index())->withRoutePrefix('/admin');
 
         $this->routePathFactory
@@ -92,7 +142,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithSection(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book', section: 'admin');
         $operation = new Index();
@@ -111,7 +160,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithVars(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = (new Index())->withVars(['grid' => 'app_book']);
@@ -130,7 +178,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithoutVarsWhenNull(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = new Index();
@@ -149,7 +196,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithRequirements(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = (new Show())->withRouteRequirements(['id' => '\d+']);
@@ -166,7 +212,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithEmptyRequirementsWhenNull(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = new Index();
@@ -183,7 +228,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithMethods(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = (new Index())->withMethods(['GET', 'POST']);
@@ -234,7 +278,6 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItCreatesRouteWithEmptyConditionWhenNotSet(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('books');
 
         $resource = new ResourceMetadata(alias: 'app.book');
         $operation = new Index();
@@ -251,9 +294,8 @@ final class OperationRouteFactoryTest extends TestCase
     public function testItUrlizesPluralName(): void
     {
         $metadata = $this->createMock(MetadataInterface::class);
-        $metadata->method('getPluralName')->willReturn('Book Categories');
 
-        $resource = new ResourceMetadata(alias: 'app.book_category');
+        $resource = new ResourceMetadata(alias: 'app.book_category', pluralName: 'Book Categories');
         $operation = new Index();
 
         $this->routePathFactory
@@ -265,5 +307,53 @@ final class OperationRouteFactoryTest extends TestCase
         $route = $this->operationRouteFactory->create($metadata, $resource, $operation);
 
         $this->assertSame('/book-categories', $route->getPath());
+    }
+
+    public function testItUrlizesPluralNameWithBcLayerEnabled(): void
+    {
+        $this->markAsSkippedIfBcLayerCannotBeEnabled();
+
+        $metadata = $this->createMock(MetadataInterface::class);
+        $metadata->method('getPluralName')->willReturn('Book Categories');
+
+        $resource = new ResourceMetadata(alias: 'app.book_category');
+        $operation = new Index();
+
+        $this->routePathFactory
+            ->expects($this->once())
+            ->method('createRoutePath')
+            ->with($operation, 'book-categories')
+            ->willReturn('/book-categories');
+
+        $route = $this->legacyOperationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertSame('/book-categories', $route->getPath());
+    }
+
+    public function testItUrlizesPluralNameUsingUnderscoreAsSeparator(): void
+    {
+        $operationRouteFactory = new OperationRouteFactory($this->routePathFactory, new UnderscorePathSegmentNameGenerator(), false);
+
+        $metadata = $this->createMock(MetadataInterface::class);
+
+        $resource = new ResourceMetadata(alias: 'app.book_category', pluralName: 'BookCategories');
+        $operation = new Index();
+
+        $this->routePathFactory
+            ->expects($this->once())
+            ->method('createRoutePath')
+            ->with($operation, 'book_categories')
+            ->willReturn('/book_categories');
+
+        $route = $operationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertSame('/book_categories', $route->getPath());
+    }
+
+    private function markAsSkippedIfBcLayerCannotBeEnabled(): void
+    {
+        if (!class_exists(Transliterator::class)) {
+            $this->markTestSkipped('This test requires The Behat Transliterator.');
+        }
     }
 }

--- a/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
@@ -42,7 +42,7 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
 
         $this->factory = new ResourceRouteCollectionFactory(
-            new OperationRouteFactory($this->routePathFactory),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
             new AttributesResourceMetadataCollectionFactory(
                 $this->resourceRegistry,
                 new OperationRouteNameFactory(),
@@ -94,6 +94,7 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
         $resource = new ResourceMetadata(
             alias: 'app.dummy',
             name: 'dummy',
+            pluralName: 'dummies',
             operations: [
                 'app_dummy_custom' => $nonHttpOperation,
                 'app_dummy_index' => $httpOperation,
@@ -113,7 +114,7 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
         $this->resourceRegistry->method('get')->with('app.dummy')->willReturn($metadata);
 
         $factory = new ResourceRouteCollectionFactory(
-            new OperationRouteFactory($this->routePathFactory),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
             $resourceMetadataFactory,
             $this->resourceRegistry,
         );

--- a/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/Resource/ResourceRouteCollectionFactoryTest.php
@@ -16,6 +16,7 @@ namespace Sylius\Resource\Tests\Symfony\Routing\Factory\Resource;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Resource\Tests\Dummy\DummyResourceWithOperations;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
 use Sylius\Resource\Metadata\MetadataInterface;
 use Sylius\Resource\Metadata\Operation;
 use Sylius\Resource\Metadata\RegistryInterface;
@@ -42,7 +43,7 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
 
         $this->factory = new ResourceRouteCollectionFactory(
-            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(new Inflector()), false),
             new AttributesResourceMetadataCollectionFactory(
                 $this->resourceRegistry,
                 new OperationRouteNameFactory(),
@@ -114,7 +115,7 @@ final class ResourceRouteCollectionFactoryTest extends TestCase
         $this->resourceRegistry->method('get')->with('app.dummy')->willReturn($metadata);
 
         $factory = new ResourceRouteCollectionFactory(
-            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(), false),
+            new OperationRouteFactory($this->routePathFactory, new Operation\DashPathSegmentNameGenerator(new Inflector()), false),
             $resourceMetadataFactory,
             $this->resourceRegistry,
         );

--- a/tests/Application/config/services.yaml
+++ b/tests/Application/config/services.yaml
@@ -69,23 +69,6 @@ services:
             - '%app.model.book_translation.class%'
         tags: ['form.type']
 
-    gedmo_doctrine_extensions.mapping.driver.attribute:
-        class: Gedmo\Mapping\Driver\AttributeReader
-        public: false
-
-    gedmo.listener.sortable:
-        class: Gedmo\Sortable\SortableListener
-        tags:
-            - { name: doctrine.event_listener, event: 'onFlush' }
-            - { name: doctrine.event_listener, event: 'loadClassMetadata' }
-            - { name: doctrine.event_listener, event: 'prePersist' }
-            - { name: doctrine.event_listener, event: 'postPersist' }
-            - { name: doctrine.event_listener, event: 'preUpdate' }
-            - { name: doctrine.event_listener, event: 'postRemove' }
-            - { name: doctrine.event_listener, event: 'postFlush' }
-        calls:
-            - [ setAnnotationReader, [ "@gedmo_doctrine_extensions.mapping.driver.attribute" ] ]
-
     App\Repository\ComicBookRepository: null
     App\Repository\LegacyBookRepository: null
 

--- a/tests/Application/config/services/integration/gedmo.yaml
+++ b/tests/Application/config/services/integration/gedmo.yaml
@@ -1,0 +1,19 @@
+services:
+    _defaults:
+        public: false
+
+    gedmo_doctrine_extensions.mapping.driver.attribute:
+        class: Gedmo\Mapping\Driver\AttributeReader
+
+    gedmo.listener.sortable:
+        class: Gedmo\Sortable\SortableListener
+        tags:
+            - { name: doctrine.event_listener, event: 'onFlush' }
+            - { name: doctrine.event_listener, event: 'loadClassMetadata' }
+            - { name: doctrine.event_listener, event: 'prePersist' }
+            - { name: doctrine.event_listener, event: 'postPersist' }
+            - { name: doctrine.event_listener, event: 'preUpdate' }
+            - { name: doctrine.event_listener, event: 'postRemove' }
+            - { name: doctrine.event_listener, event: 'postFlush' }
+        calls:
+            - [ setAnnotationReader, [ "@gedmo_doctrine_extensions.mapping.driver.attribute" ] ]

--- a/tests/Application/src/Kernel.php
+++ b/tests/Application/src/Kernel.php
@@ -15,8 +15,11 @@ namespace App;
 
 use App\Shared\Application\Command\CommandHandlerInterface;
 use App\Shared\Application\Query\QueryHandlerInterface;
+use Gedmo\Sluggable\Util\Urlizer;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 class Kernel extends BaseKernel
@@ -25,6 +28,8 @@ class Kernel extends BaseKernel
 
     protected function build(ContainerBuilder $container): void
     {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../config'));
+
         $container->registerForAutoconfiguration(QueryHandlerInterface::class)
             ->addTag('messenger.message_handler', ['bus' => 'query.bus'])
         ;
@@ -38,5 +43,14 @@ class Kernel extends BaseKernel
                 'enable_authenticator_manager' => true,
             ]);
         }
+
+        if (class_exists(Urlizer::class)) {
+            $this->configureAppWithGedmoDoctrineExtensions($loader);
+        }
+    }
+
+    private function configureAppWithGedmoDoctrineExtensions(YamlFileLoader $loader): void
+    {
+        $loader->load('services/integration/gedmo.yaml');
     }
 }

--- a/tests/Application/src/Tests/Controller/BlogPostApiTest.php
+++ b/tests/Application/src/Tests/Controller/BlogPostApiTest.php
@@ -31,7 +31,7 @@ final class BlogPostApiTest extends ApiTestCase
     {
         $this->markAsSkippedIfNecessary();
 
-        $this->client->request('POST', '/blog-posts/', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/blog-posts/' : 'blog-posts', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -174,5 +174,10 @@ final class BlogPostApiTest extends ApiTestCase
         if (ResourceBundleInterface::STATE_MACHINE_SYMFONY !== $stateMachine) {
             $this->markTestSkipped();
         }
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Application/src/Tests/Controller/BlogPostApiTest.php
+++ b/tests/Application/src/Tests/Controller/BlogPostApiTest.php
@@ -29,9 +29,34 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_blog_post(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/blog-posts/' : 'blog-posts', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+        $this->client->request('POST', 'blog-posts', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "current_place": {
+                    "draft": 1
+                }
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_creating_a_blog_post_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
+
+        $this->client->request('POST', '/blog-posts/', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -52,7 +77,7 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_allows_reviewing_a_blog_post(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
         $blogPost = BlogPostFactory::new()
             ->onDraft()
@@ -80,7 +105,7 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_allows_publishing_a_blog_post(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
         $blogPost = BlogPostFactory::new()
             ->reviewed()
@@ -108,7 +133,7 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_allows_rejecting_a_blog_post(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
         $blogPost = BlogPostFactory::new()
             ->reviewed()
@@ -136,7 +161,7 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_does_not_allow_to_publish_a_blog_post_with_draft_status(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
         $blogPost = BlogPostFactory::new()
             ->onDraft()
@@ -152,7 +177,7 @@ final class BlogPostApiTest extends ApiTestCase
     #[Test]
     public function it_does_not_allow_to_reject_a_blog_post_with_draft_status(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne();
 
         $blogPost = BlogPostFactory::new()
             ->onDraft()
@@ -165,7 +190,7 @@ final class BlogPostApiTest extends ApiTestCase
         $this->assertResponseHeaderSame('content-type', 'application/json');
     }
 
-    private function markAsSkippedIfNecessary(): void
+    private function markAsSkippedIfCurrentStateMachineIsNotTheSymfonyOne(): void
     {
         $container = self::getContainer();
 
@@ -179,5 +204,19 @@ final class BlogPostApiTest extends ApiTestCase
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 }

--- a/tests/Application/src/Tests/Controller/BookApiTest.php
+++ b/tests/Application/src/Tests/Controller/BookApiTest.php
@@ -32,7 +32,8 @@ class BookApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_book(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $data =
 <<<EOT
@@ -46,7 +47,42 @@ class BookApiTest extends ApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', '/books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "title":"Star Wars: Dark Disciple", 
+                "author":"Christie Golden"
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_creating_a_book_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        $data =
+            <<<EOT
+        {
+            "translations": {
+                "en_US": {
+                    "title": "Star Wars: Dark Disciple"
+                }
+            },
+            "author": "Christie Golden"
+        }
+EOT;
+
+        $this->client->request('POST', '/books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -138,7 +174,7 @@ EOT;
     #[Test]
     public function it_allows_showing_a_book(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $book = BookFactory::new()
             ->withTranslations([
@@ -173,11 +209,29 @@ EOT;
     #[Test]
     public function it_allows_indexing_books(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         DefaultBooksStory::load();
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books');
+        $this->client->request('GET', '/books');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesDefaultBooksIndex();
+    }
+
+    #[Test]
+    public function it_allows_indexing_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        DefaultBooksStory::load();
+
+        $this->client->request('GET', '/books/');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
@@ -189,11 +243,29 @@ EOT;
     #[Test]
     public function it_allows_paginating_the_index_of_books(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         MoreBooksStory::load();
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books', ['page' => 2]);
+        $this->client->request('GET', '/books', ['page' => 2]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesMoreBooksIndexPage2();
+    }
+
+    #[Test]
+    public function it_allows_paginating_the_index_of_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        MoreBooksStory::load();
+
+        $this->client->request('GET', '/books/', ['page' => 2]);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
@@ -205,7 +277,7 @@ EOT;
     #[Test]
     public function it_does_not_allow_showing_resource_if_it_not_exists(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $this->client->request('GET', '/books/3');
 
@@ -215,7 +287,7 @@ EOT;
     #[Test]
     public function it_does_not_apply_sorting_for_non_existing_field(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         MoreBooksStory::load();
 
@@ -231,7 +303,7 @@ EOT;
     #[Test]
     public function it_does_not_apply_filtering_for_non_existing_field(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         MoreBooksStory::load();
 
@@ -247,7 +319,7 @@ EOT;
     #[Test]
     public function it_applies_sorting_for_existing_field(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         MoreBooksStory::load();
 
@@ -339,7 +411,7 @@ EOT;
     #[Test]
     public function it_applies_filtering_for_existing_field(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         MoreBooksStory::load();
         BookFactory::new()->withAuthor('J.R.R. Tolkien')->create();
@@ -383,7 +455,7 @@ EOT;
     #[Test]
     public function it_allows_creating_a_book_via_custom_factory(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $data =
             <<<'JSON'
@@ -418,7 +490,7 @@ EOT;
     #[Test]
     public function it_allows_indexing_books_via_custom_repository(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         DefaultBooksStory::load();
 
@@ -434,7 +506,7 @@ EOT;
     #[Test]
     public function it_allows_showing_a_book_via_custom_repository(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         DefaultBooksStory::load();
 
@@ -661,20 +733,29 @@ EOT;
         );
     }
 
-    private function markAsSkippedIfNecessary(): void
+    private function markAsSkippedIfHateoasIsNotAvailable(): void
     {
         if ('test_without_hateoas' === self::getContainer()->get('kernel')->getEnvironment()) {
             $this->markTestSkipped();
         }
     }
 
-    public function assert()
-    {
-        return $this->assertEquals();
-    }
-
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 }

--- a/tests/Application/src/Tests/Controller/BookApiTest.php
+++ b/tests/Application/src/Tests/Controller/BookApiTest.php
@@ -46,7 +46,7 @@ class BookApiTest extends ApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -177,7 +177,7 @@ EOT;
 
         DefaultBooksStory::load();
 
-        $this->client->request('GET', '/books/');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
@@ -193,7 +193,7 @@ EOT;
 
         MoreBooksStory::load();
 
-        $this->client->request('GET', '/books/', ['page' => 2]);
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books', ['page' => 2]);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
@@ -671,5 +671,10 @@ EOT;
     public function assert()
     {
         return $this->assertEquals();
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Application/src/Tests/Controller/ComicBookApiTest.php
+++ b/tests/Application/src/Tests/Controller/ComicBookApiTest.php
@@ -42,7 +42,7 @@ final class ComicBookApiTest extends ApiTestCase
             JSON
         ;
 
-        $this->client->request('POST', '/v1/comic-books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/v1/comic-books/' : '/v1/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -79,7 +79,7 @@ final class ComicBookApiTest extends ApiTestCase
             JSON
         ;
 
-        $this->client->request('POST', '/v1.2/comic-books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/v1.2/comic-books/' : '/v1.2/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -214,14 +214,16 @@ EOT;
 
         DefaultComicBooksStory::load();
 
-        $this->client->request('GET', '/v1/comic-books/');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/v1/comic-books/' : '/v1/comic-books');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseHeaderSame('content-type', 'application/json');
 
+        $selfHref = $this->isRoutingPathBcLayerEnabled() ? "\/v1\/comic-books\/?page=1&limit=10" : "\/v1\/comic-books?page=1&limit=10";
+
         $this->assertResponseMatchesPattern(
-            <<<'JSON'
+            <<<JSON
             {
                 "page": 1,
                 "limit": 10,
@@ -229,13 +231,13 @@ EOT;
                 "total": 2,
                 "_links": {
                     "self": {
-                        "href": "\/v1\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     },
                     "first": {
-                        "href": "\/v1\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     },
                     "last": {
-                        "href": "\/v1\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     }
                 },
                 "_embedded": {
@@ -270,14 +272,16 @@ EOT;
 
         DefaultComicBooksStory::load();
 
-        $this->client->request('GET', '/v1.2/comic-books/');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/v1.2/comic-books/' : 'v1.2/comic-books');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseHeaderSame('content-type', 'application/json');
 
+        $selfHref = $this->isRoutingPathBcLayerEnabled() ? "\/v1.2\/comic-books\/?page=1&limit=10" : "\/v1.2\/comic-books?page=1&limit=10";
+
         $this->assertResponseMatchesPattern(
-            <<<'JSON'
+            <<<JSON
             {
                 "page": 1,
                 "limit": 10,
@@ -285,13 +289,13 @@ EOT;
                 "total": 2,
                 "_links": {
                     "self": {
-                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     },
                     "first": {
-                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     },
                     "last": {
-                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
+                        "href": "{$selfHref}"
                     }
                 },
                 "_embedded": {
@@ -340,5 +344,10 @@ EOT;
                 ->withLastName('Sorrentino'),
             )
         ;
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Application/src/Tests/Controller/ComicBookApiTest.php
+++ b/tests/Application/src/Tests/Controller/ComicBookApiTest.php
@@ -30,6 +30,8 @@ final class ComicBookApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_comic_book(): void
     {
+        $this->markAsSkippedIfBcLayerIsEnabled();
+
         $data =
             <<<'JSON'
             {
@@ -42,7 +44,44 @@ final class ComicBookApiTest extends ApiTestCase
             JSON
         ;
 
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/v1/comic-books/' : '/v1/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', '/v1/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "author": {
+                    "first_name": "Joe",
+                    "last_name": "Kelly"
+                },
+                "title": "Deadpool #1-69"
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_creating_a_comic_book_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+
+        $data =
+            <<<'JSON'
+            {
+                "title": "Deadpool #1-69",
+                "author": {
+                    "firstName": "Joe",
+                    "lastName": "Kelly"
+                }
+            }
+            JSON
+        ;
+
+        $this->client->request('POST', '/v1/comic-books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -65,7 +104,8 @@ final class ComicBookApiTest extends ApiTestCase
     #[Test]
     public function it_allows_versioned_creating_a_comic_book(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $data =
             <<<'JSON'
@@ -79,7 +119,43 @@ final class ComicBookApiTest extends ApiTestCase
             JSON
         ;
 
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/v1.2/comic-books/' : '/v1.2/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', '/v1.2/comic-books', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "author_first_name": "Joe",
+                "author_last_name": "Kelly",
+                "title": "Deadpool #1-69"
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_versioned_creating_a_comic_book_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        $data =
+            <<<'JSON'
+            {
+                "title": "Deadpool #1-69",
+                "author": {
+                    "firstName": "Joe",
+                    "lastName": "Kelly"
+                }
+            }
+            JSON
+        ;
+
+        $this->client->request('POST', '/v1.2/comic-books/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -185,7 +261,7 @@ EOT;
     #[Test]
     public function it_allows_versioning_of_a_showing_comic_book_serialization(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         $comicBook = self::someComicBook()->create();
 
@@ -210,20 +286,19 @@ EOT;
     #[Test]
     public function it_allows_indexing_of_comic_books(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         DefaultComicBooksStory::load();
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/v1/comic-books/' : '/v1/comic-books');
+        $this->client->request('GET', '/v1/comic-books');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseHeaderSame('content-type', 'application/json');
 
-        $selfHref = $this->isRoutingPathBcLayerEnabled() ? "\/v1\/comic-books\/?page=1&limit=10" : "\/v1\/comic-books?page=1&limit=10";
-
         $this->assertResponseMatchesPattern(
-            <<<JSON
+            <<<'JSON'
             {
                 "page": 1,
                 "limit": 10,
@@ -231,13 +306,70 @@ EOT;
                 "total": 2,
                 "_links": {
                     "self": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1\/comic-books?page=1&limit=10"
                     },
                     "first": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1\/comic-books?page=1&limit=10"
                     },
                     "last": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1\/comic-books?page=1&limit=10"
+                    }
+                },
+                "_embedded": {
+                    "items": [
+                        {
+                            "id": @integer@,
+                            "author": {
+                                "first_name": "Andrea",
+                                "last_name": "Sorrentino"
+                            },
+                            "title": "Old Man Logan"
+                        },
+                        {
+                            "id": @integer@,
+                            "author": {
+                                "first_name": "Brian Michael",
+                                "last_name": "Bendis"
+                            },
+                            "title": "Civil War II"
+                        }
+                    ]
+                }
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_indexing_of_comic_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        DefaultComicBooksStory::load();
+
+        $this->client->request('GET', '/v1/comic-books/');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "page": 1,
+                "limit": 10,
+                "pages": 1,
+                "total": 2,
+                "_links": {
+                    "self": {
+                        "href": "\/v1\/comic-books\/?page=1&limit=10"
+                    },
+                    "first": {
+                        "href": "\/v1\/comic-books\/?page=1&limit=10"
+                    },
+                    "last": {
+                        "href": "\/v1\/comic-books\/?page=1&limit=10"
                     }
                 },
                 "_embedded": {
@@ -268,17 +400,69 @@ EOT;
     #[Test]
     public function it_allows_versioned_indexing_of_comic_books(): void
     {
-        $this->markAsSkippedIfNecessary();
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
 
         DefaultComicBooksStory::load();
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/v1.2/comic-books/' : 'v1.2/comic-books');
+        $this->client->request('GET', 'v1.2/comic-books');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseHeaderSame('content-type', 'application/json');
 
-        $selfHref = $this->isRoutingPathBcLayerEnabled() ? "\/v1.2\/comic-books\/?page=1&limit=10" : "\/v1.2\/comic-books?page=1&limit=10";
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "page": 1,
+                "limit": 10,
+                "pages": 1,
+                "total": 2,
+                "_links": {
+                    "self": {
+                        "href": "\/v1.2\/comic-books?page=1&limit=10"
+                    },
+                    "first": {
+                        "href": "\/v1.2\/comic-books?page=1&limit=10"
+                    },
+                    "last": {
+                        "href": "\/v1.2\/comic-books?page=1&limit=10"
+                    }
+                },
+                "_embedded": {
+                  "items": [
+                    {
+                      "id": @integer@,
+                      "author_first_name": "Andrea",
+                      "author_last_name": "Sorrentino",
+                      "title": "Old Man Logan"
+                    },
+                    {
+                      "id": @integer@,
+                      "author_first_name": "Brian Michael",
+                      "author_last_name": "Bendis",
+                      "title": "Civil War II"
+                    }
+                  ]
+                }
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_versioned_indexing_of_comic_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfHateoasIsNotAvailable();
+
+        DefaultComicBooksStory::load();
+
+        $this->client->request('GET', '/v1.2/comic-books/');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
 
         $this->assertResponseMatchesPattern(
             <<<JSON
@@ -289,13 +473,13 @@ EOT;
                 "total": 2,
                 "_links": {
                     "self": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
                     },
                     "first": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
                     },
                     "last": {
-                        "href": "{$selfHref}"
+                        "href": "\/v1.2\/comic-books\/?page=1&limit=10"
                     }
                 },
                 "_embedded": {
@@ -327,7 +511,7 @@ EOT;
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
-    private function markAsSkippedIfNecessary(): void
+    private function markAsSkippedIfHateoasIsNotAvailable(): void
     {
         if ('test_without_hateoas' === self::getContainer()->get('kernel')->getEnvironment()) {
             $this->markTestSkipped();
@@ -349,5 +533,19 @@ EOT;
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 }

--- a/tests/Application/src/Tests/Controller/GedmoApiTest.php
+++ b/tests/Application/src/Tests/Controller/GedmoApiTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Controller;
 
+use Gedmo\Sortable\SortableListener;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\ApiTestCase;
@@ -25,6 +26,7 @@ final class GedmoApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_comic_book(): void
     {
+        $this->markAsSkippedIfBcLayerIsEnabled();
         $this->markAsSkippedIfGedmoDoctrineExtensionsIsNotAvailable();
 
         $data =
@@ -34,7 +36,37 @@ final class GedmoApiTest extends ApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/gedmos/' : '/gedmos', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', '/gedmos', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "position": 0,
+                "extra": "Some info"
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_creating_a_comic_book_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->markAsSkippedIfGedmoDoctrineExtensionsIsNotAvailable();
+
+        $data =
+            <<<EOT
+        {
+            "extra": "Some info"
+        }
+EOT;
+
+        $this->client->request('POST', '/gedmos/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -54,6 +86,20 @@ EOT;
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 
     private function markAsSkippedIfGedmoDoctrineExtensionsIsNotAvailable(): void

--- a/tests/Application/src/Tests/Controller/GedmoApiTest.php
+++ b/tests/Application/src/Tests/Controller/GedmoApiTest.php
@@ -25,6 +25,8 @@ final class GedmoApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_comic_book(): void
     {
+        $this->markAsSkippedIfGedmoDoctrineExtensionsIsNotAvailable();
+
         $data =
 <<<EOT
         {
@@ -32,7 +34,7 @@ final class GedmoApiTest extends ApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/gedmos/', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/gedmos/' : '/gedmos', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -47,5 +49,17 @@ EOT;
             }
             JSON
         );
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfGedmoDoctrineExtensionsIsNotAvailable(): void
+    {
+        if (!class_exists(SortableListener::class)) {
+            $this->markTestSkipped('Gedmo Doctrine Extension is not available.');
+        }
     }
 }

--- a/tests/Application/src/Tests/Controller/PullRequestApiTest.php
+++ b/tests/Application/src/Tests/Controller/PullRequestApiTest.php
@@ -28,7 +28,7 @@ final class PullRequestApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_pull_request(): void
     {
-        $this->client->request('POST', '/pull-requests/', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/pull-requests/' : '/pull-requests', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -104,5 +104,10 @@ final class PullRequestApiTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertResponseHeaderSame('content-type', 'application/json');
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Application/src/Tests/Controller/PullRequestApiTest.php
+++ b/tests/Application/src/Tests/Controller/PullRequestApiTest.php
@@ -28,7 +28,28 @@ final class PullRequestApiTest extends ApiTestCase
     #[Test]
     public function it_allows_creating_a_pull_request(): void
     {
-        $this->client->request('POST', $this->isRoutingPathBcLayerEnabled() ? '/pull-requests/' : '/pull-requests', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+        $this->markAsSkippedIfBcLayerIsEnabled();
+        $this->client->request('POST', '/pull-requests', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertResponseHeaderSame('content-type', 'application/json');
+
+        $this->assertResponseMatchesPattern(
+            <<<'JSON'
+            {
+                "id": @integer@,
+                "current_place": "start"
+            }
+            JSON
+        );
+    }
+
+    #[Test]
+    public function it_allows_creating_a_pull_request_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+        $this->client->request('POST', '/pull-requests/', [], [], ['CONTENT_TYPE' => 'application/json'], '{}');
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -109,5 +130,19 @@ final class PullRequestApiTest extends ApiTestCase
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 }

--- a/tests/Application/src/Tests/Controller/ScienceBookUiTest.php
+++ b/tests/Application/src/Tests/Controller/ScienceBookUiTest.php
@@ -83,7 +83,7 @@ final class ScienceBookUiTest extends WebTestCase
             ->create()
         ;
 
-        $this->client->request('GET', '/science-books/');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/' : '/science-books');
         $response = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -201,7 +201,7 @@ final class ScienceBookUiTest extends WebTestCase
     {
         ScienceBookFactory::createOne();
 
-        $this->client->request('GET', '/science-books/');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/' : '/science-books');
         $this->client->submitForm('Delete');
 
         $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);
@@ -235,7 +235,7 @@ final class ScienceBookUiTest extends WebTestCase
             ->create()
         ;
 
-        $this->client->request('GET', '/science-books/?criteria[search][value]=history of time');
+        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/?criteria[search][value]=history of time' : '/science-books?criteria[search][value]=history of time');
         $response = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(expectedCode: Response::HTTP_OK);
@@ -249,5 +249,10 @@ final class ScienceBookUiTest extends WebTestCase
             sprintf('<td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td>', $secondBook->getId()),
             $content,
         );
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Application/src/Tests/Controller/ScienceBookUiTest.php
+++ b/tests/Application/src/Tests/Controller/ScienceBookUiTest.php
@@ -63,6 +63,8 @@ final class ScienceBookUiTest extends WebTestCase
     #[Test]
     public function it_allows_indexing_books(): void
     {
+        $this->markAsSkippedIfBcLayerIsEnabled();
+
         $firstBook = ScienceBookFactory::new()
             ->withTitle('A Brief History of Time')
             ->withAuthor(
@@ -83,7 +85,50 @@ final class ScienceBookUiTest extends WebTestCase
             ->create()
         ;
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/' : '/science-books');
+        $this->client->request('GET', '/science-books');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = $response->getContent();
+        $this->assertStringContainsString('<h1>Books</h1>', $content);
+        $this->assertStringContainsString(
+            sprintf('<td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td>', $firstBook->getId()),
+            $content,
+        );
+        $this->assertStringContainsString(
+            sprintf('<td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td>', $secondBook->getId()),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function it_allows_indexing_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+
+        $firstBook = ScienceBookFactory::new()
+            ->withTitle('A Brief History of Time')
+            ->withAuthor(
+                AuthorFactory::new()
+                    ->withFirstName('Stephen')
+                    ->withLastName('Hawking'),
+            )
+            ->create()
+        ;
+
+        $secondBook = ScienceBookFactory::new()
+            ->withTitle('The Future of Humanity')
+            ->withAuthor(
+                AuthorFactory::new()
+                    ->withFirstName('Michio')
+                    ->withLastName('Kaku'),
+            )
+            ->create()
+        ;
+
+        $this->client->request('GET', '/science-books/');
         $response = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -199,9 +244,29 @@ final class ScienceBookUiTest extends WebTestCase
     #[Test]
     public function it_allows_deleting_a_book(): void
     {
+        $this->markAsSkippedIfBcLayerIsEnabled();
+
         ScienceBookFactory::createOne();
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/' : '/science-books');
+        $this->client->request('GET', '/science-books');
+        $this->client->submitForm('Delete');
+
+        $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);
+
+        /** @var ScienceBook[] $books */
+        $books = static::getContainer()->get('app.repository.science_book')->findAll();
+
+        $this->assertEmpty($books);
+    }
+
+    #[Test]
+    public function it_allows_deleting_a_book_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+
+        ScienceBookFactory::createOne();
+
+        $this->client->request('GET', '/science-books/');
         $this->client->submitForm('Delete');
 
         $this->assertResponseRedirects(null, expectedCode: Response::HTTP_FOUND);
@@ -215,6 +280,8 @@ final class ScienceBookUiTest extends WebTestCase
     #[Test]
     public function it_allows_filtering_books(): void
     {
+        $this->markAsSkippedIfBcLayerIsEnabled();
+
         $firstBook = ScienceBookFactory::new()
             ->withTitle('A Brief History of Time')
             ->withAuthor(
@@ -235,7 +302,48 @@ final class ScienceBookUiTest extends WebTestCase
             ->create()
         ;
 
-        $this->client->request('GET', $this->isRoutingPathBcLayerEnabled() ? '/science-books/?criteria[search][value]=history of time' : '/science-books?criteria[search][value]=history of time');
+        $this->client->request('GET', '/science-books?criteria[search][value]=history of time');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseStatusCodeSame(expectedCode: Response::HTTP_OK);
+        $content = $response->getContent();
+        $this->assertStringContainsString('<h1>Books</h1>', $content);
+        $this->assertStringContainsString(
+            sprintf('<td>%d</td><td>A Brief History of Time</td><td>Stephen Hawking</td>', $firstBook->getId()),
+            $content,
+        );
+        $this->assertStringNotContainsString(
+            sprintf('<td>%d</td><td>The Future of Humanity</td><td>Michio Kaku</td>', $secondBook->getId()),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function it_allows_filtering_books_with_bc_layer(): void
+    {
+        $this->markAsSkippedIfBcLayerIsNotEnabled();
+
+        $firstBook = ScienceBookFactory::new()
+            ->withTitle('A Brief History of Time')
+            ->withAuthor(
+                AuthorFactory::new()
+                    ->withFirstName('Stephen')
+                    ->withLastName('Hawking'),
+            )
+            ->create()
+        ;
+
+        $secondBook = ScienceBookFactory::new()
+            ->withTitle('The Future of Humanity')
+            ->withAuthor(
+                AuthorFactory::new()
+                    ->withFirstName('Michio')
+                    ->withLastName('Kaku'),
+            )
+            ->create()
+        ;
+
+        $this->client->request('GET', '/science-books/?criteria[search][value]=history of time');
         $response = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(expectedCode: Response::HTTP_OK);
@@ -254,5 +362,19 @@ final class ScienceBookUiTest extends WebTestCase
     private function isRoutingPathBcLayerEnabled(): bool
     {
         return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
+    }
+
+    private function markAsSkippedIfBcLayerIsEnabled(): void
+    {
+        if ($this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be disabled.');
+        }
+    }
+
+    private function markAsSkippedIfBcLayerIsNotEnabled(): void
+    {
+        if (!$this->isRoutingPathBcLayerEnabled()) {
+            $this->markTestSkipped('This test requires The BC layer to be enabled.');
+        }
     }
 }

--- a/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
@@ -18,7 +18,9 @@ use App\Entity\BookTranslation;
 use App\Entity\ComicBook;
 use App\Factory\BookFactory;
 use App\Form\Type\BookType;
+use Behat\Transliterator\Transliterator;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 use Sylius\Bundle\ResourceBundle\Doctrine\ResourceMappingDriverChain;
@@ -30,7 +32,8 @@ use Sylius\Resource\Doctrine\Common\State\PersistProcessor;
 use Sylius\Resource\Doctrine\Common\State\RemoveProcessor;
 use Sylius\Resource\Factory\Factory;
 
-class SyliusResourceExtensionTest extends AbstractExtensionTestCase
+#[CoversClass(SyliusResourceExtension::class)]
+final class SyliusResourceExtensionTest extends AbstractExtensionTestCase
 {
     /** @test */
     public function it_registers_services_and_parameters_for_resources(): void
@@ -77,9 +80,9 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
     public function it_registers_default_translation_parameters(): void
     {
         $this->load([
-             'translation' => [
-                 'locale_provider' => 'test.custom_locale_provider',
-             ],
+            'translation' => [
+                'locale_provider' => 'test.custom_locale_provider',
+            ],
          ]);
 
         $this->assertContainerBuilderHasAlias('sylius.translation_locale_provider', 'test.custom_locale_provider');
@@ -210,6 +213,57 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
         $emptyPhpFile = realpath(__DIR__ . '/php/empty_file.php');
         $this->assertContainerBuilderHasService('sylius.metadata.resource_extractor.php_file');
         $this->assertSame([$emptyPhpFile], $this->container->getDefinition('sylius.metadata.resource_extractor.php_file')->getArgument(0));
+    }
+
+    public function testItRegistersRoutingPathBcLayerAutomatically(): void
+    {
+        $this->load();
+
+        if (class_exists(Transliterator::class)) {
+            $this->assertTrue($this->container->getParameter('sylius.routing_path_bc_layer'));
+
+            return;
+        }
+
+        $this->assertFalse($this->container->getParameter('sylius.routing_path_bc_layer'));
+    }
+
+    public function testRoutingPathBcLayerCanBeEnabled(): void
+    {
+        if (!class_exists(Transliterator::class)) {
+            $this->markTestSkipped('This test requires Transliterator.');
+        }
+
+        $this->load([
+            'routing_path_bc_layer' => true,
+        ]);
+
+        $this->assertTrue($this->container->getParameter('sylius.routing_path_bc_layer'));
+    }
+
+    public function testRoutingPathBcLayerCanBeDisabled(): void
+    {
+        $this->load([
+            'routing_path_bc_layer' => false,
+        ]);
+
+        $this->assertFalse($this->container->getParameter('sylius.routing_path_bc_layer'));
+    }
+
+    public function testItRegistersDashPathSegmentNameGeneratorByDefault(): void
+    {
+        $this->load();
+
+        $this->assertSame('sylius.metadata.path_segment_name_generator.dash', $this->container->getAlias('sylius.path_segment_name_generator')->__toString());
+    }
+
+    public function testItRegistersCustomPathSegmentNameGenerator(): void
+    {
+        $this->load([
+            'path_segment_name_generator' => 'sylius.metadata.path_segment_name_generator.underscore',
+        ]);
+
+        $this->assertSame('sylius.metadata.path_segment_name_generator.underscore', $this->container->getAlias('sylius.path_segment_name_generator')->__toString());
     }
 
     protected function getContainerExtensions(): array

--- a/tests/Bundle/Routing/CrudRoutesAttributesLoaderTest.php
+++ b/tests/Bundle/Routing/CrudRoutesAttributesLoaderTest.php
@@ -33,7 +33,7 @@ final class CrudRoutesAttributesLoaderTest extends KernelTestCase
         // Test index
         $bookIndex = $routesCollection->get('app_book_index');
         $this->assertNotNull($bookIndex);
-        $this->assertEquals('/books/', $bookIndex->getPath());
+        $this->assertEquals($this->isRoutingPathBcLayerEnabled() ? '/books/' : '/books', $bookIndex->getPath());
         $this->assertEquals(['GET'], $bookIndex->getMethods());
         $this->assertEquals([
             '_controller' => 'app.controller.book::indexAction',
@@ -69,7 +69,7 @@ final class CrudRoutesAttributesLoaderTest extends KernelTestCase
         // Test update
         $bookUpdate = $routesCollection->get('app_book_update');
         $this->assertNotNull($bookUpdate);
-        $this->assertEquals(['GET', 'PUT', 'PATCH'], $bookUpdate->getMethods());
+        $this->assertEquals($this->isRoutingPathBcLayerEnabled() ? ['GET', 'PUT', 'PATCH'] : ['GET', 'PUT', 'PATCH', 'POST'], $bookUpdate->getMethods());
         $this->assertEquals('/books/{id}/edit', $bookUpdate->getPath());
         $this->assertEquals([
             '_controller' => 'app.controller.book::updateAction',
@@ -81,8 +81,8 @@ final class CrudRoutesAttributesLoaderTest extends KernelTestCase
         // Test delete
         $bookDelete = $routesCollection->get('app_book_delete');
         $this->assertNotNull($bookDelete);
-        $this->assertEquals('/books/{id}', $bookDelete->getPath());
-        $this->assertEquals(['DELETE'], $bookDelete->getMethods());
+        $this->assertEquals($this->isRoutingPathBcLayerEnabled() ? '/books/{id}' : '/books/{id}/delete', $bookDelete->getPath());
+        $this->assertEquals($this->isRoutingPathBcLayerEnabled() ? ['DELETE'] : ['DELETE', 'POST'], $bookDelete->getMethods());
         $this->assertEquals([
             '_controller' => 'app.controller.book::deleteAction',
             '_sylius' => [
@@ -605,5 +605,10 @@ final class CrudRoutesAttributesLoaderTest extends KernelTestCase
         // Test create
         $bookCreate = $routesCollection->get(sprintf('app_%s_book_create', $section));
         $this->assertNotNull($bookCreate);
+    }
+
+    private function isRoutingPathBcLayerEnabled(): bool
+    {
+        return (bool) $this->getContainer()->getParameter('sylius.routing_path_bc_layer');
     }
 }

--- a/tests/Bundle/Routing/ResourceLoaderTest.php
+++ b/tests/Bundle/Routing/ResourceLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\Routing;
 
+use Behat\Transliterator\Transliterator;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ResourceBundle\Routing\ResourceLoader;
 use Sylius\Bundle\ResourceBundle\Routing\RouteFactoryInterface;
@@ -225,6 +226,8 @@ YAML;
 
     public function testItGeneratesRoutingWithBcLayerEnabled(): void
     {
+        $this->markAsSkippedIfBcLayerCannotBeEnabled();
+
         $loader = $this->createLoaderWithMockedDependencies(true);
 
         $resource = <<<YAML
@@ -261,6 +264,8 @@ YAML;
 
     public function testItGeneratesBulkDeleteRoutingWithBcLayerEnabled(): void
     {
+        $this->markAsSkippedIfBcLayerCannotBeEnabled();
+
         $loader = $this->createLoaderWithMockedDependencies(true);
 
         $resource = <<<YAML
@@ -331,5 +336,12 @@ YAML;
         $this->assertArrayHasKey('_sylius', $route->getDefaults());
         $this->assertArrayHasKey($key, $route->getDefaults()['_sylius']);
         $this->assertEquals($expectedValue, $route->getDefaults()['_sylius'][$key]);
+    }
+
+    private function markAsSkippedIfBcLayerCannotBeEnabled(): void
+    {
+        if (!class_exists(Transliterator::class)) {
+            $this->markTestSkipped('This test requires The Behat Transliterator.');
+        }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Behat transliteration is deprecated. It's not maintained anymore.
I reused the `routing_path_bc_layer` that we introduced in this branch that have no release yet.

Why reusing this one? Cause it might have a difference in the plurialization. So it could lead to a path change.

- [x] Configure default plural name on resource in a metadata factory without using legacy MetadataInterface.