### PR TITLE
[ExpressionLanguage] Parse form options

### DIFF
--- a/src/Bundle/Resources/config/services/expression_language.php
+++ b/src/Bundle/Resources/config/services/expression_language.php
@@ -57,6 +57,9 @@ return static function (ContainerConfigurator $container) {
     $services->set('sylius.expression_language.variables_collection.factory', VariablesCollection::class)
         ->args([tagged_iterator('sylius.resource_factory_variables')]);
 
+    $services->set('sylius.expression_language.variables_collection.form', VariablesCollection::class)
+        ->args([tagged_iterator('sylius.form_variables')]);
+
     $services->set('sylius.expression_language.variables_collection.repository', VariablesCollection::class)
         ->args([tagged_iterator('sylius.repository_variables')]);
 
@@ -81,6 +84,13 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.resource_factory.expression_language'),
             service('sylius.expression_language.variables_collection.factory'),
+            tagged_iterator('sylius.resource_factory_providers'),
+        ]);
+
+    $services->set('sylius.expression_language.argument_parser.form', ArgumentParser::class)
+        ->args([
+            service('sylius.resource_factory.expression_language'),
+            service('sylius.expression_language.variables_collection.form'),
             tagged_iterator('sylius.resource_factory_providers'),
         ]);
 

--- a/src/Bundle/Resources/config/services/form.php
+++ b/src/Bundle/Resources/config/services/form.php
@@ -32,7 +32,10 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('sylius.form.factory', FormFactory::class)
         ->private()
-        ->args([service('form.factory')]);
+        ->args([
+            service('form.factory'),
+            service('sylius.expression_language.argument_parser.form'),
+        ]);
 
     $services->alias(FormFactoryInterface::class, 'sylius.form.factory');
 };

--- a/src/Component/src/Symfony/Form/Factory/FormFactory.php
+++ b/src/Component/src/Symfony/Form/Factory/FormFactory.php
@@ -15,7 +15,9 @@ namespace Sylius\Resource\Symfony\Form\Factory;
 
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
+use Sylius\Resource\Exception\InvalidArgumentException;
 use Sylius\Resource\Metadata\Operation;
+use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
 use Symfony\Component\Form\FormFactoryInterface as SymfonyFormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -24,17 +26,17 @@ use Symfony\Component\Form\FormInterface;
  */
 final class FormFactory implements FormFactoryInterface
 {
-    private SymfonyFormFactoryInterface $formFactory;
-
-    public function __construct(SymfonyFormFactoryInterface $formFactory)
-    {
-        $this->formFactory = $formFactory;
+    public function __construct(
+        private readonly SymfonyFormFactoryInterface $formFactory,
+        private readonly ArgumentParserInterface $argumentParser,
+    ) {
     }
 
     public function create(Operation $operation, Context $context, mixed $data = null): FormInterface
     {
         $formType = $operation->getFormType();
         $formOptions = $operation->getFormOptions() ?? [];
+        $formOptions = $this->parseFormOptions($formOptions);
 
         if (null === $formType) {
             throw new \RuntimeException(sprintf('Operation "%s" has no configured form type.', $operation->getName() ?? ''));
@@ -47,5 +49,35 @@ final class FormFactory implements FormFactoryInterface
         }
 
         return $this->formFactory->createNamed('', $formType, $data, array_merge($formOptions, ['csrf_protection' => false]));
+    }
+
+    /**
+     * @param array<string, mixed> $formOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function parseFormOptions(array $formOptions): array
+    {
+        foreach ($formOptions as $key => $value) {
+            if (\is_array($value)) {
+                $formOptions[$key] = $this->parseFormOptions($formOptions[$key]);
+
+                continue;
+            }
+
+            if (!\is_scalar($value)) {
+                throw new InvalidArgumentException(sprintf('Parameter "%s" should be a scalar or an array.', $key));
+            }
+
+            if (!is_string($value) || !str_starts_with($value, '@=')) {
+                continue;
+            }
+
+            $value = substr($value, 2);
+
+            $formOptions[$key] = $this->argumentParser->parseExpression($value);
+        }
+
+        return $formOptions;
     }
 }

--- a/src/Component/src/Symfony/Form/Factory/FormFactory.php
+++ b/src/Component/src/Symfony/Form/Factory/FormFactory.php
@@ -59,7 +59,7 @@ final class FormFactory implements FormFactoryInterface
     {
         foreach ($formOptions as $key => $value) {
             if (\is_array($value)) {
-                $formOptions[$key] = $this->parseFormOptions($formOptions[$key]);
+                $formOptions[$key] = $this->parseFormOptions($value);
 
                 continue;
             }

--- a/src/Component/src/Symfony/Form/Factory/FormFactory.php
+++ b/src/Component/src/Symfony/Form/Factory/FormFactory.php
@@ -35,8 +35,7 @@ final class FormFactory implements FormFactoryInterface
     public function create(Operation $operation, Context $context, mixed $data = null): FormInterface
     {
         $formType = $operation->getFormType();
-        $formOptions = $operation->getFormOptions() ?? [];
-        $formOptions = $this->parseFormOptions($formOptions);
+        $formOptions = $this->parseFormOptions($operation->getFormOptions() ?? []);
 
         if (null === $formType) {
             throw new \RuntimeException(sprintf('Operation "%s" has no configured form type.', $operation->getName() ?? ''));

--- a/src/Component/tests/Symfony/Form/Factory/FormFactoryTest.php
+++ b/src/Component/tests/Symfony/Form/Factory/FormFactoryTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Resource\Tests\Symfony\Form\Factory;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
 use Sylius\Resource\Metadata\Operation;
+use Sylius\Resource\Symfony\ExpressionLanguage\ArgumentParserInterface;
 use Sylius\Resource\Symfony\Form\Factory\FormFactory;
 use Symfony\Component\Form\FormFactoryInterface as SymfonyFormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -24,14 +26,17 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class FormFactoryTest extends TestCase
 {
-    private SymfonyFormFactoryInterface $symfonyFormFactory;
+    private SymfonyFormFactoryInterface&MockObject $symfonyFormFactory;
+
+    private ArgumentParserInterface&MockObject $argumentParser;
 
     private FormFactory $formFactory;
 
     protected function setUp(): void
     {
         $this->symfonyFormFactory = $this->createMock(SymfonyFormFactoryInterface::class);
-        $this->formFactory = new FormFactory($this->symfonyFormFactory);
+        $this->argumentParser = $this->createMock(ArgumentParserInterface::class);
+        $this->formFactory = new FormFactory($this->symfonyFormFactory, $this->argumentParser);
     }
 
     public function testItIsInitializable(): void
@@ -72,6 +77,36 @@ final class FormFactoryTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with('App\Form\DummyType', null, ['foo' => 'fighters'])
+            ->willReturn($form);
+
+        $result = $this->formFactory->create($operation, new Context(new RequestOption($request)));
+
+        $this->assertSame($form, $result);
+    }
+
+    public function testItUsesExpressionParserForExpressionLanguagePrefixedFormOptions(): void
+    {
+        $operation = $this->createMock(Operation::class);
+        $form = $this->createMock(FormInterface::class);
+        $request = $this->createMock(Request::class);
+
+        $operation->method('getFormType')->willReturn('App\Form\DummyType');
+        $operation->method('getFormOptions')->willReturn(['customer' => '@=sylius_context_shopper.getCustomer()']);
+        $request->method('getRequestFormat')->willReturn('html');
+
+        $customer = new \StdClass();
+
+        $this->argumentParser
+            ->expects($this->exactly(1))
+            ->method('parseExpression')
+            ->with('sylius_context_shopper.getCustomer()')
+            ->willReturn($customer)
+        ;
+
+        $this->symfonyFormFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with('App\Form\DummyType', null, ['customer' => $customer])
             ->willReturn($form);
 
         $result = $this->formFactory->create($operation, new Context(new RequestOption($request)));

--- a/src/Component/tests/Symfony/Form/Factory/FormFactoryTest.php
+++ b/src/Component/tests/Symfony/Form/Factory/FormFactoryTest.php
@@ -100,8 +100,7 @@ final class FormFactoryTest extends TestCase
             ->expects($this->exactly(1))
             ->method('parseExpression')
             ->with('sylius_context_shopper.getCustomer()')
-            ->willReturn($customer)
-        ;
+            ->willReturn($customer);
 
         $this->symfonyFormFactory
             ->expects($this->once())


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially https://github.com/Sylius/Sylius/issues/18212
| License         | MIT

We need this to convert this current route on Sylius
```yaml
sylius_shop_checkout_address:
    # ...
    defaults:
        _sylius:
            form:
                type: Sylius\Bundle\ShopBundle\Form\Type\Checkout\AddressType
                options:
                    customer: expr:service('sylius.context.customer').getCustomer()
```
