### PR TITLE
Remove processor will return deleted data

### DIFF
--- a/src/Component/src/Doctrine/Common/State/RemoveProcessor.php
+++ b/src/Component/src/Doctrine/Common/State/RemoveProcessor.php
@@ -43,7 +43,7 @@ final class RemoveProcessor implements ProcessorInterface
             throw new DeleteResourceException();
         }
 
-        return null;
+        return $data;
     }
 
     /**

--- a/src/Component/tests/Doctrine/Common/State/RemoveProcessorTest.php
+++ b/src/Component/tests/Doctrine/Common/State/RemoveProcessorTest.php
@@ -50,7 +50,8 @@ final class RemoveProcessorTest extends TestCase
         $manager->expects($this->once())->method('remove')->with($data);
         $manager->expects($this->once())->method('flush');
 
-        $this->removeProcessor->process($data, $operation, new Context());
+        $result = $this->removeProcessor->process($data, $operation, new Context());
+        $this->assertSame($data, $result);
     }
 
     public function testItDoesNothingWhenDataIsNotManagedByDoctrine(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes (on Sylius E-commerce only)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

it fixes `sylius.channel.post_delete` listener on Sylius E-commerce project with new routing.

Before
<img width="863" height="129" alt="image" src="https://github.com/user-attachments/assets/1fa91ae2-8a87-4650-9fde-c2573a612a7e" />

After
<img width="680" height="265" alt="image" src="https://github.com/user-attachments/assets/2195a87f-184c-4dbe-8b0d-f8f94e074af7" />
