### PR TITLE
feat(routing): Use the PathSegmentNameGenerator with operation short …

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,48 @@
+## UPGRADE FOR `1.15.x`
+
+### FROM `1.14.x` to `1.15.x`
+
+#### Routing Path
+
+Routing paths may have been changed depending on your configuration.
+
+*Using ResourceController*
+
+```yaml
+# config/packages/
+sylius_resource:
+    routing_path_bc_layer: false
+```
+
+If you have disabled the routing path bc-layer, the bulk delete operations will have this path change:
+
+example:
+```diff
+-/science-books/bulk_delete
++/science-books/bulk-delete
+```
+
+*Using the new routing system with `AsResource` attribute and operations*
+
+If the shortName of your operation contains an underscore, it will be replaced by a dash.
+
+example:
+```diff
+-/subscriptions/bulk_delete
++/subscriptions/bulk-delete
+-/subscriptions/bulk_publish
++/subscriptions/bulk-publish
+```
+
+Note this will keep an underscore if you have configured the resource bundle like this:
+```yaml
+# config/packages/
+sylius_resource:
+    path_segment_name_generator: sylius.metadata.path_segment_name_generator.underscore
+```
+
+Please note this configuration is not recommended for SEO.
+
 ## UPGRADE FOR `1.14.x`
 
 ### FROM `1.13.x` to `1.14.x`

--- a/src/Bundle/Resources/config/services/routing.php
+++ b/src/Bundle/Resources/config/services/routing.php
@@ -95,27 +95,50 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('sylius.routing.factory.operation_route_path_factory.collection', CollectionOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, 60)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ])
+    ;
 
     $services->set('sylius.routing.factory.operation_route_path_factory.create', CreateOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, -50)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ])
+    ;
 
     $services->set('sylius.routing.factory.operation_route_path_factory.bulk_operation', BulkOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, -40)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ]);
 
     $services->set('sylius.routing.factory.operation_route_path_factory.update', UpdateOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, -30)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ])
+    ;
 
     $services->set('sylius.routing.factory.operation_route_path_factory.delete', DeleteOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, -20)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ])
+    ;
 
     $services->set('sylius.routing.factory.operation_route_path_factory.show', ShowOperationRoutePathFactory::class)
         ->decorate('sylius.routing.factory.operation_route_path_factory.default', null, -10)
-        ->args([service('.inner')]);
+        ->args([
+            service('.inner'),
+            service('sylius.path_segment_name_generator'),
+        ])
+    ;
 
     $services->set('sylius.routing.factory.route_attributes', RouteAttributesFactory::class)
         ->private();

--- a/src/Bundle/Routing/ResourceLoader.php
+++ b/src/Bundle/Routing/ResourceLoader.php
@@ -110,7 +110,7 @@ final class ResourceLoader extends Loader
                 $httpMethods[] = 'POST';
             }
 
-            $bulkDeleteRoute = $this->createRoute($metadata, $configuration, $rootPath . '/' . ($bcLayerEnabled ? 'bulk-delete' : 'bulk_delete'), 'bulkDelete', $httpMethods, $isApi);
+            $bulkDeleteRoute = $this->createRoute($metadata, $configuration, $rootPath . '/' . 'bulk-delete', 'bulkDelete', $httpMethods, $isApi);
             $routes->add($this->getRouteName($metadata, $configuration, 'bulk_delete'), $bulkDeleteRoute);
         }
 

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactory.php
@@ -15,14 +15,17 @@ namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\BulkOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 
 /**
  * @experimental
  */
 final class BulkOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -30,7 +33,7 @@ final class BulkOperationRoutePathFactory implements OperationRoutePathFactoryIn
         $shortName = $operation->getShortName() ?? '';
 
         if ($operation instanceof BulkOperationInterface) {
-            return sprintf('%s/%s', $rootPath, $shortName);
+            return sprintf('%s/%s', $rootPath, $this->pathSegmentNameGenerator->getSegmentName($shortName, false));
         }
 
         return $this->decorated->createRoutePath($operation, $rootPath);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactory.php
@@ -15,14 +15,17 @@ namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\CollectionOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 
 /**
  * @experimental
  */
 final class CollectionOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -32,7 +35,7 @@ final class CollectionOperationRoutePathFactory implements OperationRoutePathFac
         if ($operation instanceof CollectionOperationInterface) {
             $path = match ($shortName) {
                 'index', 'get_collection' => '',
-                default => '/' . $shortName,
+                default => '/' . $this->pathSegmentNameGenerator->getSegmentName($shortName ?? '', false),
             };
 
             return sprintf('%s%s', $rootPath, $path);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactory.php
@@ -15,14 +15,17 @@ namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\CreateOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 
 /**
  * @experimental
  */
 final class CreateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -33,7 +36,7 @@ final class CreateOperationRoutePathFactory implements OperationRoutePathFactory
             $path = match ($shortName) {
                 'create' => '/new',
                 'post' => '',
-                default => '/' . $shortName,
+                default => '/' . $this->pathSegmentNameGenerator->getSegmentName($shortName ?? '', false),
             };
 
             return sprintf('%s%s', $rootPath, $path);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactory.php
@@ -16,14 +16,17 @@ namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 use Sylius\Resource\Metadata\Api\ApiOperationInterface;
 use Sylius\Resource\Metadata\DeleteOperationInterface;
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 
 /**
  * @experimental
  */
 final class DeleteOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -32,7 +35,10 @@ final class DeleteOperationRoutePathFactory implements OperationRoutePathFactory
         $identifier = $operation->getResource()?->getIdentifier() ?? 'id';
 
         if ($operation instanceof DeleteOperationInterface) {
-            $path = $operation instanceof ApiOperationInterface && 'delete' === $shortName ? '' : '/' . $shortName;
+            $path = $operation instanceof ApiOperationInterface && 'delete' === $shortName
+                ? ''
+                : '/' . $this->pathSegmentNameGenerator->getSegmentName($shortName ?? '', false)
+            ;
 
             return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);
         }

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 use Sylius\Resource\Metadata\ShowOperationInterface;
 
 /**
@@ -21,8 +22,10 @@ use Sylius\Resource\Metadata\ShowOperationInterface;
  */
 final class ShowOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -33,7 +36,7 @@ final class ShowOperationRoutePathFactory implements OperationRoutePathFactoryIn
         if ($operation instanceof ShowOperationInterface) {
             $path = match ($shortName) {
                 'show', 'get' => '',
-                default => '/' . $shortName,
+                default => '/' . $this->pathSegmentNameGenerator->getSegmentName($shortName ?? '', false),
             };
 
             return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);

--- a/src/Component/src/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactory.php
+++ b/src/Component/src/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Resource\Symfony\Routing\Factory\RoutePath;
 
 use Sylius\Resource\Metadata\HttpOperation;
+use Sylius\Resource\Metadata\Operation\PathSegmentNameGeneratorInterface;
 use Sylius\Resource\Metadata\UpdateOperationInterface;
 
 /**
@@ -21,8 +22,10 @@ use Sylius\Resource\Metadata\UpdateOperationInterface;
  */
 final class UpdateOperationRoutePathFactory implements OperationRoutePathFactoryInterface
 {
-    public function __construct(private OperationRoutePathFactoryInterface $decorated)
-    {
+    public function __construct(
+        private OperationRoutePathFactoryInterface $decorated,
+        private PathSegmentNameGeneratorInterface $pathSegmentNameGenerator,
+    ) {
     }
 
     public function createRoutePath(HttpOperation $operation, string $rootPath): string
@@ -34,7 +37,7 @@ final class UpdateOperationRoutePathFactory implements OperationRoutePathFactory
             $path = match ($shortName) {
                 'update' => '/edit',
                 'put', 'patch' => '',
-                default => '/' . $shortName,
+                default => '/' . $this->pathSegmentNameGenerator->getSegmentName($shortName ?? '', false),
             };
 
             return sprintf('%s/{%s}%s', $rootPath, $identifier, $path);

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/BulkOperationRoutePathFactoryTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\BulkDelete;
 use Sylius\Resource\Metadata\BulkUpdate;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\BulkOperationRoutePathFactory;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
@@ -29,7 +31,10 @@ final class BulkOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->bulkOperationRoutePathFactory = new BulkOperationRoutePathFactory($this->routePathFactory);
+        $this->bulkOperationRoutePathFactory = new BulkOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForBulkDeleteOperations(): void
@@ -38,7 +43,7 @@ final class BulkOperationRoutePathFactoryTest extends TestCase
 
         $result = $this->bulkOperationRoutePathFactory->createRoutePath($operation, '/dummies');
 
-        $this->assertSame('/dummies/bulk_delete', $result);
+        $this->assertSame('/dummies/bulk-delete', $result);
     }
 
     public function testItGeneratesRoutePathForBulkUpdateOperations(): void
@@ -47,7 +52,7 @@ final class BulkOperationRoutePathFactoryTest extends TestCase
 
         $result = $this->bulkOperationRoutePathFactory->createRoutePath($operation, '/dummies');
 
-        $this->assertSame('/dummies/bulk_update', $result);
+        $this->assertSame('/dummies/bulk-update', $result);
     }
 
     public function testItDelegatesToDecoratedFactoryForNonBulkOperations(): void

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/CollectionOperationRoutePathFactoryTest.php
@@ -16,6 +16,8 @@ namespace Sylius\Resource\Tests\Symfony\Routing\Factory\RoutePath;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\CollectionOperationRoutePathFactory;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
@@ -29,7 +31,10 @@ final class CollectionOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->collectionOperationRoutePathFactory = new CollectionOperationRoutePathFactory($this->routePathFactory);
+        $this->collectionOperationRoutePathFactory = new CollectionOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForIndexOperations(): void

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/CreateOperationRoutePathFactoryTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Create;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\CreateOperationRoutePathFactory;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
 
@@ -29,7 +31,10 @@ final class CreateOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->createOperationRoutePathFactory = new CreateOperationRoutePathFactory($this->routePathFactory);
+        $this->createOperationRoutePathFactory = new CreateOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForCreateOperations(): void

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/DeleteOperationRoutePathFactoryTest.php
@@ -16,6 +16,8 @@ namespace Sylius\Resource\Tests\Symfony\Routing\Factory\RoutePath;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Delete;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\DeleteOperationRoutePathFactory;
@@ -30,7 +32,10 @@ final class DeleteOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->deleteOperationRoutePathFactory = new DeleteOperationRoutePathFactory($this->routePathFactory);
+        $this->deleteOperationRoutePathFactory = new DeleteOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForDeleteOperations(): void

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/ShowOperationRoutePathFactoryTest.php
@@ -16,6 +16,8 @@ namespace Sylius\Resource\Tests\Symfony\Routing\Factory\RoutePath;
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Api;
 use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Symfony\Routing\Factory\RoutePath\OperationRoutePathFactoryInterface;
@@ -30,7 +32,10 @@ final class ShowOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->showOperationRoutePathFactory = new ShowOperationRoutePathFactory($this->routePathFactory);
+        $this->showOperationRoutePathFactory = new ShowOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForShowOperations(): void

--- a/src/Component/tests/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactoryTest.php
+++ b/src/Component/tests/Symfony/Routing/Factory/RoutePath/UpdateOperationRoutePathFactoryTest.php
@@ -15,6 +15,8 @@ namespace Sylius\Resource\Tests\Symfony\Routing\Factory\RoutePath;
 
 use PHPUnit\Framework\TestCase;
 use Sylius\Resource\Metadata\Api;
+use Sylius\Resource\Metadata\Inflector\Inflector;
+use Sylius\Resource\Metadata\Operation\DashPathSegmentNameGenerator;
 use Sylius\Resource\Metadata\ResourceMetadata;
 use Sylius\Resource\Metadata\Show;
 use Sylius\Resource\Metadata\Update;
@@ -30,7 +32,10 @@ final class UpdateOperationRoutePathFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->routePathFactory = $this->createMock(OperationRoutePathFactoryInterface::class);
-        $this->updateOperationRoutePathFactory = new UpdateOperationRoutePathFactory($this->routePathFactory);
+        $this->updateOperationRoutePathFactory = new UpdateOperationRoutePathFactory(
+            $this->routePathFactory,
+            new DashPathSegmentNameGenerator(new Inflector()),
+        );
     }
 
     public function testItGeneratesRoutePathForUpdateOperations(): void

--- a/tests/Bundle/Routing/ResourceLoaderTest.php
+++ b/tests/Bundle/Routing/ResourceLoaderTest.php
@@ -259,7 +259,7 @@ YAML;
         $this->assertNotNull($bulkDeleteRoute);
         $this->assertContains('DELETE', $bulkDeleteRoute->getMethods());
         $this->assertContains('POST', $bulkDeleteRoute->getMethods());
-        $this->assertEquals('/products/bulk_delete', $bulkDeleteRoute->getPath());
+        $this->assertEquals('/products/bulk-delete', $bulkDeleteRoute->getPath());
     }
 
     public function testItGeneratesBulkDeleteRoutingWithBcLayerEnabled(): void


### PR DESCRIPTION
…names

| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

We introduced the PathSegmentNameGeneratorInterface in #1108, but we do not use it when using the operation short name to generate the route path.
You can look at the UPGRADE.md for more details.