### PR TITLE
Fix resource configuration for AsResource with only applicationName set

### DIFF
--- a/src/Bundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusResourceExtension.php
@@ -216,6 +216,7 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
     private function getResourceAlias(ResourceMetadata $resource, string $className): string
     {
         $alias = $resource->getAlias();
+        $applicationName = $resource->getApplicationName() ?? 'app';
 
         if (null !== $alias) {
             return $alias;
@@ -229,7 +230,7 @@ final class SyliusResourceExtension extends Extension implements PrependExtensio
             $shortName = substr($shortName, 0, strlen($shortName) - strlen($suffix));
         }
 
-        return 'app.' . u($shortName)->snake()->toString();
+        return u($applicationName)->snake()->toString() . '.' . u($shortName)->snake()->toString();
     }
 
     /**

--- a/tests/Bundle/DependencyInjection/Dummy/BookWithApplicationNameResource.php
+++ b/tests/Bundle/DependencyInjection/Dummy/BookWithApplicationNameResource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy;
+
+use Sylius\Resource\Metadata\AsResource;
+
+#[AsResource(applicationName: 'myApp')]
+final class BookWithApplicationNameResource
+{
+}

--- a/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/tests/Bundle/DependencyInjection/SyliusResourceExtensionTest.php
@@ -26,6 +26,7 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 use Sylius\Bundle\ResourceBundle\Doctrine\ResourceMappingDriverChain;
 use Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\BookWithAliasResource;
+use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\BookWithApplicationNameResource;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\DummyResource;
 use Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Dummy\NoDriverResource;
 use Sylius\Resource\Doctrine\Common\State\PersistProcessor;
@@ -148,6 +149,15 @@ final class SyliusResourceExtensionTest extends AbstractExtensionTestCase
             'app.book' => [
                 'classes' => [
                     'model' => BookWithAliasResource::class,
+                    'controller' => ResourceController::class,
+                    'factory' => Factory::class,
+                    'form' => DefaultResourceType::class,
+                ],
+                'driver' => 'doctrine/orm',
+            ],
+            'my_app.book_with_application_name' => [
+                'classes' => [
+                    'model' => BookWithApplicationNameResource::class,
                     'controller' => ResourceController::class,
                     'factory' => Factory::class,
                     'form' => DefaultResourceType::class,


### PR DESCRIPTION
it should not assume app, but only fall back on app if applicationName is not specified

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
