### PR TITLE
Fix double slashes on route paths

### DIFF
--- a/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/OperationRouteFactory.php
@@ -40,7 +40,7 @@ final class OperationRouteFactory implements OperationRouteFactoryInterface
         $routePath = $operation->getPath() ?? $this->getDefaultRoutePath($metadata, $resource, $operation);
 
         if (null !== $routePrefix = $operation->getRoutePrefix()) {
-            $routePath = $routePrefix . '/' . $routePath;
+            $routePath = sprintf('%s/%s', rtrim($routePrefix, '/'), ltrim($routePath, '/'));
         }
 
         return new Route(

--- a/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/OperationRouteFactoryTest.php
@@ -120,7 +120,7 @@ final class OperationRouteFactoryTest extends TestCase
 
         $route = $this->bcOperationRouteFactory->create($metadata, $resource, $operation);
 
-        $this->assertSame('/admin//books', $route->getPath());
+        $this->assertSame('/admin/books', $route->getPath());
     }
 
     public function testItCreatesRouteWithRoutePrefix(): void
@@ -137,7 +137,37 @@ final class OperationRouteFactoryTest extends TestCase
 
         $route = $this->operationRouteFactory->create($metadata, $resource, $operation);
 
-        $this->assertSame('/admin//books', $route->getPath());
+        $this->assertSame('/admin/books', $route->getPath());
+    }
+
+    public function testItCreatesRouteWithCustomPathAndRoutePrefix(): void
+    {
+        $metadata = $this->createMock(MetadataInterface::class);
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = new Index(path: '/custom/books/list', routePrefix: '/admin');
+
+        $this->routePathFactory
+            ->expects($this->never())
+            ->method('createRoutePath');
+
+        $route = $this->operationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertSame('/admin/custom/books/list', $route->getPath());
+    }
+
+    public function testItCreatesRouteWithCustomPathAndRoutePrefixAndTooManySlashes(): void
+    {
+        $metadata = $this->createMock(MetadataInterface::class);
+        $resource = new ResourceMetadata(alias: 'app.book');
+        $operation = new Index(path: '/custom/books/list', routePrefix: '/admin/');
+
+        $this->routePathFactory
+            ->expects($this->never())
+            ->method('createRoutePath');
+
+        $route = $this->operationRouteFactory->create($metadata, $resource, $operation);
+
+        $this->assertSame('/admin/custom/books/list', $route->getPath());
     }
 
     public function testItCreatesRouteWithSection(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

As we have almost finished the 1.14 version, there's no reason to maintain 1.13 here. This is a kind of a DX fix.