### PR TITLE
Fix: preserve explicit class from #[AsResource] in getResourceWithDef…

### DIFF
--- a/src/Component/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Component/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -31,7 +31,9 @@ trait OperationDefaultsTrait
         ResourceMetadata $resource,
         MetadataInterface $resourceConfiguration,
     ): ResourceMetadata {
-        $resource = $resource->withClass($resourceClass);
+        if (null === $resource->getClass()) {
+            $resource = $resource->withClass($resourceClass);
+        }
 
         if (null === $resource->getAlias()) {
             $resource = $resource->withAlias($resourceConfiguration->getAlias());


### PR DESCRIPTION
…aults()

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no-->
| Related tickets | fixes #1157
| License         | MIT
