### PR TITLE
Deprecate expressions without prefix

### DIFF
--- a/src/Component/src/State/Factory.php
+++ b/src/Component/src/State/Factory.php
@@ -74,6 +74,7 @@ final class Factory implements FactoryInterface
                 trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
             }
 
+            // Not reachable as long as the BC layer above is there
             if (!str_starts_with($value, '@=')) {
                 $arguments[$key] = $value;
 

--- a/src/Component/src/State/Factory.php
+++ b/src/Component/src/State/Factory.php
@@ -69,6 +69,18 @@ final class Factory implements FactoryInterface
     private function parseArgumentValues(array $arguments): array
     {
         foreach ($arguments as $key => $value) {
+            if (!str_starts_with($value, '@=')) {
+                $value = '@=' . $value;
+                trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
+            }
+
+            if (!str_starts_with($value, '@=')) {
+                $arguments[$key] = $value;
+
+                continue;
+            }
+
+            $value = substr($value, 2);
             $arguments[$key] = $this->argumentParser->parseExpression($value);
         }
 

--- a/src/Component/src/Symfony/Request/State/Provider.php
+++ b/src/Component/src/Symfony/Request/State/Provider.php
@@ -118,6 +118,18 @@ final class Provider implements ProviderInterface
     private function parseArgumentValues(array $arguments): array
     {
         foreach ($arguments as $key => $value) {
+            if (!str_starts_with($value, '@=')) {
+                $value = '@=' . $value;
+                trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
+            }
+
+            if (!str_starts_with($value, '@=')) {
+                $arguments[$key] = $value;
+
+                continue;
+            }
+
+            $value = substr($value, 2);
             $arguments[$key] = $this->argumentParser->parseExpression($value);
         }
 

--- a/src/Component/src/Symfony/Request/State/Provider.php
+++ b/src/Component/src/Symfony/Request/State/Provider.php
@@ -123,6 +123,7 @@ final class Provider implements ProviderInterface
                 trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
             }
 
+            // Not reachable as long as the BC layer above is there
             if (!str_starts_with($value, '@=')) {
                 $arguments[$key] = $value;
 

--- a/src/Component/src/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/src/Symfony/Routing/RedirectHandler.php
@@ -141,6 +141,7 @@ final class RedirectHandler implements RedirectHandlerInterface
             trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your redirect arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
         }
 
+        // Not reachable as long as the BC layer above is there
         if (!str_starts_with($value, '@=')) {
             return $value;
         }

--- a/src/Component/src/Symfony/Routing/RedirectHandler.php
+++ b/src/Component/src/Symfony/Routing/RedirectHandler.php
@@ -108,7 +108,7 @@ final class RedirectHandler implements RedirectHandlerInterface
                 throw new InvalidArgumentException(sprintf('Parameter "%s" should be a scalar or an array.', $key));
             }
 
-            if (\is_string($value) && str_contains($value, 'resource.')) {
+            if (\is_string($value) && str_starts_with($value, 'resource.')) {
                 $propertyPath = substr($value, 9);
 
                 if (\is_object($data) && $accessor->isReadable($data, $propertyPath)) {
@@ -125,10 +125,28 @@ final class RedirectHandler implements RedirectHandlerInterface
                 $variables[$resourceName] = $data;
             }
 
-            // TODO, the best way to detect if we need to parse an expression will need to add "@=" syntax.
-            $parameters[$key] = \is_string($value) ? $this->argumentParser->parseExpression($value, $variables) : $value;
+            $parameters[$key] = \is_string($value) ? $this->parseStringValue($value, $variables) : $value;
         }
 
         return $parameters;
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function parseStringValue(string $value, array $variables): mixed
+    {
+        if (!str_starts_with($value, '@=')) {
+            $value = '@=' . $value;
+            trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your redirect arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
+        }
+
+        if (!str_starts_with($value, '@=')) {
+            return $value;
+        }
+
+        $value = substr($value, 2);
+
+        return $this->argumentParser->parseExpression($value, $variables);
     }
 }

--- a/src/Component/tests/State/FactoryTest.php
+++ b/src/Component/tests/State/FactoryTest.php
@@ -64,6 +64,20 @@ final class FactoryTest extends TestCase
         $this->assertEquals('51353e91-5295-4876-a994-cae4b3ff3a7c', $result->userId);
     }
 
+    public function testItCallsFactoryWithExpressionLanguagePrefixedArgumentsFromOperationAsCallable(): void
+    {
+        $operation = new Create(factory: [FactoryCallable::class, 'create'], factoryArguments: ['userId' => '@=user.getUserIdentifier()']);
+        $this->argumentParser->expects($this->once())
+            ->method('parseExpression')
+            ->with('user.getUserIdentifier()')
+            ->willReturn('51353e91-5295-4876-a994-cae4b3ff3a7c');
+
+        $result = $this->factory->create($operation, new Context());
+
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertEquals('51353e91-5295-4876-a994-cae4b3ff3a7c', $result->userId);
+    }
+
     public function testItCallsFactoryFromOperationAsString(): void
     {
         $factory = $this->createMock(FactoryInterface::class);

--- a/src/Component/tests/Symfony/Request/State/ProviderTest.php
+++ b/src/Component/tests/Symfony/Request/State/ProviderTest.php
@@ -145,7 +145,7 @@ final class ProviderTest extends TestCase
         $this->assertSame($stdClass, $response);
     }
 
-    public function testItCallsRepositoryAsStringWithSpecificRepositoryMethodAnArguments(): void
+    public function testItCallsRepositoryAsStringWithSpecificRepositoryMethodAndArguments(): void
     {
         $operation = $this->createMock(Operation::class);
         $request = $this->createMock(Request::class);
@@ -155,6 +155,33 @@ final class ProviderTest extends TestCase
         $operation->method('getRepository')->willReturn('App\Repository');
         $operation->method('getRepositoryMethod')->willReturn('find');
         $operation->method('getRepositoryArguments')->willReturn(['id' => "request.attributes.get('id')"]);
+
+        $this->argumentParser
+            ->expects($this->once())
+            ->method('parseExpression')
+            ->with("request.attributes.get('id')")
+            ->willReturn('my_id');
+
+        $this->locator->method('has')->with('App\Repository')->willReturn(true);
+        $this->locator->method('get')->with('App\Repository')->willReturn($repository);
+
+        $repository->method('find')->with('my_id')->willReturn($stdClass);
+
+        $response = $this->provider->provide($operation, new Context(new RequestOption($request)));
+
+        $this->assertSame($stdClass, $response);
+    }
+
+    public function testItCallsRepositoryAsStringWithSpecificRepositoryMethodAndExpressionLanguagePrefixedArguments(): void
+    {
+        $operation = $this->createMock(Operation::class);
+        $request = $this->createMock(Request::class);
+        $repository = $this->createMock(RepositoryInterface::class);
+        $stdClass = new \stdClass();
+
+        $operation->method('getRepository')->willReturn('App\Repository');
+        $operation->method('getRepositoryMethod')->willReturn('find');
+        $operation->method('getRepositoryArguments')->willReturn(['id' => "@=request.attributes.get('id')"]);
 
         $this->argumentParser
             ->expects($this->once())

--- a/src/Component/tests/Symfony/Routing/RedirectHandlerTest.php
+++ b/src/Component/tests/Symfony/Routing/RedirectHandlerTest.php
@@ -355,15 +355,49 @@ final class RedirectHandlerTest extends TestCase
         $data = $this->createDataWithId();
         $operation = (new Create(
             redirectToRoute: 'app_book_show',
-            redirectArguments: ['id' => 'resource.id', 'page' => '1'],
+            redirectArguments: ['id' => 'resource.id', 'page' => "request.query.get('page')"],
         ))->withResource(new ResourceMetadata(alias: 'app.book')); // name is null
         $request = $this->createMock(Request::class);
 
         $this->argumentParser
             ->expects($this->once())
             ->method('parseExpression')
-            ->with('1', ['resource' => $data]) // Only 'resource', no name
+            ->with("request.query.get('page')", ['resource' => $data]) // Only 'resource', no name
             ->willReturn('1');
+
+        $this->mockFilterStorage();
+        $this->router
+            ->method('generate')
+            ->with('app_book_show', ['id' => 'xyz', 'page' => '1'])
+            ->willReturn('/books/xyz?page=1');
+
+        $this->redirectHandler->redirectToResource($data, $operation, $request);
+    }
+
+    public function testItUsesExpressionParserForExpressionLanguagePrefixedValues(): void
+    {
+        $data = $this->createDataWithId();
+        $operation = (new Create(
+            redirectToRoute: 'app_book_show',
+            redirectArguments: ['id' => '@resource.getId()', 'page' => "@=request.query.get('page')"],
+        ))->withResource(new ResourceMetadata(alias: 'app.book')); // name is null
+        $request = $this->createMock(Request::class);
+
+        $this->argumentParser
+            ->expects($this->exactly(2))
+            ->method('parseExpression')
+            ->willReturnCallback(function (string $expression) {
+                if ('@resource.getId()' === $expression) {
+                    return 'xyz';
+                }
+
+                if ("request.query.get('page')" === $expression) {
+                    return '1';
+                }
+
+                return null;
+            })
+        ;
 
         $this->mockFilterStorage();
         $this->router


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Recently, we added an argument parser to use expression language on the "vars" for the resource routing using `@=` (https://github.com/Sylius/SyliusResourceBundle/pull/1043).
In the redirect and in the factory, we used an hack to detect if we need to parse the value or not.
Now it's time to use the same syntax with `@=`.