### PR TITLE
fix(provider) Fix parsing nested repository arguments

### DIFF
--- a/src/Component/src/Symfony/Request/State/Provider.php
+++ b/src/Component/src/Symfony/Request/State/Provider.php
@@ -18,6 +18,7 @@ use Psr\Container\ContainerInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\CreatePaginatorTrait;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
+use Sylius\Resource\Exception\InvalidArgumentException;
 use Sylius\Resource\Exception\RuntimeException;
 use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\CollectionOperationInterface;
@@ -118,22 +119,36 @@ final class Provider implements ProviderInterface
     private function parseArgumentValues(array $arguments): array
     {
         foreach ($arguments as $key => $value) {
-            if (!str_starts_with($value, '@=')) {
-                $value = '@=' . $value;
-                trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
-            }
-
-            // Not reachable as long as the BC layer above is there
-            if (!str_starts_with($value, '@=')) {
-                $arguments[$key] = $value;
+            if (is_array($value)) {
+                $arguments[$key] = $this->parseArgumentValues($value);
 
                 continue;
             }
 
-            $value = substr($value, 2);
-            $arguments[$key] = $this->argumentParser->parseExpression($value);
+            if (!\is_scalar($value)) {
+                throw new InvalidArgumentException(sprintf('Parameter "%s" should be a scalar or an array.', $key));
+            }
+
+            $arguments[$key] = \is_string($value) ? $this->parseStringValue($value) : $value;
         }
 
         return $arguments;
+    }
+
+    private function parseStringValue(string $value): mixed
+    {
+        if (!str_starts_with($value, '@=')) {
+            $value = '@=' . $value;
+            trigger_deprecation('sylius/resource-bundle', '1.14', 'You passed "%s" as a string value in your repository arguments. If this is a value that needs to be parsed using the expression language, please prefix your string with "@=". In your case, use "@=%s"."', $value, $value);
+        }
+
+        // Not reachable as long as the BC layer above is there
+        if (!str_starts_with($value, '@=')) {
+            return $value;
+        }
+
+        $value = substr($value, 2);
+
+        return $this->argumentParser->parseExpression($value);
     }
 }

--- a/src/Component/tests/Symfony/Request/State/ProviderTest.php
+++ b/src/Component/tests/Symfony/Request/State/ProviderTest.php
@@ -21,6 +21,7 @@ use Sylius\Component\Resource\Tests\Dummy\RepositoryWithCallables;
 use Sylius\Resource\Context\Context;
 use Sylius\Resource\Context\Option\RequestOption;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
+use Sylius\Resource\Exception\InvalidArgumentException;
 use Sylius\Resource\Exception\RuntimeException;
 use Sylius\Resource\Metadata\Index;
 use Sylius\Resource\Metadata\Operation;
@@ -199,6 +200,33 @@ final class ProviderTest extends TestCase
         $this->assertSame($stdClass, $response);
     }
 
+    public function testItParsesNestedArrayArguments(): void
+    {
+        $operation = $this->createMock(Operation::class);
+        $request = $this->createMock(Request::class);
+        $repository = $this->createMock(RepositoryInterface::class);
+        $stdClass = new \stdClass();
+
+        $operation->method('getRepository')->willReturn('App\Repository');
+        $operation->method('getRepositoryMethod')->willReturn('findOneBy');
+        $operation->method('getRepositoryArguments')->willReturn([['tokenValue' => "@=request.attributes.get('tokenValue')"]]);
+
+        $this->argumentParser
+            ->expects($this->once())
+            ->method('parseExpression')
+            ->with("request.attributes.get('tokenValue')")
+            ->willReturn('my_token');
+
+        $this->locator->method('has')->with('App\Repository')->willReturn(true);
+        $this->locator->method('get')->with('App\Repository')->willReturn($repository);
+
+        $repository->method('findOneBy')->with(['tokenValue' => 'my_token'])->willReturn($stdClass);
+
+        $response = $this->provider->provide($operation, new Context(new RequestOption($request)));
+
+        $this->assertSame($stdClass, $response);
+    }
+
     public function testItThrowsAnExceptionWhenRepositoryMethodDoesNotExist(): void
     {
         $operation = $this->createMock(Operation::class);
@@ -242,6 +270,25 @@ final class ProviderTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($errorMessage);
+
+        $this->provider->provide($operation, new Context(new RequestOption($request)));
+    }
+
+    public function testItThrowsAnExceptionWhenRepositoryArgumentsAreNotScalarOnes(): void
+    {
+        $operation = $this->createMock(Operation::class);
+        $request = $this->createMock(Request::class);
+        $repository = $this->createMock(RepositoryInterface::class);
+
+        $operation->method('getRepository')->willReturn('App\Repository');
+        $operation->method('getRepositoryMethod')->willReturn('findOneBy');
+        $operation->method('getRepositoryArguments')->willReturn([['foo' => 'resource.code', 'bar' => new \stdClass()]]);
+
+        $this->locator->method('has')->with('App\Repository')->willReturn(true);
+        $this->locator->method('get')->with('App\Repository')->willReturn($repository);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "bar" should be a scalar or an array.');
 
         $this->provider->provide($operation, new Context(new RequestOption($request)));
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

We need this fix to parse findOneBy arguments:
```yaml
sylius_shop_order_show:
    # ...
    defaults:
        _sylius:
            repository:
                method: findOneBy
                arguments: [tokenValue: $tokenValue]
```

With the conversion, we have a nested array like this:
```php
new Update(
    // ...
    repositoryMethod: 'findOneBy',
    repositoryArguments: [
        [
            'tokenValue' => "@=request.attributes.get('tokenValue')",
        ],
    ],
),
```