### PR TITLE
Add new reflection system for class names

### DIFF
--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -32,6 +32,7 @@ use Sylius\Resource\Metadata\OperationMutatorInterface;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\ResourceMutatorInterface;
 use Sylius\Resource\Reflection\ClassReflection;
+use Sylius\Resource\Reflection\ReflectionClassRecursiveIterator;
 use Sylius\Resource\State\ProcessorInterface;
 use Sylius\Resource\State\ProviderInterface;
 use Sylius\Resource\State\ResponderInterface;
@@ -182,8 +183,8 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
         $mapping = $container->getParameter('sylius.resource.mapping');
         $paths = $mapping['paths'] ?? [];
 
-        /** @var class-string $className */
-        foreach (ClassReflection::getResourcesByPaths($paths) as $className) {
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($paths) as $reflectionClass) {
+            $className = $reflectionClass->getName();
             $resourceAttributes = ClassReflection::getClassAttributes($className, AsResource::class);
 
             foreach ($resourceAttributes as $resourceAttribute) {

--- a/src/Bundle/Routing/CrudRoutesAttributesLoader.php
+++ b/src/Bundle/Routing/CrudRoutesAttributesLoader.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Routing;
 use Sylius\Component\Resource\Annotation\SyliusCrudRoutes as LegacySyliusCrudRoutes;
 use Sylius\Resource\Annotation\SyliusCrudRoutes;
 use Sylius\Resource\Reflection\ClassReflection;
+use Sylius\Resource\Reflection\ReflectionClassRecursiveIterator;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Yaml\Yaml;
@@ -39,7 +40,8 @@ final class CrudRoutesAttributesLoader implements RouteLoaderInterface
         $routeCollection = new RouteCollection();
         $paths = $this->mapping['paths'] ?? [];
 
-        foreach (ClassReflection::getResourcesByPaths($paths) as $className) {
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($paths) as $reflectionClass) {
+            $className = $reflectionClass->getName();
             $this->addRoutesForSyliusCrudRoutesAttributes($routeCollection, $className);
         }
 

--- a/src/Bundle/Routing/RoutesAttributesLoader.php
+++ b/src/Bundle/Routing/RoutesAttributesLoader.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Routing;
 
-use Sylius\Resource\Reflection\ClassReflection;
+use Sylius\Resource\Reflection\ReflectionClassRecursiveIterator;
 use Sylius\Resource\Symfony\Routing\Factory\AttributesOperationRouteFactoryInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
@@ -35,7 +35,8 @@ final class RoutesAttributesLoader implements RouteLoaderInterface
         $routeCollection = new RouteCollection();
         $paths = $this->mapping['paths'] ?? [];
 
-        foreach (ClassReflection::getResourcesByPaths($paths) as $className) {
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($paths) as $reflectionClass) {
+            $className = $reflectionClass->getName();
             $this->routesAttributesFactory->createRouteForClass($routeCollection, $className);
             $this->attributesOperationRouteFactory->createRouteForClass($routeCollection, $className);
         }

--- a/src/Component/src/Metadata/Resource/Factory/AttributesResourceClassListFactory.php
+++ b/src/Component/src/Metadata/Resource/Factory/AttributesResourceClassListFactory.php
@@ -16,6 +16,7 @@ namespace Sylius\Resource\Metadata\Resource\Factory;
 use Sylius\Resource\Metadata\AsResource;
 use Sylius\Resource\Metadata\Resource\ResourceClassList;
 use Sylius\Resource\Reflection\ClassReflection;
+use Sylius\Resource\Reflection\ReflectionClassRecursiveIterator;
 
 /**
  * Creates a resource class list from {@see AsResource} attributes.
@@ -46,7 +47,9 @@ final class AttributesResourceClassListFactory implements ResourceClassListFacto
 
         $paths = $this->mapping['paths'] ?? [];
 
-        foreach (ClassReflection::getResourcesByPaths($paths) as $resourceClass) {
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($paths) as $reflectionClass) {
+            $resourceClass = $reflectionClass->getName();
+
             if ([] === ClassReflection::getClassAttributes($resourceClass, AsResource::class)) {
                 continue;
             }

--- a/src/Component/src/Reflection/ClassReflection.php
+++ b/src/Component/src/Reflection/ClassReflection.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Reflection;
 
-use Symfony\Component\Finder\Finder;
-
 final class ClassReflection
 {
     /**
@@ -22,47 +20,24 @@ final class ClassReflection
      */
     public static function getResourcesByPaths(array $paths): iterable
     {
-        foreach ($paths as $resourceDirectory) {
-            $resources = self::getResourcesByPath($resourceDirectory);
+        trigger_deprecation('sylius/resource-bundle', '1.14', 'The method "%s" is deprecated, use "%s::%s" instead.', __METHOD__, ReflectionClassRecursiveIterator::class, 'getReflectionClassesFromDirectories');
 
-            foreach ($resources as $className) {
-                yield $className;
-            }
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories($paths) as $reflectionClass) {
+            yield $reflectionClass->getName();
         }
     }
 
     public static function getResourcesByPath(string $path): iterable
     {
-        $finder = new Finder();
-        $finder->files()->in($path)->name('*.php')->sortByName(true);
+        trigger_deprecation('sylius/resource-bundle', '1.14', 'The method "%s" is deprecated, use "%s::%s" instead.', __METHOD__, ReflectionClassRecursiveIterator::class, 'getReflectionClassesFromDirectories');
 
-        foreach ($finder as $file) {
-            $fileContent = file_get_contents((string) $file->getRealPath());
-            if (false === $fileContent) {
-                throw new \RuntimeException(sprintf('Unable to read "%s" file', $file->getRealPath()));
-            }
-
-            preg_match('/namespace (.+);/', $fileContent, $matches);
-
-            $namespace = $matches[1] ?? null;
-
-            if (!preg_match('/class\s+(\w+)/', $fileContent, $matches)) {
-                // no class found
-                continue;
-            }
-
-            $className = trim($matches[1]);
-
-            if (null !== $namespace) {
-                yield $namespace . '\\' . $className;
-            } else {
-                yield $className;
-            }
+        foreach (ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([$path]) as $reflectionClass) {
+            yield $reflectionClass->getName();
         }
     }
 
     /**
-     * @psalm-param class-string $className
+     * @param class-string $className
      *
      * @return \ReflectionAttribute[]
      */

--- a/src/Component/src/Reflection/ReflectionClassRecursiveIterator.php
+++ b/src/Component/src/Reflection/ReflectionClassRecursiveIterator.php
@@ -16,6 +16,10 @@ namespace Sylius\Resource\Reflection;
 /**
  * Gets reflection classes for php files in the given directories.
  *
+ * This class in inspired by this API Platform one:
+ *
+ * @see https://github.com/api-platform/core/blob/main/src/Metadata/Util/ReflectionClassRecursiveIterator.php
+ *
  * @internal
  */
 final class ReflectionClassRecursiveIterator

--- a/src/Component/src/Reflection/ReflectionClassRecursiveIterator.php
+++ b/src/Component/src/Reflection/ReflectionClassRecursiveIterator.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Reflection;
+
+/**
+ * Gets reflection classes for php files in the given directories.
+ *
+ * @internal
+ */
+final class ReflectionClassRecursiveIterator
+{
+    /** @var array<string, array<class-string, \ReflectionClass<object>>> */
+    private static array $localCache;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param string[] $directories
+     *
+     * @return array<class-string, \ReflectionClass<object>>
+     */
+    public static function getReflectionClassesFromDirectories(array $directories, string $ignoreRegex = ''): array
+    {
+        $id = hash('xxh3', implode('', $directories) . $ignoreRegex);
+        if (isset(self::$localCache[$id])) {
+            return self::$localCache[$id];
+        }
+
+        $includedFiles = [];
+        foreach ($directories as $path) {
+            $iterator = new \RegexIterator(
+                new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
+                    \RecursiveIteratorIterator::LEAVES_ONLY,
+                ),
+                '/^' . $ignoreRegex . '.+\.php$/i',
+                \RecursiveRegexIterator::GET_MATCH,
+            );
+
+            foreach ($iterator as $file) {
+                /** @var array{0: string} $file */
+                $sourceFile = $file[0];
+
+                if (!preg_match('(^phar:)i', (string) $sourceFile)) {
+                    $sourceFile = realpath($sourceFile);
+                }
+
+                try {
+                    require_once $sourceFile;
+                } catch (\Throwable) {
+                    // invalid PHP file (example: missing parent class)
+                    continue;
+                }
+
+                $includedFiles[$sourceFile] = true;
+            }
+        }
+
+        $sortedClasses = get_declared_classes();
+        sort($sortedClasses);
+        $sortedInterfaces = get_declared_interfaces();
+        sort($sortedInterfaces);
+        $declared = [...$sortedClasses, ...$sortedInterfaces];
+        $ret = [];
+        foreach ($declared as $className) {
+            $reflectionClass = new \ReflectionClass($className);
+            $sourceFile = $reflectionClass->getFileName();
+            if (isset($includedFiles[$sourceFile])) {
+                $ret[$className] = $reflectionClass;
+            }
+        }
+
+        return self::$localCache[$id] = $ret;
+    }
+}

--- a/src/Component/tests/Reflection/ReflectionClassRecursiveIteratorTest.php
+++ b/src/Component/tests/Reflection/ReflectionClassRecursiveIteratorTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Resource\Tests\Reflection;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Resource\Reflection\ReflectionClassRecursiveIterator;
+
+final class ReflectionClassRecursiveIteratorTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a temporary directory for test PHP files
+        $this->tmpDir = sys_get_temp_dir() . '/reflection_iterator_' . uniqid('', true);
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tmpDir);
+
+        parent::tearDown();
+    }
+
+    public function testItReturnsReflectionClassesFromGivenDirectories(): void
+    {
+        $this->createPhpFile(
+            $this->tmpDir . '/Foo.php',
+            <<<'PHP'
+            <?php
+
+            namespace Test\Fixtures;
+
+            final class Foo
+            {
+            }
+            PHP
+        );
+
+        $this->createPhpFile(
+            $this->tmpDir . '/Bar.php',
+            <<<'PHP'
+            <?php
+
+            namespace Test\Fixtures;
+
+            interface Bar
+            {
+            }
+            PHP
+        );
+
+        $reflections = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([
+            $this->tmpDir,
+        ]);
+
+        self::assertArrayHasKey('Test\\Fixtures\\Foo', $reflections);
+        self::assertArrayHasKey('Test\\Fixtures\\Bar', $reflections);
+
+        self::assertInstanceOf(\ReflectionClass::class, $reflections['Test\\Fixtures\\Foo']);
+        self::assertInstanceOf(\ReflectionClass::class, $reflections['Test\\Fixtures\\Bar']);
+
+        self::assertSame(
+            realpath($this->tmpDir . '/Foo.php'),
+            $reflections['Test\\Fixtures\\Foo']->getFileName(),
+        );
+    }
+
+    public function testItUsesLocalCacheForSameDirectories(): void
+    {
+        $this->createPhpFile(
+            $this->tmpDir . '/Cached.php',
+            <<<'PHP'
+            <?php
+
+            namespace Test\Fixtures;
+
+            final class Cached
+            {
+            }
+            PHP
+        );
+
+        $firstCall = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([
+            $this->tmpDir,
+        ]);
+
+        $secondCall = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([
+            $this->tmpDir,
+        ]);
+
+        // Same array instance returned from cache
+        self::assertSame($firstCall, $secondCall);
+        self::assertArrayHasKey('Test\\Fixtures\\Cached', $secondCall);
+    }
+
+    public function testItIgnoresInvalidPhpFiles(): void
+    {
+        $this->createPhpFile(
+            $this->tmpDir . '/Invalid.php',
+            <<<'PHP'
+            <?php
+
+            // This file is intentionally invalid
+            class Invalid extends UnknownParent
+            {
+            }
+            PHP
+        );
+
+        $reflections = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([
+            $this->tmpDir,
+        ]);
+
+        self::assertSame([], $reflections);
+    }
+
+    public function testItOnlyIncludesFilesMatchingIgnoreRegex(): void
+    {
+        $this->createPhpFile(
+            $this->tmpDir . '/IncludedOne.php',
+            <<<'PHP'
+        <?php
+
+        namespace Test\Fixtures;
+
+        final class IncludedOne
+        {
+        }
+        PHP
+        );
+
+        $this->createPhpFile(
+            $this->tmpDir . '/Excluded.php',
+            <<<'PHP'
+        <?php
+
+        namespace Test\Fixtures;
+
+        final class Excluded
+        {
+        }
+        PHP
+        );
+
+        $reflections = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories(
+            [$this->tmpDir],
+            '.*Included',
+        );
+
+        self::assertArrayHasKey('Test\\Fixtures\\IncludedOne', $reflections);
+        self::assertArrayNotHasKey('Test\\Fixtures\\Excluded', $reflections);
+    }
+
+    private function createPhpFile(string $path, string $contents): void
+    {
+        file_put_contents($path, $contents);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
+        }
+
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (but introduce a deprecation is a new feature, according to Symfony rules)
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #1017
| License         | MIT

The system becomes from API-Platform source code. We know this system is already reliable.
https://github.com/api-platform/core/blob/main/src/Metadata/Util/ReflectionClassRecursiveIterator.php