### PR TITLE
Fix sourceEntity not updated when copying parent association mappings

### DIFF
--- a/src/Bundle/EventListener/ORMMappedSuperClassSubscriber.php
+++ b/src/Bundle/EventListener/ORMMappedSuperClassSubscriber.php
@@ -83,6 +83,7 @@ final class ORMMappedSuperClassSubscriber extends AbstractDoctrineListener imple
             if ($parentMetadata->isMappedSuperclass) {
                 foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
                     if ($this->isRelation($value['type']) && !isset($metadata->associationMappings[$key])) {
+                        $value['sourceEntity'] = $class;
                         $metadata->associationMappings[$key] = $value;
                     }
                 }


### PR DESCRIPTION
## Summary

`ORMMappedSuperClassSubscriber::setAssociationMappings()` copies association mappings from a parent mapped-superclass without updating `sourceEntity` to the child entity class. This causes Doctrine's `BasicEntityPersister` to generate incorrect SQL table aliases when eager-loading inverse one-to-one associations.

## The problem

When an application overrides a resource model (e.g. `App\Entity\Vendor` extends plugin's `BaseVendor`), the subscriber copies associations from the parent:

```php
$metadata->associationMappings[$key] = $value; // sourceEntity stays as BaseVendor
```

Doctrine's own `ClassMetadataFactory::addInheritedRelations()` would update `sourceEntity` to the child class, but the subscriber bypasses that logic.

When `sourceEntity` doesn't match the concrete entity name, `BasicEntityPersister::getSQLTableAlias()` generates a different cache key, producing a non-existent table alias:

```sql
-- Broken: t23 doesn't exist
LEFT JOIN vendor t8 ON t23.profile_id = t0.id

-- Expected:
LEFT JOIN vendor t8 ON t8.profile_id = t0.id
```

## The fix

Set `sourceEntity` to the child class before assigning the mapping:

```php
$value['sourceEntity'] = $class;
$metadata->associationMappings[$key] = $value;
```

## How to trigger

All three conditions must be true:

1. A plugin defines a bidirectional one-to-one between two mapped-superclasses (e.g. `Vendor ↔ Profile`)
2. The inverse side uses an interface as `target-entity` (resolved via `ResolveTargetEntityListener`)
3. The application overrides the owning-side entity via `sylius_resource` config