### PR TITLE
[Chore] Replace internal tag by experimental one on Operations

### DIFF
--- a/src/Component/src/Metadata/Operations.php
+++ b/src/Component/src/Metadata/Operations.php
@@ -16,7 +16,7 @@ namespace Sylius\Resource\Metadata;
 use RuntimeException;
 
 /**
- * @internal
+ * @experimental
  *
  * @template T of Operation
  */


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

As we use it on external routing configuration files, we need to remove the internal tag.

Example:
```php
<?php

declare(strict_types=1);

// ...
use Sylius\Resource\Metadata\Operations;
use Sylius\Resource\Metadata\ResourceMetadata;

return (new ResourceMetadata())
    // ...
    ->withOperations(new Operations([
        //...
    ]))
;
```