### PR TITLE
Make validator constraints compatible with Symfony 8

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,23 @@
 ## UPGRADE FOR `1.14.x`
 
+### FROM `1.14.1` to `1.14.2`
+
+#### Validator Constraints
+
+The `Enabled`, `Disabled` and `UniqueWithinCollectionConstraint` constraints now use named arguments
+(`#[HasNamedArguments]`) to be compatible with Symfony 8.
+
+Passing an array of options to configure these constraints is deprecated and will be removed in 2.0.
+Use named arguments instead:
+
+```php
+// Before (deprecated)
+new Enabled(['message' => 'My message']);
+
+// After
+new Enabled(message: 'My message');
+```
+
 ### FROM `1.13.x` to `1.14.x`
 
 #### Minimal Requirements

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -108,6 +108,13 @@ parameters:
         # See: src/Bundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php:46
         - '/Class Doctrine\\Common\\Persistence\\ObjectManager not found/'
 
+        # Doctrine Persistence 4.x marks MappingDriverChain as @final
+        # ResourceMappingDriverChain has always extended it to add resource mapping support
+        # The parent is only soft-final (@final phpdoc), so extending it stays runtime-safe
+        # Pulled in transitively by Doctrine ORM 3.x; ORM 2.x ships an older, non-final version
+        # See: src/Bundle/Doctrine/ResourceMappingDriverChain.php
+        - '/Class Sylius\\Bundle\\ResourceBundle\\Doctrine\\ResourceMappingDriverChain extends @final class Doctrine\\Persistence\\Mapping\\Driver\\MappingDriverChain/'
+
         # Doctrine ORM 3.x introduces new mapping classes
         # AssociationMapping class exists only in ORM 3.x, not in ORM 2.x
         # Code supports both versions, so we need to ignore these errors when running with ORM 2.x

--- a/src/Bundle/Validator/Constraints/Disabled.php
+++ b/src/Bundle/Validator/Constraints/Disabled.php
@@ -14,12 +14,24 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 
 use Sylius\Bundle\ResourceBundle\Validator\DisabledValidator;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class Disabled extends Constraint
 {
     public string $message = 'sylius.resource.not_disabled';
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.resource.not_disabled',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): array
     {

--- a/src/Bundle/Validator/Constraints/Disabled.php
+++ b/src/Bundle/Validator/Constraints/Disabled.php
@@ -22,12 +22,29 @@ final class Disabled extends Constraint
 {
     public string $message = 'sylius.resource.not_disabled';
 
+    /**
+     * @param array{message?: string, groups?: array<string>|null, payload?: mixed}|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         string $message = 'sylius.resource.not_disabled',
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.14',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in 2.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message = $options['message'] ?? $message;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message;

--- a/src/Bundle/Validator/Constraints/Enabled.php
+++ b/src/Bundle/Validator/Constraints/Enabled.php
@@ -14,12 +14,24 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 
 use Sylius\Bundle\ResourceBundle\Validator\EnabledValidator;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 final class Enabled extends Constraint
 {
     public string $message = 'sylius.resource.not_enabled';
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'sylius.resource.not_enabled',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): array
     {

--- a/src/Bundle/Validator/Constraints/Enabled.php
+++ b/src/Bundle/Validator/Constraints/Enabled.php
@@ -22,12 +22,29 @@ final class Enabled extends Constraint
 {
     public string $message = 'sylius.resource.not_enabled';
 
+    /**
+     * @param array{message?: string, groups?: array<string>|null, payload?: mixed}|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         string $message = 'sylius.resource.not_enabled',
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.14',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in 2.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message = $options['message'] ?? $message;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message;

--- a/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
+++ b/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
@@ -24,13 +24,31 @@ final class UniqueWithinCollectionConstraint extends Constraint
 
     public string $attributePath = 'code';
 
+    /**
+     * @param array{message?: string, attributePath?: string, groups?: array<string>|null, payload?: mixed}|null $options
+     */
     #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         string $message = 'This code must be unique within this collection.',
         string $attributePath = 'code',
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (\is_array($options)) {
+            trigger_deprecation(
+                'sylius/resource-bundle',
+                '1.14',
+                'Passing an array of options to configure the "%s" constraint is deprecated and will be removed in 2.0, use named arguments instead.',
+                static::class,
+            );
+
+            $message = $options['message'] ?? $message;
+            $attributePath = $options['attributePath'] ?? $attributePath;
+            $groups ??= $options['groups'] ?? null;
+            $payload ??= $options['payload'] ?? null;
+        }
+
         parent::__construct(groups: $groups, payload: $payload);
 
         $this->message = $message;

--- a/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
+++ b/src/Bundle/Validator/Constraints/UniqueWithinCollectionConstraint.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ResourceBundle\Validator\Constraints;
 
 use Sylius\Bundle\ResourceBundle\Validator\UniqueWithinCollectionConstraintValidator;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
@@ -22,6 +23,19 @@ final class UniqueWithinCollectionConstraint extends Constraint
     public string $message = 'This code must be unique within this collection.';
 
     public string $attributePath = 'code';
+
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'This code must be unique within this collection.',
+        string $attributePath = 'code',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+
+        $this->message = $message;
+        $this->attributePath = $attributePath;
+    }
 
     public function validatedBy(): string
     {

--- a/tests/Bundle/Validator/Constraints/DisabledTest.php
+++ b/tests/Bundle/Validator/Constraints/DisabledTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Validator\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Validator\Constraints\Disabled;
+
+final class DisabledTest extends TestCase
+{
+    public function testUsesDefaultMessage(): void
+    {
+        $constraint = new Disabled();
+
+        $this->assertSame('sylius.resource.not_disabled', $constraint->message);
+    }
+
+    public function testAcceptsNamedArguments(): void
+    {
+        $constraint = new Disabled(message: 'Custom message');
+
+        $this->assertSame('Custom message', $constraint->message);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSupportsLegacyArrayOptionsAndTriggersDeprecation(): void
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $constraint = new Disabled(['message' => 'Legacy message']);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('Legacy message', $constraint->message);
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('Passing an array of options', $deprecations[0]);
+    }
+}

--- a/tests/Bundle/Validator/Constraints/EnabledTest.php
+++ b/tests/Bundle/Validator/Constraints/EnabledTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Validator\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Validator\Constraints\Enabled;
+
+final class EnabledTest extends TestCase
+{
+    public function testUsesDefaultMessage(): void
+    {
+        $constraint = new Enabled();
+
+        $this->assertSame('sylius.resource.not_enabled', $constraint->message);
+    }
+
+    public function testAcceptsNamedArguments(): void
+    {
+        $constraint = new Enabled(message: 'Custom message');
+
+        $this->assertSame('Custom message', $constraint->message);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSupportsLegacyArrayOptionsAndTriggersDeprecation(): void
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $constraint = new Enabled(['message' => 'Legacy message']);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('Legacy message', $constraint->message);
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('Passing an array of options', $deprecations[0]);
+    }
+}

--- a/tests/Bundle/Validator/Constraints/UniqueWithinCollectionConstraintTest.php
+++ b/tests/Bundle/Validator/Constraints/UniqueWithinCollectionConstraintTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Validator\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Validator\Constraints\UniqueWithinCollectionConstraint;
+
+final class UniqueWithinCollectionConstraintTest extends TestCase
+{
+    public function testUsesDefaultValues(): void
+    {
+        $constraint = new UniqueWithinCollectionConstraint();
+
+        $this->assertSame('This code must be unique within this collection.', $constraint->message);
+        $this->assertSame('code', $constraint->attributePath);
+    }
+
+    public function testAcceptsNamedArguments(): void
+    {
+        $constraint = new UniqueWithinCollectionConstraint(message: 'Custom message', attributePath: 'name');
+
+        $this->assertSame('Custom message', $constraint->message);
+        $this->assertSame('name', $constraint->attributePath);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSupportsLegacyArrayOptionsAndTriggersDeprecation(): void
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $constraint = new UniqueWithinCollectionConstraint([
+                'message' => 'Legacy message',
+                'attributePath' => 'name',
+            ]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('Legacy message', $constraint->message);
+        $this->assertSame('name', $constraint->attributePath);
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('Passing an array of options', $deprecations[0]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/pull/19072
| License         | MIT

Adds named-arguments constructors (`#[HasNamedArguments]`) to the `Enabled`, `Disabled` and `UniqueWithinCollectionConstraint` constraints so they load correctly under Symfony 8 — one of the blockers for Symfony 8 support in Sylius (Sylius/Sylius#19072)