### PR TITLE
Fix sourceEntity not updated when copying parent association mappings

### DIFF
--- a/src/Bundle/EventListener/ORMMappedSuperClassSubscriber.php
+++ b/src/Bundle/EventListener/ORMMappedSuperClassSubscriber.php
@@ -87,6 +87,13 @@ final class ORMMappedSuperClassSubscriber extends AbstractDoctrineListener imple
                 foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
                     $type = \is_array($value) ? $value['type'] : $value->type();
                     if ($this->isRelation($type) && !isset($metadata->associationMappings[$key])) {
+                        if (\is_array($value)) {
+                            $value['sourceEntity'] = $class;
+                        } else {
+                            /** @psalm-suppress UndefinedClass */
+                            $value->sourceEntity = $class; /** @phpstan-ignore-line */
+                        }
+
                         $metadata->associationMappings[$key] = $value; /** @phpstan-ignore-line */
                     }
                 }

--- a/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
+++ b/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
@@ -18,48 +18,55 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber;
 use Sylius\Bundle\ResourceBundle\Tests\Fixtures\ChildEntity;
 use Sylius\Bundle\ResourceBundle\Tests\Fixtures\ParentEntity;
-use Sylius\Resource\Metadata\RegistryInterface;
+use Sylius\Resource\Metadata\Registry;
 
 final class ORMMappedSuperClassSubscriberTest extends TestCase
 {
     public function testItUpdatesSourceEntityWhenCopyingParentAssociationMappings(): void
     {
-        $registry = $this->createMock(RegistryInterface::class);
-        $subscriber = new ORMMappedSuperClassSubscriber($registry);
+        $subscriber = new ORMMappedSuperClassSubscriber(new Registry());
 
         $namingStrategy = new DefaultNamingStrategy();
 
         $childMetadata = new ClassMetadata(ChildEntity::class, $namingStrategy);
         $childMetadata->wakeupReflection(new RuntimeReflectionService());
 
-        $driver = $this->createMock(MappingDriver::class);
-        $driver
-            ->method('getAllClassNames')
-            ->willReturn([ParentEntity::class]);
-        $driver
-            ->method('loadMetadataForClass')
-            ->willReturnCallback(static function (string $className, ClassMetadata $metadata): void {
+        $configuration = new Configuration();
+        $configuration->setNamingStrategy($namingStrategy);
+        $configuration->setMetadataDriverImpl(new class () implements MappingDriver {
+            public function loadMetadataForClass(string $className, ClassMetadataInterface $metadata): void
+            {
                 if ($className !== ParentEntity::class) {
                     return;
                 }
 
+                /** @var ClassMetadata $metadata */
                 $metadata->isMappedSuperclass = true;
                 $metadata->mapOneToOne([
                     'fieldName' => 'relatedEntity',
                     'targetEntity' => ParentEntity::class,
                     'joinColumns' => [['name' => 'related_entity_id', 'referencedColumnName' => 'id']],
                 ]);
-            });
+            }
 
-        $configuration = $this->createMock(Configuration::class);
-        $configuration->method('getMetadataDriverImpl')->willReturn($driver);
-        $configuration->method('getNamingStrategy')->willReturn($namingStrategy);
+            /** @return list<string> */
+            public function getAllClassNames(): array
+            {
+                return [ParentEntity::class];
+            }
+
+            public function isTransient(string $className): bool
+            {
+                return false;
+            }
+        });
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->method('getConfiguration')->willReturn($configuration);

--- a/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
+++ b/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
@@ -40,14 +40,14 @@ final class ORMMappedSuperClassSubscriberTest extends TestCase
 
         $configuration = new Configuration();
         $configuration->setNamingStrategy($namingStrategy);
-        $configuration->setMetadataDriverImpl(new class () implements MappingDriver {
+        $configuration->setMetadataDriverImpl(new class() implements MappingDriver {
+            /** @param ClassMetadata $metadata */
             public function loadMetadataForClass(string $className, ClassMetadataInterface $metadata): void
             {
                 if ($className !== ParentEntity::class) {
                     return;
                 }
 
-                /** @var ClassMetadata $metadata */
                 $metadata->isMappedSuperclass = true;
                 $metadata->mapOneToOne([
                     'fieldName' => 'relatedEntity',

--- a/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
+++ b/tests/Bundle/EventListener/ORMMappedSuperClassSubscriberTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Bundle\EventListener;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\ChildEntity;
+use Sylius\Bundle\ResourceBundle\Tests\Fixtures\ParentEntity;
+use Sylius\Resource\Metadata\RegistryInterface;
+
+final class ORMMappedSuperClassSubscriberTest extends TestCase
+{
+    public function testItUpdatesSourceEntityWhenCopyingParentAssociationMappings(): void
+    {
+        $registry = $this->createMock(RegistryInterface::class);
+        $subscriber = new ORMMappedSuperClassSubscriber($registry);
+
+        $namingStrategy = new DefaultNamingStrategy();
+
+        $childMetadata = new ClassMetadata(ChildEntity::class, $namingStrategy);
+        $childMetadata->wakeupReflection(new RuntimeReflectionService());
+
+        $driver = $this->createMock(MappingDriver::class);
+        $driver
+            ->method('getAllClassNames')
+            ->willReturn([ParentEntity::class]);
+        $driver
+            ->method('loadMetadataForClass')
+            ->willReturnCallback(static function (string $className, ClassMetadata $metadata): void {
+                if ($className !== ParentEntity::class) {
+                    return;
+                }
+
+                $metadata->isMappedSuperclass = true;
+                $metadata->mapOneToOne([
+                    'fieldName' => 'relatedEntity',
+                    'targetEntity' => ParentEntity::class,
+                    'joinColumns' => [['name' => 'related_entity_id', 'referencedColumnName' => 'id']],
+                ]);
+            });
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getMetadataDriverImpl')->willReturn($driver);
+        $configuration->method('getNamingStrategy')->willReturn($namingStrategy);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConfiguration')->willReturn($configuration);
+
+        $event = new LoadClassMetadataEventArgs($childMetadata, $em);
+        $subscriber->loadClassMetadata($event);
+
+        self::assertArrayHasKey('relatedEntity', $childMetadata->associationMappings);
+
+        $association = $childMetadata->associationMappings['relatedEntity'];
+        $sourceEntity = \is_array($association) ? $association['sourceEntity'] : $association->sourceEntity;
+
+        self::assertSame(ChildEntity::class, $sourceEntity);
+    }
+}

--- a/tests/Bundle/Fixtures/ChildEntity.php
+++ b/tests/Bundle/Fixtures/ChildEntity.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+class ChildEntity extends ParentEntity
+{
+}

--- a/tests/Bundle/Fixtures/ParentEntity.php
+++ b/tests/Bundle/Fixtures/ParentEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Fixtures;
+
+use Sylius\Resource\Model\ResourceInterface;
+
+class ParentEntity implements ResourceInterface
+{
+    private ?int $id = null;
+
+    private ?object $relatedEntity = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

## Summary

When `ORMMappedSuperClassSubscriber` copies association mappings from a parent mapped-superclass to a child entity, the `sourceEntity` property is not updated to reflect the concrete child class. This causes Doctrine's `BasicEntityPersister` to generate incorrect SQL table aliases for eager-loaded inverse one-to-one associations.

**Root cause:** The subscriber directly assigns the parent's association mapping to the child metadata without updating `sourceEntity`, unlike Doctrine's own `ClassMetadataFactory::addInheritedRelations()` which sets `$mapping->sourceEntity = $subClass->name`.

**Symptom:** When the owning side of an inverse one-to-one association is eager-loaded, `BasicEntityPersister::getSelectColumnsSQL()` calls `getSQLTableAlias($association->sourceEntity, $assocAlias)` which produces a different alias than the one used for the JOIN table (because `sourceEntity` still points to the mapped-superclass instead of the concrete entity). This results in `Unknown column` SQL errors.

**Reproduction scenario:**
1. A mapped-superclass `BaseVendor` has a one-to-one owning association to `Profile`
2. A concrete entity `AppVendor extends BaseVendor` is registered via `resolve_target_entities`
3. `Profile` has an inverse one-to-one back to `VendorInterface` (resolved to `AppVendor`)
4. Loading `Profile` triggers eager-loading of the inverse side, which generates broken SQL because `sourceEntity` is `BaseVendor` instead of `AppVendor`