### PR TITLE
Fallback to generic translations on operation with a custom name

### DIFF
--- a/src/Component/src/Symfony/Session/Flash/FlashHelper.php
+++ b/src/Component/src/Symfony/Session/Flash/FlashHelper.php
@@ -17,7 +17,11 @@ use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
 use Sylius\Resource\Humanizer\StringHumanizer;
 use Sylius\Resource\Metadata\BulkOperationInterface;
+use Sylius\Resource\Metadata\CreateOperationInterface;
+use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\Operation;
+use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\Metadata\UpdateOperationInterface;
 use Sylius\Resource\Symfony\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -79,22 +83,36 @@ final class FlashHelper implements FlashHelperInterface
         $resource = $operation->getResource();
         Assert::notNull($resource);
 
-        $translationKeySuffix = sprintf('%s%s', $operation->getShortName() ?? '', 'error' === $type ? '_error' : '');
-        $key = 'success' === $type ? $operation->getNotificationMessage() : null;
-        $key ??= sprintf('%s.%s.%s', $resource->getApplicationName() ?? '', $resource->getName() ?? '', $translationKeySuffix);
-        $fallbackKey = sprintf('sylius.resource.%s', $translationKeySuffix);
+        $translationKeys = iterator_to_array($this->getTranslationKeys($resource, $operation, $type));
+
+        /** @var string $firstTranslationKey */
+        $firstTranslationKey = reset($translationKeys);
 
         $parameters = $this->getTranslationParameters($operation);
+        $notificationMessage = $operation->getNotificationMessage();
+
+        // It's defined by the user, it should be used.
+        if ('success' === $type && null !== $notificationMessage) {
+            // Do not use the translator if not needed
+            if ($this->translator instanceof TranslatorBagInterface && !$this->translator->getCatalogue()->has($notificationMessage, 'flashes')) {
+                return $notificationMessage;
+            }
+
+            return $this->translator->trans($notificationMessage, $parameters, 'flashes');
+        }
 
         if (!$this->translator instanceof TranslatorBagInterface) {
-            return $this->translator->trans($fallbackKey, $parameters, 'flashes');
+            return $this->translator->trans($firstTranslationKey, $parameters, 'flashes');
         }
 
-        if ($this->translator->getCatalogue()->has($key, 'flashes')) {
-            return $this->translator->trans($key, $parameters, 'flashes');
+        foreach ($translationKeys as $translationKey) {
+            if ($this->translator->getCatalogue()->has($translationKey, 'flashes')) {
+                return $this->translator->trans($translationKey, $parameters, 'flashes');
+            }
         }
 
-        return $this->translator->trans($fallbackKey, $parameters, 'flashes');
+        // Last fallback, use the first translation key.
+        return $this->translator->trans($firstTranslationKey, $parameters, 'flashes');
     }
 
     private function addFlash(string $message, string $type, Context $context): void
@@ -119,13 +137,100 @@ final class FlashHelper implements FlashHelperInterface
             return [];
         }
 
-        $resourceName = $operation instanceof BulkOperationInterface ? $resource->getPluralName() : $resource->getName();
-        $humanizedName = ucfirst(StringHumanizer::humanize($resourceName ?? ''));
+        $humanizedName = ucfirst(StringHumanizer::humanize($resource->getName() ?? ''));
 
         if ($operation instanceof BulkOperationInterface) {
-            return ['%resources%' => $humanizedName];
+            $humanizedPluralName = ucfirst(StringHumanizer::humanize($resource->getPluralName() ?? ''));
+
+            return [
+                '%resource%' => $humanizedName,
+                '%resources%' => $humanizedPluralName,
+            ];
         }
 
         return ['%resource%' => $humanizedName];
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function getTranslationKeys(ResourceMetadata $resource, Operation $operation, string $type): iterable
+    {
+        $applicationName = $resource->getApplicationName() ?? '';
+        $resourceName = $resource->getName() ?? '';
+        $operationShortName = $operation->getShortName() ?? '';
+
+        $translationKeySuffix = 'error' === $type ? '_error' : '';
+
+        /**
+         * Examples:
+         * app.product.my_operation
+         * app.product.my_operation_error
+         */
+        yield sprintf(
+            '%s.%s.%s%s',
+            $applicationName,
+            $resourceName,
+            $operationShortName,
+            $translationKeySuffix,
+        );
+
+        $genericOperationType = $this->getGenericOperationType($operation);
+
+        /**
+         * Examples:
+         * app.product.delete
+         * app.product.delete_error
+         */
+        if ($genericOperationType !== $operationShortName) {
+            yield sprintf(
+                '%s.%s.%s%s',
+                $applicationName,
+                $resourceName,
+                $genericOperationType,
+                $translationKeySuffix,
+            );
+        }
+
+        /**
+         * Examples:
+         * sylius.resource.my_operation
+         * sylius.resource.my_operation_error
+         */
+        yield sprintf(
+            'sylius.resource.%s%s',
+            $operationShortName,
+            $translationKeySuffix,
+        );
+
+        /**
+         * Examples:
+         * sylius.resource.delete
+         * sylius.resource.delete_error
+         */
+        if ($genericOperationType !== $operationShortName) {
+            yield sprintf(
+                'sylius.resource.%s%s',
+                $genericOperationType,
+                $translationKeySuffix,
+            );
+        }
+    }
+
+    private function getGenericOperationType(Operation $operation): ?string
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            return 'delete';
+        }
+
+        if ($operation instanceof CreateOperationInterface) {
+            return 'create';
+        }
+
+        if ($operation instanceof UpdateOperationInterface) {
+            return 'update';
+        }
+
+        return null;
     }
 }

--- a/src/Component/tests/Symfony/Session/Flash/FlashHelperTest.php
+++ b/src/Component/tests/Symfony/Session/Flash/FlashHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Tests\Symfony\Session\Flash;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
@@ -22,336 +23,413 @@ use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Symfony\EventDispatcher\GenericEvent;
 use Sylius\Resource\Symfony\Session\Flash\FlashHelper;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[CoversClass(FlashHelper::class)]
 final class FlashHelperTest extends TestCase
 {
-    private TranslatorInterface $translator;
-
-    private FlashHelper $flashHelper;
-
-    protected function setUp(): void
-    {
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->flashHelper = new FlashHelper($this->translator);
-    }
-
-    public function testItIsInitializable(): void
-    {
-        $this->assertInstanceOf(FlashHelper::class, $this->flashHelper);
-    }
-
     public function testItAddsSuccessFlashesWithCustomMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $flashHelper = new FlashHelper($this->createTranslator());
+        $flashHelper->addSuccessFlash($operation, $context, 'Custom message.');
 
-        $flashBag->expects($this->once())->method('add')->with('success', 'Custom message.');
-
-        $this->flashHelper->addSuccessFlash($operation, $context, 'Custom message.');
+        $this->assertSame('Custom message.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsSuccessFlashesWithSpecificMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.dummy.create' => '%resource% was created successfully!!',
+            'sylius.resource.create' => '%resource% was created successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.dummy.create', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.dummy.create', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Dummy was created successfully.');
-
-        $flashBag->expects($this->once())->method('add')->with('success', 'Dummy was created successfully.');
-
         $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Dummy was created successfully!!', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsSuccessFlashesWithFallbackMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.create' => '%resource% was created successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $flashHelper->addSuccessFlash($operation, $context);
 
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.dummy.create', 'flashes')->willReturn(false);
-        $translator->expects($this->once())->method('trans')->with('sylius.resource.create', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Dummy was created successfully.');
+        $this->assertSame('Dummy was created successfully.', $session->getFlashBag()->all()['success'][0]);
+    }
 
-        $flashBag->expects($this->once())->method('add')->with('success', 'Dummy was created successfully.');
+    public function testItAddsSuccessFlashesWithSpecificMessageForCustomOperationName(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.dummy.create_for_customer' => '%resource% has been added to this customer successfully.',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new Create(shortName: 'create_for_customer'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
 
         $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Dummy has been added to this customer successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsSuccessFlashesWithCustomMessageOnItsOperation(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.dummy.shipped' => '%resource% was shipped successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create(notificationMessage: 'app.dummy.shipped'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.dummy.shipped', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.dummy.shipped', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Dummy was shipped successfully.');
-
-        $flashBag->expects($this->once())->method('add')->with('success', 'Dummy was shipped successfully.');
-
         $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Dummy was shipped successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
-    public function testItAddsSuccessFlashesWithDefaultMessageWhenTranslatorIsNotABag(): void
+    public function testItAddsSuccessFlashesWithCustomMessageOnItsOperationEvenIfThisIsNotInTheTranslationBag(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator();
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new Create(notificationMessage: 'Dummy was shipped successfully.'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Dummy was shipped successfully.', $session->getFlashBag()->all()['success'][0]);
+    }
+
+    public function testItAddsSuccessFlashesWithFirstDefaultMessageWhenTranslatorIsNotABag(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $flashHelper = new FlashHelper($translator);
 
-        $this->translator->expects($this->once())->method('trans')->with('sylius.resource.create', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Dummy was created successfully.');
+        $translator->expects($this->once())->method('trans')->with('app.dummy.create', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Dummy was created successfully.');
 
-        $flashBag->expects($this->once())->method('add')->with('success', 'Dummy was created successfully.');
+        $flashHelper->addSuccessFlash($operation, $context);
 
-        $this->flashHelper->addSuccessFlash($operation, $context);
+        $this->assertSame('Dummy was created successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsSuccessFlashesWithHumanizedMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.admin_user.create' => '%resource% was created successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'admin_user', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.admin_user.create', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.admin_user.create', ['%resource%' => 'Admin user'], 'flashes')->willReturn('Admin user was created successfully.');
-
-        $flashBag->expects($this->once())->method('add')->with('success', 'Admin user was created successfully.');
-
         $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Admin user was created successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsSuccessFlashesWithHumanizedMessageAndPluralNameOnBulkOperation(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.admin_user.bulk_delete' => '%resources% was removed successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new BulkDelete())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'admin_user', pluralName: 'admin_users', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.admin_user.bulk_delete', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.admin_user.bulk_delete', ['%resources%' => 'Admin users'], 'flashes')->willReturn('Admin users was removed successfully.');
-
-        $flashBag->expects($this->once())->method('add')->with('success', 'Admin users was removed successfully.');
-
         $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Admin users was removed successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsErrorFlashesWithCustomMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $flashHelper = new FlashHelper($this->createTranslator());
 
-        $flashBag->expects($this->once())->method('add')->with('error', 'Custom error message.');
+        $flashHelper->addErrorFlash($operation, $context, 'Custom error message.');
 
-        $this->flashHelper->addErrorFlash($operation, $context, 'Custom error message.');
+        $this->assertSame('Custom error message.', $session->getFlashBag()->all()['error'][0]);
     }
 
     public function testItAddsErrorFlashesWithSpecificMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.dummy.create_error' => 'Cannot create %resource% resource!!',
+            'sylius.resource.create_error' => 'Cannot create %resource% resource.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.dummy.create_error', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.dummy.create_error', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Cannot create Dummy resource.');
-
-        $flashBag->expects($this->once())->method('add')->with('error', 'Cannot create Dummy resource.');
-
         $flashHelper->addErrorFlash($operation, $context);
+
+        $this->assertSame('Cannot create Dummy resource!!', $session->getFlashBag()->all()['error'][0]);
     }
 
     public function testItAddsErrorFlashesWithFallbackMessage(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.create_error' => 'Cannot create %resource% resource.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
 
         $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $flashHelper->addErrorFlash($operation, $context);
 
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.dummy.create_error', 'flashes')->willReturn(false);
-        $translator->expects($this->once())->method('trans')->with('sylius.resource.create_error', ['%resource%' => 'Dummy'], 'flashes')->willReturn('Cannot create Dummy resource.');
+        $this->assertSame('Cannot create Dummy resource.', $session->getFlashBag()->all()['error'][0]);
+    }
 
-        $flashBag->expects($this->once())->method('add')->with('error', 'Cannot create Dummy resource.');
+    public function testItAddsErrorFlashesWithSpecificMessageForCustomOperationName(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.dummy.create_for_customer_error' => 'Cannot create %resource% resource for this customer.',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new Create(shortName: 'create_for_customer'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
 
         $flashHelper->addErrorFlash($operation, $context);
+
+        $this->assertSame('Cannot create Dummy resource for this customer.', $session->getFlashBag()->all()['error'][0]);
+    }
+
+    public function testItAddsErrorFlashesWithFallbackMessageForCustomOperationName(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.create_error' => 'Cannot create %resource% resource.',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new Create(shortName: 'create_for_customer'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addErrorFlash($operation, $context);
+
+        $this->assertSame('Cannot create Dummy resource.', $session->getFlashBag()->all()['error'][0]);
+    }
+
+    public function testItAddsErrorFlashesWithAFallbackToDeleteTranslationKeyForABulkDelete(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.delete_error' => 'Cannot delete %resource% resource.',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new BulkDelete())->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addErrorFlash($operation, $context);
+
+        $this->assertSame('Cannot delete Dummy resource.', $session->getFlashBag()->all()['error'][0]);
+    }
+
+    public function testItAddsErrorFlashesWithAFallbackToDeleteTranslationKeyForABulkDeleteWithACustomOperationName(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.delete_error' => 'Cannot delete %resource% resource.',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new BulkDelete(shortName: 'bulk_delete_for_taxon'))->withResource(new ResourceMetadata(alias: 'app.dummy', name: 'dummy', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addErrorFlash($operation, $context);
+
+        $this->assertSame('Cannot delete Dummy resource.', $session->getFlashBag()->all()['error'][0]);
     }
 
     public function testItTranslatesFlashesFromEventWhenTranslatorIsNotABag(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $event = $this->createMock(GenericEvent::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $event = new GenericEvent();
+        $event->setMessage('app.admin_user.banned');
+        $event->setMessageType('success');
+        $event->setMessageParameters(['%admin_user%' => 'Darth Vader']);
 
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $flashHelper = new FlashHelper($translator);
 
-        $event->method('getMessage')->willReturn('app.admin_user.banned');
-        $event->method('getMessageType')->willReturn('success');
-        $event->method('getMessageParameters')->willReturn(['%admin_user%' => 'Darth Vader']);
+        $translator->expects($this->once())->method('trans')->with('app.admin_user.banned', ['%admin_user%' => 'Darth Vader'], 'flashes')->willReturn('Darth Vader was banned successfully.');
 
-        $this->translator->expects($this->once())->method('trans')->with('app.admin_user.banned', ['%admin_user%' => 'Darth Vader'], 'flashes')->willReturn('Darth Vader was banned successfully.');
+        $flashHelper->addFlashFromEvent($event, $context);
 
-        $flashBag->expects($this->once())->method('add')->with('success', 'Darth Vader was banned successfully.');
-
-        $this->flashHelper->addFlashFromEvent($event, $context);
+        $this->assertSame('Darth Vader was banned successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItTranslatesFlashesFromEventWhenTranslatorIsABag(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
-        $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
-        $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
-        $event = $this->createMock(GenericEvent::class);
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $event = new GenericEvent();
+        $event->setMessage('app.admin_user.banned');
+        $event->setMessageType('success');
+        $event->setMessageParameters(['%admin_user%' => 'Darth Vader']);
+
+        $translator = $this->createTranslator([
+            'app.admin_user.banned' => '%admin_user% was banned successfully.',
+        ]);
 
         $flashHelper = new FlashHelper($translator);
-
         $context = new Context(new RequestOption($request));
 
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $event->method('getMessage')->willReturn('app.admin_user.banned');
-        $event->method('getMessageType')->willReturn('success');
-        $event->method('getMessageParameters')->willReturn(['%admin_user%' => 'Darth Vader']);
-
-        $translator->method('getCatalogue')->willReturn($messageCatalogue);
-        $messageCatalogue->expects($this->once())->method('has')->with('app.admin_user.banned', 'flashes')->willReturn(true);
-        $translator->expects($this->once())->method('trans')->with('app.admin_user.banned', ['%admin_user%' => 'Darth Vader'], 'flashes')->willReturn('Darth Vader was banned successfully.');
-
-        $flashBag->expects($this->once())->method('add')->with('success', 'Darth Vader was banned successfully.');
-
         $flashHelper->addFlashFromEvent($event, $context);
+
+        $this->assertSame('Darth Vader was banned successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItDoesNotTranslateEventMessageWhenTranslatorIsABagAndDoesNotContainsTheKey(): void
     {
-        $request = $this->createMock(Request::class);
-        $session = $this->createMock(SessionInterface::class);
-        $flashBag = $this->createMock(FlashBagInterface::class);
         $translator = $this->createMockForIntersectionOfInterfaces([TranslatorInterface::class, TranslatorBagInterface::class]);
         $messageCatalogue = $this->createMock(MessageCatalogueInterface::class);
-        $event = $this->createMock(GenericEvent::class);
+
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
 
         $flashHelper = new FlashHelper($translator);
 
+        $event = new GenericEvent();
+        $event->setMessage('Darth Vader was banned successfully.');
+        $event->setMessageType('success');
+
         $context = new Context(new RequestOption($request));
-
-        $request->method('getSession')->willReturn($session);
-        $session->method('getBag')->with('flashes')->willReturn($flashBag);
-
-        $event->method('getMessage')->willReturn('Darth Vader was banned successfully.');
-        $event->method('getMessageType')->willReturn('success');
-        $event->method('getMessageParameters')->willReturn([]);
 
         $translator->method('getCatalogue')->willReturn($messageCatalogue);
         $messageCatalogue->expects($this->once())->method('has')->with('Darth Vader was banned successfully.', 'flashes')->willReturn(false);
 
         $translator->expects($this->never())->method('trans');
 
-        $flashBag->expects($this->once())->method('add')->with('success', 'Darth Vader was banned successfully.');
-
         $flashHelper->addFlashFromEvent($event, $context);
+
+        $this->assertSame('Darth Vader was banned successfully.', $session->getFlashBag()->all()['success'][0]);
+    }
+
+    /**
+     * @param array<string, string> $translations
+     */
+    private function createTranslator(array $translations = []): TranslatorInterface&TranslatorBagInterface
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+
+        foreach ($translations as $key => $translation) {
+            $translator->addResource('array', [
+                $key => $translation,
+            ], 'en', 'flashes');
+        }
+
+        return $translator;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | kind of (it has difference with the legacy routing system)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It allows to have a fallback to "sylius.product.delete_error" translation key for a bulk delete on a product.
<img width="1680" height="680" alt="Capture d’écran du 2026-01-30 15-16-11" src="https://github.com/user-attachments/assets/6c7c61e6-6402-4ddc-9404-191a4e552803" />

