### PR TITLE
feat(notification): Translate resource name in flash messages

### DIFF
--- a/src/Bundle/Controller/FlashHelper.php
+++ b/src/Bundle/Controller/FlashHelper.php
@@ -19,13 +19,12 @@ use Sylius\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use function Symfony\Component\String\u;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class FlashHelper implements FlashHelperInterface
 {
-    private const UI_TRANSLATION_PREFIX = 'sylius.ui.';
-
     /** @var RequestStack|SessionInterface */
     private $requestStack;
 
@@ -149,30 +148,27 @@ final class FlashHelper implements FlashHelperInterface
 
     private function getParametersWithName(MetadataInterface $metadata, string $actionName): array
     {
+        $applicationName = $metadata->getApplicationName();
+
         if (stripos($actionName, 'bulk') !== false) {
             $resourceName = $metadata->getPluralName();
             $fallback = ucfirst($resourceName);
 
-            return ['%resources%' => $this->translateResourceName($resourceName, $fallback)];
+            return ['%resources%' => $this->translateResourceName($applicationName, $resourceName, $fallback)];
         }
 
         $resourceName = $metadata->getName();
         $fallback = ucfirst($metadata->getHumanizedName());
 
-        return ['%resource%' => $this->translateResourceName($resourceName, $fallback)];
+        return ['%resource%' => $this->translateResourceName($applicationName, $resourceName, $fallback)];
     }
 
-    private function translateResourceName(string $resourceName, string $fallback): string
+    private function translateResourceName(string $applicationName, string $resourceName, string $fallback): string
     {
-        $snakeCaseName = $this->convertToSnakeCase($resourceName);
-        $translationKey = sprintf('%s%s', self::UI_TRANSLATION_PREFIX, $snakeCaseName);
+        $snakeCaseName = u($resourceName)->snake()->toString();
+        $translationKey = sprintf('%s.ui.%s', $applicationName, $snakeCaseName);
         $translated = $this->translator->trans($translationKey, [], 'messages');
 
         return $translated === $translationKey ? $fallback : $translated;
-    }
-
-    private function convertToSnakeCase(string $input): string
-    {
-        return strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1_$2', $input));
     }
 }

--- a/src/Component/src/Symfony/Session/Flash/FlashHelper.php
+++ b/src/Component/src/Symfony/Session/Flash/FlashHelper.php
@@ -137,10 +137,12 @@ final class FlashHelper implements FlashHelperInterface
             return [];
         }
 
-        $humanizedName = ucfirst(StringHumanizer::humanize($resource->getName() ?? ''));
+        $resourceName = $this->translateResource($resource);
+        $humanizedName = $resourceName ?? ucfirst(StringHumanizer::humanize($resource->getName() ?? ''));
 
         if ($operation instanceof BulkOperationInterface) {
-            $humanizedPluralName = ucfirst(StringHumanizer::humanize($resource->getPluralName() ?? ''));
+            $resourcePluralName = $this->translateResource($resource, true);
+            $humanizedPluralName = $resourcePluralName ?? ucfirst(StringHumanizer::humanize($resource->getPluralName() ?? ''));
 
             return [
                 '%resource%' => $humanizedName,
@@ -149,6 +151,21 @@ final class FlashHelper implements FlashHelperInterface
         }
 
         return ['%resource%' => $humanizedName];
+    }
+
+    private function translateResource(ResourceMetadata $resource, bool $plurialize = false): ?string
+    {
+        $translationKey = sprintf(
+            '%s.ui.%s',
+            $resource->getApplicationName() ?? '',
+            $plurialize ? ($resource->getPluralName() ?? '') : ($resource->getName() ?? ''),
+        );
+
+        if ($this->translator instanceof TranslatorBagInterface && $this->translator->getCatalogue()->has($translationKey)) {
+            return $this->translator->trans($translationKey);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Component/tests/Symfony/Session/Flash/FlashHelperTest.php
+++ b/src/Component/tests/Symfony/Session/Flash/FlashHelperTest.php
@@ -186,6 +186,28 @@ final class FlashHelperTest extends TestCase
         $this->assertSame('Admin user was created successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
+    public function testItAddsSuccessFlashesWithTranslatedResourceInTheMessage(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'sylius.resource.create' => '%resource% was created successfully.',
+        ], [
+            'app.ui.promotion' => 'Cart promotion',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new Create())->withResource(new ResourceMetadata(alias: 'app.promotion', name: 'promotion', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Cart promotion was created successfully.', $session->getFlashBag()->all()['success'][0]);
+    }
+
     public function testItAddsSuccessFlashesWithHumanizedMessageAndPluralNameOnBulkOperation(): void
     {
         $session = new Session();
@@ -204,6 +226,28 @@ final class FlashHelperTest extends TestCase
         $flashHelper->addSuccessFlash($operation, $context);
 
         $this->assertSame('Admin users was removed successfully.', $session->getFlashBag()->all()['success'][0]);
+    }
+
+    public function testItAddsSuccessFlashesWithTranslatedResourceWithPluralNameInTheMessageOnBulkOperation(): void
+    {
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
+
+        $translator = $this->createTranslator([
+            'app.promotion.bulk_delete' => '%resources% was removed successfully.',
+        ], [
+            'app.ui.promotions' => 'Cart promotions',
+        ]);
+
+        $flashHelper = new FlashHelper($translator);
+
+        $operation = (new BulkDelete())->withResource(new ResourceMetadata(alias: 'app.promotion', name: 'promotion', pluralName: 'promotions', applicationName: 'app'));
+        $context = new Context(new RequestOption($request));
+
+        $flashHelper->addSuccessFlash($operation, $context);
+
+        $this->assertSame('Cart promotions was removed successfully.', $session->getFlashBag()->all()['success'][0]);
     }
 
     public function testItAddsErrorFlashesWithCustomMessage(): void
@@ -417,17 +461,24 @@ final class FlashHelperTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $translations
+     * @param array<string, string> $flashesTranslations
+     * @param array<string, string> $messagesTranslations
      */
-    private function createTranslator(array $translations = []): TranslatorInterface&TranslatorBagInterface
+    private function createTranslator(array $flashesTranslations = [], array $messagesTranslations = []): TranslatorInterface&TranslatorBagInterface
     {
         $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
 
-        foreach ($translations as $key => $translation) {
+        foreach ($flashesTranslations as $key => $translation) {
             $translator->addResource('array', [
                 $key => $translation,
             ], 'en', 'flashes');
+        }
+
+        foreach ($messagesTranslations as $key => $translation) {
+            $translator->addResource('array', [
+                $key => $translation,
+            ], 'en', 'messages');
         }
 
         return $translator;

--- a/tests/Bundle/Controller/FlashHelperTest.php
+++ b/tests/Bundle/Controller/FlashHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\Tests\Controller;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ResourceBundle\Controller\FlashHelper;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[CoversClass(FlashHelper::class)]
 final class FlashHelperTest extends TestCase
 {
     private FlashHelper $flashHelper;
@@ -51,7 +53,7 @@ final class FlashHelperTest extends TestCase
 
     public function testAddsSuccessFlashWithTranslatedResourceNameForSingleResource(): void
     {
-        $this->configureTranslator(['sylius.ui.product' => 'Product']);
+        $this->configureTranslator(['app.ui.product' => 'Product']);
         $requestConfiguration = $this->createRequestConfiguration('product', 'sylius.resource.create');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'create');
@@ -61,7 +63,7 @@ final class FlashHelperTest extends TestCase
 
     public function testAddsSuccessFlashWithTranslatedPluralResourceNameForBulkAction(): void
     {
-        $this->configureTranslator(['sylius.ui.products' => 'Products']);
+        $this->configureTranslator(['app.ui.products' => 'Products']);
         $requestConfiguration = $this->createRequestConfiguration('product', 'sylius.resource.bulk_delete', 'products');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'bulk_delete');
@@ -71,7 +73,7 @@ final class FlashHelperTest extends TestCase
 
     public function testConvertsCamelCaseToSnakeCaseForResourceNames(): void
     {
-        $this->configureTranslator(['sylius.ui.product_variant' => 'Product Variant']);
+        $this->configureTranslator(['app.ui.product_variant' => 'Product Variant']);
         $requestConfiguration = $this->createRequestConfiguration('productVariant', 'sylius.resource.update');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'update');
@@ -81,7 +83,7 @@ final class FlashHelperTest extends TestCase
 
     public function testConvertsCamelCaseToSnakeCaseForPluralResourceNames(): void
     {
-        $this->configureTranslator(['sylius.ui.product_variants' => 'Product Variants']);
+        $this->configureTranslator(['app.ui.product_variants' => 'Product Variants']);
         $requestConfiguration = $this->createRequestConfiguration('productVariant', 'sylius.resource.bulk_update', 'productVariants');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'bulk_update');
@@ -91,7 +93,7 @@ final class FlashHelperTest extends TestCase
 
     public function testAddsErrorFlashWithTranslatedResourceName(): void
     {
-        $this->configureTranslator(['sylius.ui.customer' => 'Customer']);
+        $this->configureTranslator(['app.ui.customer' => 'Customer']);
         $requestConfiguration = $this->createRequestConfiguration('customer', 'sylius.resource.delete');
 
         $this->flashHelper->addErrorFlash($requestConfiguration, 'delete');
@@ -111,7 +113,7 @@ final class FlashHelperTest extends TestCase
 
     public function testTranslatesResourceNameToGerman(): void
     {
-        $this->configureTranslator(['sylius.ui.product' => 'Produkt']);
+        $this->configureTranslator(['app.ui.product' => 'Produkt']);
         $requestConfiguration = $this->createRequestConfiguration('product', 'sylius.resource.create');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'create');
@@ -121,7 +123,7 @@ final class FlashHelperTest extends TestCase
 
     public function testTranslatesPluralResourceNameToGerman(): void
     {
-        $this->configureTranslator(['sylius.ui.products' => 'Produkte']);
+        $this->configureTranslator(['app.ui.products' => 'Produkte']);
         $requestConfiguration = $this->createRequestConfiguration('product', 'sylius.resource.bulk_delete', 'products');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'bulk_delete');
@@ -131,7 +133,7 @@ final class FlashHelperTest extends TestCase
 
     public function testTranslatesResourceNameToGermanForUpdate(): void
     {
-        $this->configureTranslator(['sylius.ui.customer' => 'Kunde']);
+        $this->configureTranslator(['app.ui.customer' => 'Kunde']);
         $requestConfiguration = $this->createRequestConfiguration('customer', 'sylius.resource.update');
 
         $this->flashHelper->addSuccessFlash($requestConfiguration, 'update');
@@ -139,11 +141,11 @@ final class FlashHelperTest extends TestCase
         $this->assertFlashMessage('success', 'sylius.resource.update', ['%resource%' => 'Kunde']);
     }
 
-    private function createRequestConfiguration(string $resourceName, string $flashMessage, ?string $pluralName = null): RequestConfiguration
+    private function createRequestConfiguration(string $resourceName, string $flashMessage, ?string $pluralName = null, ?string $applicationName = null): RequestConfiguration
     {
         $metadata = $this->createMock(MetadataInterface::class);
         $metadata->method('getName')->willReturn($resourceName);
-        $metadata->method('getApplicationName')->willReturn('app');
+        $metadata->method('getApplicationName')->willReturn($applicationName ?? 'app');
 
         if ($pluralName !== null) {
             $metadata->method('getPluralName')->willReturn($pluralName);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This improves the feature added in https://github.com/Sylius/SyliusResourceBundle/pull/1089
It also adds the same feature in the new FlashHelper.