### PR TITLE
fix translatable resource not getting its translation mapped with AsResource

### DIFF
--- a/src/Bundle/EventListener/ORMTranslatableListener.php
+++ b/src/Bundle/EventListener/ORMTranslatableListener.php
@@ -88,6 +88,10 @@ final class ORMTranslatableListener implements EventSubscriber
      */
     private function mapTranslatable(ClassMetadata $metadata): void
     {
+        if ($metadata->hasAssociation('translations')) {
+            return;
+        }
+
         $className = $metadata->name;
 
         try {
@@ -96,24 +100,18 @@ final class ORMTranslatableListener implements EventSubscriber
             return;
         }
 
-        if (!$resourceMetadata->hasParameter('translation')) {
-            return;
-        }
-
         /** @var MetadataInterface $translationResourceMetadata */
         $translationResourceMetadata = $this->resourceMetadataRegistry->get($resourceMetadata->getAlias() . '_translation');
 
-        if (!$metadata->hasAssociation('translations')) {
-            $metadata->mapOneToMany([
-                'fieldName' => 'translations',
-                'targetEntity' => $translationResourceMetadata->getClass('model'),
-                'mappedBy' => 'translatable',
-                'fetch' => ClassMetadata::FETCH_EXTRA_LAZY,
-                'indexBy' => 'locale',
-                'cascade' => ['persist', 'remove'],
-                'orphanRemoval' => true,
-            ]);
-        }
+        $metadata->mapOneToMany([
+            'fieldName' => 'translations',
+            'targetEntity' => $translationResourceMetadata->getClass('model'),
+            'mappedBy' => 'translatable',
+            'fetch' => ClassMetadata::FETCH_EXTRA_LAZY,
+            'indexBy' => 'locale',
+            'cascade' => ['persist', 'remove'],
+            'orphanRemoval' => true,
+        ]);
     }
 
     /**


### PR DESCRIPTION
`AsResource` does not have `translations` configuration
and there seems to be no way to currently get it mapped properly when using attributes?
This ensures that when you `AsResource` tag your translation resource as `<alias>_translation`,
the mapping occurs, even without the resource metadata translation parameter.
which seemed to be an artificial limitation also not implemented in the mapTranslation



| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #1018
| License         | MIT
