### PR TITLE
Use interface_exists instead of class_exists for interface alias guards

### DIFF
--- a/src/Component/src/Doctrine/Persistence/RepositoryInterface.php
+++ b/src/Component/src/Doctrine/Persistence/RepositoryInterface.php
@@ -39,6 +39,6 @@ interface RepositoryInterface extends ObjectRepository
     public function remove(ResourceInterface $resource): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Repository\RepositoryInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Repository\RepositoryInterface::class, false)) {
     class_alias(RepositoryInterface::class, \Sylius\Component\Resource\Repository\RepositoryInterface::class);
 }

--- a/src/Component/src/Factory/FactoryInterface.php
+++ b/src/Component/src/Factory/FactoryInterface.php
@@ -24,6 +24,6 @@ interface FactoryInterface
     public function createNew();
 }
 
-if (!class_exists(\Sylius\Component\Resource\Factory\FactoryInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Factory\FactoryInterface::class, false)) {
     class_alias(FactoryInterface::class, \Sylius\Component\Resource\Factory\FactoryInterface::class);
 }

--- a/src/Component/src/Factory/TranslatableFactoryInterface.php
+++ b/src/Component/src/Factory/TranslatableFactoryInterface.php
@@ -24,6 +24,6 @@ interface TranslatableFactoryInterface extends FactoryInterface
     public function createNew();
 }
 
-if (!class_exists(\Sylius\Component\Resource\Factory\TranslatableFactoryInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Factory\TranslatableFactoryInterface::class, false)) {
     class_alias(TranslatableFactoryInterface::class, \Sylius\Component\Resource\Factory\TranslatableFactoryInterface::class);
 }

--- a/src/Component/src/Generator/RandomnessGeneratorInterface.php
+++ b/src/Component/src/Generator/RandomnessGeneratorInterface.php
@@ -22,6 +22,6 @@ interface RandomnessGeneratorInterface
     public function generateInt(int $min, int $max): int;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Generator\RandomnessGeneratorInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Generator\RandomnessGeneratorInterface::class, false)) {
     class_alias(RandomnessGeneratorInterface::class, \Sylius\Component\Resource\Generator\RandomnessGeneratorInterface::class);
 }

--- a/src/Component/src/Metadata/MetadataInterface.php
+++ b/src/Component/src/Metadata/MetadataInterface.php
@@ -60,6 +60,6 @@ interface MetadataInterface
     public function getPermissionCode(string $permissionName): string;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Metadata\MetadataInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Metadata\MetadataInterface::class, false)) {
     class_alias(MetadataInterface::class, \Sylius\Component\Resource\Metadata\MetadataInterface::class);
 }

--- a/src/Component/src/Metadata/RegistryInterface.php
+++ b/src/Component/src/Metadata/RegistryInterface.php
@@ -38,6 +38,6 @@ interface RegistryInterface
     public function addFromAliasAndConfiguration(string $alias, array $configuration): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Metadata\RegistryInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Metadata\RegistryInterface::class, false)) {
     class_alias(RegistryInterface::class, \Sylius\Component\Resource\Metadata\RegistryInterface::class);
 }

--- a/src/Component/src/Model/ArchivableInterface.php
+++ b/src/Component/src/Model/ArchivableInterface.php
@@ -20,6 +20,6 @@ interface ArchivableInterface
     public function setArchivedAt(?\DateTimeInterface $archivedAt): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\ArchivableInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\ArchivableInterface::class, false)) {
     class_alias(ArchivableInterface::class, \Sylius\Component\Resource\Model\ArchivableInterface::class);
 }

--- a/src/Component/src/Model/CodeAwareInterface.php
+++ b/src/Component/src/Model/CodeAwareInterface.php
@@ -20,6 +20,6 @@ interface CodeAwareInterface
     public function setCode(?string $code): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\CodeAwareInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\CodeAwareInterface::class, false)) {
     class_alias(CodeAwareInterface::class, \Sylius\Component\Resource\Model\CodeAwareInterface::class);
 }

--- a/src/Component/src/Model/ResourceInterface.php
+++ b/src/Component/src/Model/ResourceInterface.php
@@ -19,6 +19,6 @@ interface ResourceInterface
     public function getId();
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\ResourceInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\ResourceInterface::class, false)) {
     class_alias(ResourceInterface::class, \Sylius\Component\Resource\Model\ResourceInterface::class);
 }

--- a/src/Component/src/Model/SlugAwareInterface.php
+++ b/src/Component/src/Model/SlugAwareInterface.php
@@ -20,6 +20,6 @@ interface SlugAwareInterface
     public function setSlug(?string $slug): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\SlugAwareInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\SlugAwareInterface::class, false)) {
     class_alias(SlugAwareInterface::class, \Sylius\Component\Resource\Model\SlugAwareInterface::class);
 }

--- a/src/Component/src/Model/TimestampableInterface.php
+++ b/src/Component/src/Model/TimestampableInterface.php
@@ -26,6 +26,6 @@ interface TimestampableInterface
     public function setUpdatedAt(?\DateTimeInterface $updatedAt);
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\TimestampableInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\TimestampableInterface::class, false)) {
     class_alias(TimestampableInterface::class, \Sylius\Component\Resource\Model\TimestampableInterface::class);
 }

--- a/src/Component/src/Model/ToggleableInterface.php
+++ b/src/Component/src/Model/ToggleableInterface.php
@@ -29,6 +29,6 @@ interface ToggleableInterface
     public function disable(): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\ToggleableInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\ToggleableInterface::class, false)) {
     class_alias(ToggleableInterface::class, \Sylius\Component\Resource\Model\ToggleableInterface::class);
 }

--- a/src/Component/src/Model/TranslatableInterface.php
+++ b/src/Component/src/Model/TranslatableInterface.php
@@ -36,6 +36,6 @@ interface TranslatableInterface
     public function setFallbackLocale(string $locale): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\TranslatableInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\TranslatableInterface::class, false)) {
     class_alias(TranslatableInterface::class, \Sylius\Component\Resource\Model\TranslatableInterface::class);
 }

--- a/src/Component/src/Model/TranslationInterface.php
+++ b/src/Component/src/Model/TranslationInterface.php
@@ -24,6 +24,6 @@ interface TranslationInterface
     public function setLocale(?string $locale): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\TranslationInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\TranslationInterface::class, false)) {
     class_alias(TranslationInterface::class, \Sylius\Component\Resource\Model\TranslationInterface::class);
 }

--- a/src/Component/src/Model/VersionedInterface.php
+++ b/src/Component/src/Model/VersionedInterface.php
@@ -20,6 +20,6 @@ interface VersionedInterface
     public function setVersion(?int $version): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Model\VersionedInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Model\VersionedInterface::class, false)) {
     class_alias(VersionedInterface::class, \Sylius\Component\Resource\Model\VersionedInterface::class);
 }

--- a/src/Component/src/StateMachine/StateMachineInterface.php
+++ b/src/Component/src/StateMachine/StateMachineInterface.php
@@ -33,6 +33,6 @@ interface StateMachineInterface extends BaseStateMachineInterface
     public function getTransitionToState(string $toState): ?string;
 }
 
-if (!class_exists(\Sylius\Component\Resource\StateMachine\StateMachineInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\StateMachine\StateMachineInterface::class, false)) {
     class_alias(StateMachineInterface::class, \Sylius\Component\Resource\StateMachine\StateMachineInterface::class);
 }

--- a/src/Component/src/Storage/StorageInterface.php
+++ b/src/Component/src/Storage/StorageInterface.php
@@ -49,6 +49,6 @@ interface StorageInterface
     public function all(): array;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Storage\StorageInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Storage\StorageInterface::class, false)) {
     class_alias(StorageInterface::class, \Sylius\Component\Resource\Storage\StorageInterface::class);
 }

--- a/src/Component/src/Translation/Provider/TranslationLocaleProviderInterface.php
+++ b/src/Component/src/Translation/Provider/TranslationLocaleProviderInterface.php
@@ -21,6 +21,6 @@ interface TranslationLocaleProviderInterface
     public function getDefaultLocaleCode(): string;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface::class, false)) {
     class_alias(TranslationLocaleProviderInterface::class, \Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface::class);
 }

--- a/src/Component/src/Translation/TranslatableEntityLocaleAssignerInterface.php
+++ b/src/Component/src/Translation/TranslatableEntityLocaleAssignerInterface.php
@@ -20,6 +20,6 @@ interface TranslatableEntityLocaleAssignerInterface
     public function assignLocale(TranslatableInterface $translatableEntity): void;
 }
 
-if (!class_exists(\Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface::class, false)) {
+if (!interface_exists(\Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface::class, false)) {
     class_alias(TranslatableEntityLocaleAssignerInterface::class, \Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface::class);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #1168
| License         | MIT
