### PR TITLE
Revert "Fix flash processor"

### DIFF
--- a/src/Component/src/State/Processor/FlashProcessor.php
+++ b/src/Component/src/State/Processor/FlashProcessor.php
@@ -59,9 +59,7 @@ final class FlashProcessor implements ProcessorInterface
     private function addFlash(Request $request, Operation $operation, Context $context): void
     {
         if ($request->attributes->has('error')) {
-            $message = $request->attributes->getString('error');
-
-            $this->flashHelper->addErrorFlash($operation, $context, $message);
+            $this->flashHelper->addErrorFlash($operation, $context);
 
             return;
         }

--- a/src/Component/tests/State/Processor/FlashProcessorTest.php
+++ b/src/Component/tests/State/Processor/FlashProcessorTest.php
@@ -94,7 +94,7 @@ final class FlashProcessorTest extends TestCase
 
         $this->flashHelper->expects($this->once())
             ->method('addErrorFlash')
-            ->with($operation, $context, 'Cannot delete, the resource is in use.')
+            ->with($operation, $context)
         ;
 
         $this->flashProcessor->process(['foo' => 'fighters'], $operation, $context);


### PR DESCRIPTION
Reverts Sylius/SyliusResourceBundle#1138

This breaks previous error message "Cannot delete, the Promotion is in use" that contains translations.